### PR TITLE
Fix migrations 002-004: replace try/except with DO blocks for role gr…

### DIFF
--- a/backend/alembic/versions/002_phase5_data_viz.py
+++ b/backend/alembic/versions/002_phase5_data_viz.py
@@ -168,14 +168,17 @@ def upgrade() -> None:
     op.create_foreign_key("fk_sample_files_file", "sample_files", "files", ["file_id"], ["id"])
     op.create_foreign_key("fk_nsf_file", "notebook_session_files", "files", ["file_id"], ["id"])
 
-    # Grant permissions (may not exist in test/dev)
-    try:
-        op.execute(
-            "GRANT SELECT, INSERT, UPDATE, DELETE ON files, documents, cellxgene_publications, qc_dashboards, plot_archive, storage_stats_cache TO bioaf_app"
-        )
-        op.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bioaf_app")
-    except Exception:
-        pass
+    # Grant permissions (conditionally — bioaf_app role may not exist in dev/POC)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'bioaf_app') THEN
+                EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON files, documents, cellxgene_publications, qc_dashboards, plot_archive, storage_stats_cache TO bioaf_app';
+                EXECUTE 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bioaf_app';
+            END IF;
+        END
+        $$;
+    """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/003_phase6_gitops_packages.py
+++ b/backend/alembic/versions/003_phase6_gitops_packages.py
@@ -133,16 +133,17 @@ def upgrade() -> None:
     )
     op.create_index("idx_template_notebooks_org", "template_notebooks", ["organization_id"])
 
-    # Grant permissions
-    try:
-        op.execute(
-            "GRANT SELECT, INSERT, UPDATE, DELETE ON "
-            "gitops_repos, environments, environment_packages, "
-            "environment_changes, template_notebooks TO bioaf_app"
-        )
-        op.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bioaf_app")
-    except Exception:
-        pass
+    # Grant permissions (conditionally — bioaf_app role may not exist in dev/POC)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'bioaf_app') THEN
+                EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON gitops_repos, environments, environment_packages, environment_changes, template_notebooks TO bioaf_app';
+                EXECUTE 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bioaf_app';
+            END IF;
+        END
+        $$;
+    """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/004_phase7_ops_polish.py
+++ b/backend/alembic/versions/004_phase7_ops_polish.py
@@ -210,17 +210,17 @@ def upgrade() -> None:
     )
     op.create_index("idx_cost_records_org_date", "cost_records", ["organization_id", "record_date"])
 
-    # Grant permissions
-    try:
-        op.execute(
-            "GRANT SELECT, INSERT, UPDATE, DELETE ON "
-            "notifications, notification_rules, notification_preferences, "
-            "slack_webhooks, notification_delivery_log, upgrade_history, "
-            "access_log, activity_feed, budget_config, cost_records TO bioaf_app"
-        )
-        op.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bioaf_app")
-    except Exception:
-        pass
+    # Grant permissions (conditionally — bioaf_app role may not exist in dev/POC)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'bioaf_app') THEN
+                EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON notifications, notification_rules, notification_preferences, slack_webhooks, notification_delivery_log, upgrade_history, access_log, activity_feed, budget_config, cost_records TO bioaf_app';
+                EXECUTE 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bioaf_app';
+            END IF;
+        END
+        $$;
+    """)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary

Fix migrations 002, 003, and 004 which fail on asyncpg due to `try/except` around `GRANT ... TO bioaf_app` statements. When the `bioaf_app` role doesn't exist (POC/dev environments), the failed GRANT poisons the PostgreSQL transaction, causing `InFailedSQLTransactionError` on subsequent statements.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Infrastructure / Terraform
- [ ] Documentation
- [ ] CI / tooling
- [ ] Refactor (no functional change)

## Related Issues

Follows up on commit aac54d4 which fixed the same bug in migration 001.

## What Changed

- **002_phase5_data_viz.py**: Replaced `try/except` around GRANT statements with a PL/pgSQL `DO` block that checks `pg_roles` before granting
- **003_phase6_gitops_packages.py**: Same fix
- **004_phase7_ops_polish.py**: Same fix

The root cause: Python's `try/except` catches the exception on the Python side, but asyncpg's underlying PostgreSQL transaction is already in a failed state. PostgreSQL rejects all subsequent SQL in that transaction with "current transaction is aborted, commands ignored until end of transaction block." Using a `DO` block with `IF EXISTS` avoids ever executing a failing statement.

## How to Test

1. `docker compose -f docker/docker-compose.poc.yml down -v`
2. `docker compose -f docker/docker-compose.poc.yml up -d --build`
3. `docker compose -f docker/docker-compose.poc.yml exec backend alembic -c alembic/alembic.ini upgrade head`
4. All 18 migrations should complete without errors

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [ ] I have added/updated tests for my changes
- [x] All new and existing tests pass locally
- [ ] I have updated documentation if needed
- [ ] Terraform changes include `terraform validate` output
- [x] Database migrations are reversible (if applicable)
- [x] No secrets, credentials, or API keys are committed
- [ ] Audit log coverage: state-changing operations write to audit log (if applicable)

## Screenshots / Outputs

Before (migration 002 fails):
```
INFO  [alembic.runtime.migration] Running upgrade 001 -> 002, Phase 5: Data Management + Visualization tables.
sqlalchemy.exc.DBAPIError: (sqlalchemy.dialects.postgresql.asyncpg.Error)
<class 'asyncpg.exceptions.InFailedSQLTransactionError'>: current transaction is aborted
[SQL: UPDATE alembic_version SET version_num='002' WHERE alembic_version.version_num = '001']
```

After (all migrations pass):
```
INFO  [alembic.runtime.migration] Running upgrade  -> 001, Initial schema
INFO  [alembic.runtime.migration] Running upgrade 001 -> 002, Phase 5: Data Management + Visualization tables.
INFO  [alembic.runtime.migration] Running upgrade 002 -> 003, Phase 6: GitOps + Package Management.
INFO  [alembic.runtime.migration] Running upgrade 003 -> 004, Phase 7: Ops Polish.
...
INFO  [alembic.runtime.migration] Running upgrade 017 -> 018, create analysis snapshots.
```

## Deployment Notes

After merging, on the POC VM:
1. Pull latest `main` in the bioAF repo
2. Rebuild: `docker compose -f docker/docker-compose.poc.yml up -d --build backend`
3. Run migrations: `docker compose -f docker/docker-compose.poc.yml exec backend alembic -c alembic/alembic.ini upgrade head`

If migrations have been partially applied (e.g., 001 succeeded previously), Alembic will resume from where it left off. If in a bad state, `docker compose down -v` will reset the database volume for a clean start.