### PR TITLE
Fix backend Docker PYTHONPATH and add migration entrypoint

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Run migrations if requested
+if [ "${RUN_MIGRATIONS:-false}" = "true" ]; then
+    echo "Running database migrations..."
+    alembic -c alembic/alembic.ini upgrade head
+fi
+
+exec "$@"

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+ENV PYTHONPATH=/app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -18,6 +19,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app/ app/
 COPY alembic/ alembic/
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 8000
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

Fix `ModuleNotFoundError: No module named 'app.config'` when running `alembic upgrade head` inside the backend Docker container by setting `PYTHONPATH=/app`. Also add an entrypoint script that optionally runs migrations before starting the app.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Infrastructure / Terraform
- [ ] Documentation
- [ ] CI / tooling
- [ ] Refactor (no functional change)

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## What Changed

- **`docker/Dockerfile.backend`**: Added `ENV PYTHONPATH=/app` so the `app` package is importable by alembic and other tools. Added `COPY` and `ENTRYPOINT` for the new entrypoint script.
- **`backend/entrypoint.sh`** (new): Shell script that runs `alembic -c alembic/alembic.ini upgrade head` when `RUN_MIGRATIONS=true`, then execs the CMD. Default behavior (just uvicorn) is unchanged.

## How to Test

1. Build the backend image: `docker compose -f docker/docker-compose.dev.yml build backend`
2. Run without `RUN_MIGRATIONS` — confirm uvicorn starts normally with no migration attempt
3. Run with `RUN_MIGRATIONS=true` and a healthy postgres — confirm `alembic upgrade head` succeeds before uvicorn starts
4. Verify the Python path fix: `docker exec <container> python -c "from app.config import settings; print(settings.app_name)"` should print `bioAF`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [ ] I have added/updated tests for my changes
- [x] All new and existing tests pass locally
- [ ] I have updated documentation if needed
- [ ] Terraform changes include `terraform validate` output
- [x] Database migrations are reversible (if applicable)
- [x] No secrets, credentials, or API keys are committed
- [ ] Audit log coverage: state-changing operations write to audit log (if applicable)

## Screenshots / Outputs

<!-- N/A — no UI or CLI output changes -->

## Deployment Notes

The corresponding `bioaf-deploy-demo` change (branch `fix/backend-docker-migrations`) adds `PYTHONPATH: /app` and `RUN_MIGRATIONS: "true"` to `docker-compose.poc.yml`. That branch should be merged alongside or after this one. After merge, the backend container will automatically run migrations on startup — no more manual `docker exec` needed.