### PR TITLE
Replace || with ?? to resolve localhost resolution

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -4,6 +4,8 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci
 COPY . .
+ARG NEXT_PUBLIC_API_URL=""
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 RUN npm run build
 
 # Production stage

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   output: "standalone",
   env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000",
   },
 };
 

--- a/frontend/src/app/pipelines/runs/[id]/page.tsx
+++ b/frontend/src/app/pipelines/runs/[id]/page.tsx
@@ -91,7 +91,7 @@ export default function PipelineRunDetailPage() {
 
   async function loadReport() {
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"}/api/pipeline-runs/${runId}/report`, {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000"}/api/pipeline-runs/${runId}/report`, {
         headers: { Authorization: `Bearer ${localStorage.getItem("bioaf_token")}` },
       });
       setReport(await res.text());

--- a/frontend/src/components/experiments/GeoExportModal.tsx
+++ b/frontend/src/components/experiments/GeoExportModal.tsx
@@ -13,7 +13,7 @@ import type {
   PipelineRunListResponse,
 } from "@/lib/types";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 interface GeoExportModalProps {
   experimentId: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { getToken, removeToken } from "./auth";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 class ApiError extends Error {
   constructor(


### PR DESCRIPTION
## Summary

Fix frontend API calls hardcoded to localhost:8000. The JS `||` operator treats empty string as falsy, so the `NEXT_PUBLIC_API_URL` fallback always fires even when the env var is set to empty. Changed to `??` (nullish coalescing) so empty string is respected, enabling relative URL routing through nginx.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Infrastructure / Terraform
- [ ] Documentation
- [ ] CI / tooling
- [ ] Refactor (no functional change)

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## What Changed

- `frontend/src/lib/api.ts`: Changed `||` to `??` for `NEXT_PUBLIC_API_URL` fallback
- `frontend/next.config.js`: Changed `||` to `??` for `NEXT_PUBLIC_API_URL` fallback
- `frontend/src/components/experiments/GeoExportModal.tsx`: Changed `||` to `??` for `NEXT_PUBLIC_API_URL` fallback
- `frontend/src/app/pipelines/runs/[id]/page.tsx`: Changed `||` to `??` for inline `NEXT_PUBLIC_API_URL` fallback
- `docker/Dockerfile.frontend`: Added `ARG NEXT_PUBLIC_API_URL` and `ENV NEXT_PUBLIC_API_URL` before `npm run build` so the variable is available at build time (not just runtime)

## How to Test

1. Build the frontend with `NEXT_PUBLIC_API_URL=""` passed as a build arg
2. Inspect the built JS bundle: `grep -r "localhost:8000" /app/.next/static/` — should return zero matches
3. Verify the app makes relative API calls (`/api/...`) that nginx proxies to the backend
4. Verify local dev still works without setting the env var (falls back to `http://localhost:8000`)

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [ ] I have added/updated tests for my changes
- [x] All new and existing tests pass locally
- [ ] I have updated documentation if needed
- [ ] Terraform changes include `terraform validate` output
- [ ] Database migrations are reversible (if applicable)
- [x] No secrets, credentials, or API keys are committed
- [ ] Audit log coverage: state-changing operations write to audit log (if applicable)

## Screenshots / Outputs

<!-- If UI or CLI output changes, paste screenshots or terminal output here. -->

## Deployment Notes

Companion PR in bioaf-deploy-demo adds `build: args: NEXT_PUBLIC_API_URL: ""` to docker-compose.poc.yml. Both PRs should be merged and pulled to the VM before rebuilding the frontend with `--no-cache`.
