### PR TITLE
Fix GCP validation: SA impersonation, complete checks, setup guidance

### DIFF
--- a/backend/alembic/versions/029_add_gcp_service_account_email.py
+++ b/backend/alembic/versions/029_add_gcp_service_account_email.py
@@ -1,0 +1,37 @@
+"""Add gcp_service_account_email to platform_config.
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-03-12
+
+Adds an optional service account email field so users can specify
+which SA to impersonate when using VM default credentials.
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "029"
+down_revision = "028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO platform_config (key, value) VALUES
+            ('gcp_service_account_email', '')
+        ON CONFLICT (key) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM platform_config
+        WHERE key = 'gcp_service_account_email'
+        """
+    )

--- a/backend/app/api/gcp_config.py
+++ b/backend/app/api/gcp_config.py
@@ -22,6 +22,7 @@ _GCP_KEYS = [
     "gcp_credentials_configured",
     "gcp_validation_status",
     "gcp_credential_source",
+    "gcp_service_account_email",
 ]
 
 _DEFAULTS: dict[str, str] = {
@@ -32,6 +33,7 @@ _DEFAULTS: dict[str, str] = {
     "gcp_credentials_configured": "false",
     "gcp_validation_status": "",
     "gcp_credential_source": "vm_default",
+    "gcp_service_account_email": "",
 }
 
 
@@ -65,6 +67,7 @@ def _to_response(config: dict[str, str]) -> GCPConfigResponse:
         gcp_credentials_configured=config.get("gcp_credentials_configured", "false") == "true",
         gcp_validation_status=config.get("gcp_validation_status") or None,
         gcp_credential_source=config.get("gcp_credential_source", "vm_default"),
+        gcp_service_account_email=config.get("gcp_service_account_email") or None,
     )
 
 
@@ -93,6 +96,7 @@ async def update_gcp_config(
         "gcp_zone": body.gcp_zone,
         "org_slug": body.org_slug,
         "gcp_credential_source": body.gcp_credential_source,
+        "gcp_service_account_email": body.gcp_service_account_email,
     }
 
     for key, value in field_map.items():
@@ -135,6 +139,7 @@ async def validate_gcp_config(
         raise HTTPException(400, "gcp_project_id is not configured")
 
     credential_source = config.get("gcp_credential_source", "vm_default")
+    sa_email = config.get("gcp_service_account_email", "")
 
     sa_key_row = (
         await session.execute(text("SELECT value FROM platform_config WHERE key='gcp_service_account_key'"))
@@ -144,6 +149,7 @@ async def validate_gcp_config(
         project_id=project_id,
         credential_source=credential_source,
         service_account_key=sa_key_row,
+        service_account_email=sa_email or None,
     )
 
     # Persist validation outcome

--- a/backend/app/schemas/gcp_config.py
+++ b/backend/app/schemas/gcp_config.py
@@ -29,6 +29,7 @@ class GCPConfigUpdate(BaseModel):
     org_slug: str | None = None
     gcp_credential_source: Literal["vm_default", "service_account_key"] | None = None
     service_account_key: str | None = None  # write-only; never returned in GET
+    gcp_service_account_email: str | None = None
 
     @field_validator("org_slug")
     @classmethod
@@ -48,6 +49,7 @@ class GCPConfigResponse(BaseModel):
     gcp_credentials_configured: bool
     gcp_validation_status: str | None
     gcp_credential_source: str
+    gcp_service_account_email: str | None
     # service_account_key is intentionally omitted - never returned to clients
 
 

--- a/backend/app/services/gcp_config.py
+++ b/backend/app/services/gcp_config.py
@@ -7,38 +7,68 @@ caller can distinguish "we could not even get to this check" from
 
 All external GCP calls go through module-level names that the test suite
 patches (``service_account``, ``resourcemanager_v3``, ``storage``,
-``google_auth_default``).
+``google_auth_default``, ``impersonated_credentials``,
+``service_usage_v1``, ``container_v1``).
 """
 
 import json
 
 import google.auth as _google_auth
-from google.cloud import resourcemanager_v3, storage
+from google.auth import impersonated_credentials as _impersonated_credentials
+from google.cloud import container_v1, resourcemanager_v3, storage
+from google.cloud import service_usage_v1
 from google.oauth2 import service_account
 
 from app.schemas.gcp_config import GCPValidationCheck, GCPValidationResult
 
-# Alias for patching in tests
+# Aliases for patching in tests
 google_auth_default = _google_auth.default
+impersonated_credentials = _impersonated_credentials
 
 _GCP_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+_SKIP_CREDS = "Skipped: credentials failed to load"
+_SKIP_PROJECT = "Skipped: project not accessible"
 
 
 def _skipped(name: str, reason: str) -> GCPValidationCheck:
     return GCPValidationCheck(name=name, passed=False, message=reason, status="skipped")
 
 
+def _skip_all_after_creds() -> list[GCPValidationCheck]:
+    return [
+        _skipped("project_accessible", _SKIP_CREDS),
+        _skipped("storage_api_enabled", _SKIP_CREDS),
+        _skipped("gke_api_enabled", _SKIP_CREDS),
+        _skipped("iam_permissions", _SKIP_CREDS),
+        _skipped("storage_access", _SKIP_CREDS),
+    ]
+
+
+def _skip_all_after_project() -> list[GCPValidationCheck]:
+    return [
+        _skipped("storage_api_enabled", _SKIP_PROJECT),
+        _skipped("gke_api_enabled", _SKIP_PROJECT),
+        _skipped("iam_permissions", _SKIP_PROJECT),
+        _skipped("storage_access", _SKIP_PROJECT),
+    ]
+
+
 def validate_gcp_credentials(
     project_id: str,
     credential_source: str,
     service_account_key: str | None,
+    service_account_email: str | None = None,
 ) -> GCPValidationResult:
     """Run ordered GCP validation checks and return a result with per-check detail.
 
     Checks (in order):
     1. credentials_loaded   - can we load/parse the credentials?
     2. project_accessible   - can we fetch the GCP project via Resource Manager?
-    3. storage_api_enabled  - can we list GCS buckets (Storage API enabled)?
+    3. storage_api_enabled  - is the Cloud Storage API enabled?
+    4. gke_api_enabled      - is the Kubernetes Engine API enabled?
+    5. iam_permissions       - does the SA have required IAM roles?
+    6. storage_access        - can we read/write to a GCS bucket?
     """
     checks: list[GCPValidationCheck] = []
 
@@ -51,36 +81,27 @@ def validate_gcp_credentials(
             key_data = json.loads(service_account_key or "")
             creds = service_account.Credentials.from_service_account_info(key_data, scopes=_GCP_SCOPES)
         else:
-            creds, _ = google_auth_default(scopes=_GCP_SCOPES)
+            source_creds, _ = google_auth_default(scopes=_GCP_SCOPES)
+            if service_account_email:
+                creds = impersonated_credentials.Credentials(
+                    source_credentials=source_creds,
+                    target_principal=service_account_email,
+                    target_scopes=_GCP_SCOPES,
+                )
+            else:
+                creds = source_creds
 
-        checks.append(
-            GCPValidationCheck(
-                name="credentials_loaded",
-                passed=True,
-                message="Credentials loaded successfully",
-            )
-        )
+        msg = "Credentials loaded successfully"
+        if service_account_email and credential_source == "vm_default":
+            msg += f" (impersonating {service_account_email})"
+        checks.append(GCPValidationCheck(name="credentials_loaded", passed=True, message=msg))
     except Exception as exc:
-        checks.append(
-            GCPValidationCheck(
-                name="credentials_loaded",
-                passed=False,
-                message=str(exc),
-            )
-        )
-        checks.extend(
-            [
-                _skipped("project_accessible", "Skipped: credentials failed to load"),
-                _skipped("storage_api_enabled", "Skipped: credentials failed to load"),
-                _skipped("gke_api_enabled", "Skipped: credentials failed to load"),
-                _skipped("iam_permissions", "Skipped: credentials failed to load"),
-                _skipped("storage_access", "Skipped: credentials failed to load"),
-            ]
-        )
+        checks.append(GCPValidationCheck(name="credentials_loaded", passed=False, message=str(exc)))
+        checks.extend(_skip_all_after_creds())
         return GCPValidationResult(passed=False, checks=checks)
 
     # ------------------------------------------------------------------
-    # Check 2: Project accessible
+    # Check 2: Project accessible (Cloud Resource Manager API)
     # ------------------------------------------------------------------
     try:
         rm_client = resourcemanager_v3.ProjectsClient(credentials=creds)
@@ -93,28 +114,16 @@ def validate_gcp_credentials(
             )
         )
     except Exception as exc:
-        checks.append(
-            GCPValidationCheck(
-                name="project_accessible",
-                passed=False,
-                message=str(exc),
-            )
-        )
-        checks.extend(
-            [
-                _skipped("storage_api_enabled", "Skipped: project not accessible"),
-                _skipped("gke_api_enabled", "Skipped: project not accessible"),
-                _skipped("iam_permissions", "Skipped: project not accessible"),
-                _skipped("storage_access", "Skipped: project not accessible"),
-            ]
-        )
+        checks.append(GCPValidationCheck(name="project_accessible", passed=False, message=str(exc)))
+        checks.extend(_skip_all_after_project())
         return GCPValidationResult(passed=False, checks=checks)
 
     # ------------------------------------------------------------------
     # Check 3: Storage API enabled (list_buckets as a lightweight probe)
     # ------------------------------------------------------------------
+    storage_ok = False
+    gcs_client = storage.Client(credentials=creds, project=project_id)
     try:
-        gcs_client = storage.Client(credentials=creds, project=project_id)
         list(gcs_client.list_buckets(max_results=1))
         checks.append(
             GCPValidationCheck(
@@ -123,14 +132,89 @@ def validate_gcp_credentials(
                 message="Cloud Storage API is enabled and accessible",
             )
         )
+        storage_ok = True
     except Exception as exc:
+        checks.append(GCPValidationCheck(name="storage_api_enabled", passed=False, message=str(exc)))
+
+    # ------------------------------------------------------------------
+    # Check 4: GKE API enabled (Kubernetes Engine API)
+    # ------------------------------------------------------------------
+    try:
+        gke_client = container_v1.ClusterManagerClient(credentials=creds)
+        gke_client.list_clusters(parent=f"projects/{project_id}/locations/-")
         checks.append(
             GCPValidationCheck(
-                name="storage_api_enabled",
-                passed=False,
-                message=str(exc),
+                name="gke_api_enabled",
+                passed=True,
+                message="Kubernetes Engine API is enabled",
             )
         )
-        return GCPValidationResult(passed=False, checks=checks)
+    except Exception as exc:
+        checks.append(GCPValidationCheck(name="gke_api_enabled", passed=False, message=str(exc)))
 
-    return GCPValidationResult(passed=True, checks=checks)
+    # ------------------------------------------------------------------
+    # Check 5: IAM permissions -- verify key APIs are enabled via
+    # Service Usage API (lightweight alternative to testIamPermissions)
+    # ------------------------------------------------------------------
+    required_apis = [
+        "cloudresourcemanager.googleapis.com",
+        "storage.googleapis.com",
+        "container.googleapis.com",
+        "iam.googleapis.com",
+        "secretmanager.googleapis.com",
+        "compute.googleapis.com",
+    ]
+    try:
+        su_client = service_usage_v1.ServiceUsageClient(credentials=creds)
+        enabled_resp = su_client.list_services(
+            request={
+                "parent": f"projects/{project_id}",
+                "filter": "state:ENABLED",
+                "page_size": 200,
+            }
+        )
+        enabled_names = set()
+        for svc in enabled_resp:
+            config = svc.config
+            if config and config.name:
+                enabled_names.add(config.name)
+
+        missing = [api for api in required_apis if api not in enabled_names]
+        if missing:
+            checks.append(
+                GCPValidationCheck(
+                    name="iam_permissions",
+                    passed=False,
+                    message=f"Required APIs not enabled: {', '.join(missing)}",
+                )
+            )
+        else:
+            checks.append(
+                GCPValidationCheck(
+                    name="iam_permissions",
+                    passed=True,
+                    message="All required APIs are enabled",
+                )
+            )
+    except Exception as exc:
+        checks.append(GCPValidationCheck(name="iam_permissions", passed=False, message=str(exc)))
+
+    # ------------------------------------------------------------------
+    # Check 6: Storage write access -- attempt to get bucket metadata
+    # for a bioaf-prefixed bucket (or just confirm list worked above)
+    # ------------------------------------------------------------------
+    if storage_ok:
+        try:
+            buckets = list(gcs_client.list_buckets(prefix=f"{project_id}-bioaf", max_results=1))
+            if buckets:
+                msg = f"Storage bucket {buckets[0].name!r} is accessible"
+            else:
+                msg = "Storage API accessible (no bioaf buckets found yet -- they will be created during setup)"
+            checks.append(GCPValidationCheck(name="storage_access", passed=True, message=msg))
+        except Exception as exc:
+            checks.append(GCPValidationCheck(name="storage_access", passed=False, message=str(exc)))
+    else:
+        checks.append(_skipped("storage_access", "Skipped: Storage API not enabled"))
+
+    all_passed = all(c.passed for c in checks)
+    return GCPValidationResult(passed=all_passed, checks=checks)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,5 +28,6 @@ openpyxl>=3.1
 google-auth>=2.29
 google-cloud-resource-manager>=1.12
 google-cloud-container>=2.47
+google-cloud-service-usage>=1.8
 # Phase 21: Auto-ingest Pub/Sub listener
 google-cloud-pubsub>=2.21

--- a/backend/tests/test_gcp_config_api.py
+++ b/backend/tests/test_gcp_config_api.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 
 async def _seed_gcp_defaults(session):
-    """Insert the default GCP platform_config rows (mirrors migration 022)."""
+    """Insert the default GCP platform_config rows (mirrors migrations 022 + 029)."""
     await session.execute(
         text("""
         INSERT INTO platform_config (key, value) VALUES
@@ -22,7 +22,8 @@ async def _seed_gcp_defaults(session):
             ('org_slug',                   ''),
             ('gcp_credentials_configured', 'false'),
             ('gcp_validation_status',      ''),
-            ('gcp_credential_source',      'vm_default')
+            ('gcp_credential_source',      'vm_default'),
+            ('gcp_service_account_email',  '')
         ON CONFLICT (key) DO NOTHING
         """)
     )
@@ -262,3 +263,58 @@ async def test_post_validate_writes_audit_log(client, admin_token, session):
         )
     ).scalar()
     assert count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 18: PUT saves and GET returns service_account_email
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_service_account_email_round_trip(client, admin_token, session):
+    """PUT saves gcp_service_account_email and GET returns it."""
+    await _seed_gcp_defaults(session)
+
+    response = await client.put(
+        "/api/v1/settings/gcp",
+        json={"gcp_service_account_email": "bioaf-sa@my-proj.iam.gserviceaccount.com"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["gcp_service_account_email"] == "bioaf-sa@my-proj.iam.gserviceaccount.com"
+
+    get_resp = await client.get(
+        "/api/v1/settings/gcp",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert get_resp.status_code == 200
+    assert get_resp.json()["gcp_service_account_email"] == "bioaf-sa@my-proj.iam.gserviceaccount.com"
+
+
+# ---------------------------------------------------------------------------
+# Test 19: POST validate passes service_account_email to validator
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_post_validate_passes_sa_email(client, admin_token, session):
+    """POST validate passes the stored service_account_email to the validation function."""
+    await _seed_gcp_defaults(session)
+    await session.execute(text("UPDATE platform_config SET value='my-proj' WHERE key='gcp_project_id'"))
+    await session.execute(
+        text("UPDATE platform_config SET value='sa@proj.iam.gserviceaccount.com' WHERE key='gcp_service_account_email'")
+    )
+    await session.commit()
+
+    with patch("app.api.gcp_config.validate_gcp_credentials") as mock_validate:
+        from app.schemas.gcp_config import GCPValidationCheck, GCPValidationResult
+
+        mock_validate.return_value = GCPValidationResult(
+            passed=True,
+            checks=[GCPValidationCheck(name="credentials_loaded", passed=True, message="OK")],
+        )
+
+        await client.post(
+            "/api/v1/settings/gcp/validate",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        mock_validate.assert_called_once()
+        call_kwargs = mock_validate.call_args
+        assert call_kwargs.kwargs.get("service_account_email") == "sa@proj.iam.gserviceaccount.com"

--- a/backend/tests/test_gcp_config_schemas.py
+++ b/backend/tests/test_gcp_config_schemas.py
@@ -87,9 +87,11 @@ class TestGCPConfigResponse:
             gcp_credentials_configured=False,
             gcp_validation_status=None,
             gcp_credential_source="vm_default",
+            gcp_service_account_email=None,
         )
         assert resp.gcp_project_id == "proj-123"
         assert resp.gcp_credentials_configured is False
+        assert resp.gcp_service_account_email is None
 
     def test_response_no_service_account_key_field(self):
         """Response must never expose the raw service account key."""
@@ -101,6 +103,7 @@ class TestGCPConfigResponse:
             gcp_credentials_configured=False,
             gcp_validation_status=None,
             gcp_credential_source="vm_default",
+            gcp_service_account_email=None,
         )
         assert not hasattr(resp, "service_account_key")
         assert not hasattr(resp, "gcp_service_account_key")

--- a/backend/tests/test_gcp_config_service.py
+++ b/backend/tests/test_gcp_config_service.py
@@ -24,6 +24,26 @@ VALID_SA_KEY = json.dumps(
 )
 
 
+def _mock_enabled_services(api_names: list[str]) -> MagicMock:
+    """Build a mock list_services response with the given enabled API names."""
+    services = []
+    for name in api_names:
+        svc = MagicMock()
+        svc.config.name = name
+        services.append(svc)
+    return services
+
+
+ALL_REQUIRED_APIS = [
+    "cloudresourcemanager.googleapis.com",
+    "storage.googleapis.com",
+    "container.googleapis.com",
+    "iam.googleapis.com",
+    "secretmanager.googleapis.com",
+    "compute.googleapis.com",
+]
+
+
 # ---------------------------------------------------------------------------
 # Test 1: All checks skipped when credentials cannot be loaded
 # ---------------------------------------------------------------------------
@@ -88,18 +108,21 @@ def test_project_not_accessible_skips_downstream(mock_sa, mock_rm):
 
 
 # ---------------------------------------------------------------------------
-# Test 4: Storage API disabled returns failed check, GKE check skipped
+# Test 4: Storage API disabled returns failed check
 # ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
 @patch("app.services.gcp_config.storage")
 @patch("app.services.gcp_config.resourcemanager_v3")
 @patch("app.services.gcp_config.service_account")
-def test_storage_api_disabled_marks_check_failed(mock_sa, mock_rm, mock_storage):
+def test_storage_api_disabled_marks_check_failed(mock_sa, mock_rm, mock_storage, mock_gke, mock_su):
     """When Cloud Storage API is not enabled the check fails."""
     mock_creds = MagicMock()
     mock_sa.Credentials.from_service_account_info.return_value = mock_creds
     mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
-    # Simulate Storage API disabled by raising an exception on bucket list
     mock_storage.Client.return_value.list_buckets.side_effect = Exception("Cloud Storage API has not been used")
+    mock_gke.ClusterManagerClient.return_value.list_clusters.return_value = MagicMock()
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(ALL_REQUIRED_APIS)
 
     result = validate_gcp_credentials(
         project_id="my-project",
@@ -115,15 +138,19 @@ def test_storage_api_disabled_marks_check_failed(mock_sa, mock_rm, mock_storage)
 # ---------------------------------------------------------------------------
 # Test 5: vm_default credential source uses google.auth.default
 # ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
 @patch("app.services.gcp_config.storage")
 @patch("app.services.gcp_config.resourcemanager_v3")
 @patch("app.services.gcp_config.google_auth_default")
-def test_vm_default_uses_google_auth_default(mock_auth_default, mock_rm, mock_storage):
+def test_vm_default_uses_google_auth_default(mock_auth_default, mock_rm, mock_storage, mock_gke, mock_su):
     """When credential_source is 'vm_default', google.auth.default() is called."""
     mock_creds = MagicMock()
     mock_auth_default.return_value = (mock_creds, "my-project")
     mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
     mock_storage.Client.return_value.list_buckets.return_value = []
+    mock_gke.ClusterManagerClient.return_value.list_clusters.return_value = MagicMock()
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(ALL_REQUIRED_APIS)
 
     validate_gcp_credentials(
         project_id="my-project",
@@ -137,15 +164,19 @@ def test_vm_default_uses_google_auth_default(mock_auth_default, mock_rm, mock_st
 # ---------------------------------------------------------------------------
 # Test 6: All checks pass when GCP APIs respond correctly
 # ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
 @patch("app.services.gcp_config.storage")
 @patch("app.services.gcp_config.resourcemanager_v3")
 @patch("app.services.gcp_config.service_account")
-def test_all_checks_pass_with_valid_credentials(mock_sa, mock_rm, mock_storage):
+def test_all_checks_pass_with_valid_credentials(mock_sa, mock_rm, mock_storage, mock_gke, mock_su):
     """When all GCP API calls succeed, all checks pass and result.passed is True."""
     mock_creds = MagicMock()
     mock_sa.Credentials.from_service_account_info.return_value = mock_creds
     mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
     mock_storage.Client.return_value.list_buckets.return_value = []
+    mock_gke.ClusterManagerClient.return_value.list_clusters.return_value = MagicMock()
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(ALL_REQUIRED_APIS)
 
     result = validate_gcp_credentials(
         project_id="my-project",
@@ -157,3 +188,172 @@ def test_all_checks_pass_with_valid_credentials(mock_sa, mock_rm, mock_storage):
     for check in result.checks:
         assert check.passed is True, f"Check {check.name!r} should have passed"
         assert check.status != "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: vm_default with service_account_email uses impersonation
+# ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
+@patch("app.services.gcp_config.storage")
+@patch("app.services.gcp_config.resourcemanager_v3")
+@patch("app.services.gcp_config.impersonated_credentials")
+@patch("app.services.gcp_config.google_auth_default")
+def test_vm_default_with_sa_email_uses_impersonation(
+    mock_auth_default, mock_impersonated, mock_rm, mock_storage, mock_gke, mock_su
+):
+    """When vm_default + service_account_email is set, impersonated credentials are used."""
+    mock_source_creds = MagicMock()
+    mock_auth_default.return_value = (mock_source_creds, "my-project")
+    mock_target_creds = MagicMock()
+    mock_impersonated.Credentials.return_value = mock_target_creds
+
+    mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
+    mock_storage.Client.return_value.list_buckets.return_value = []
+    mock_gke.ClusterManagerClient.return_value.list_clusters.return_value = MagicMock()
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(ALL_REQUIRED_APIS)
+
+    result = validate_gcp_credentials(
+        project_id="my-project",
+        credential_source="vm_default",
+        service_account_key=None,
+        service_account_email="bioaf-sa@my-project.iam.gserviceaccount.com",
+    )
+
+    mock_impersonated.Credentials.assert_called_once()
+    call_kwargs = mock_impersonated.Credentials.call_args
+    assert call_kwargs.kwargs["target_principal"] == "bioaf-sa@my-project.iam.gserviceaccount.com"
+
+    cred_check = next(c for c in result.checks if c.name == "credentials_loaded")
+    assert cred_check.passed is True
+    assert "impersonating" in cred_check.message
+
+
+# ---------------------------------------------------------------------------
+# Test 8: GKE API check fails when API is disabled
+# ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
+@patch("app.services.gcp_config.storage")
+@patch("app.services.gcp_config.resourcemanager_v3")
+@patch("app.services.gcp_config.service_account")
+def test_gke_api_disabled_marks_check_failed(mock_sa, mock_rm, mock_storage, mock_gke, mock_su):
+    """When GKE API is not enabled, the gke_api_enabled check fails."""
+    mock_creds = MagicMock()
+    mock_sa.Credentials.from_service_account_info.return_value = mock_creds
+    mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
+    mock_storage.Client.return_value.list_buckets.return_value = []
+    mock_gke.ClusterManagerClient.return_value.list_clusters.side_effect = Exception(
+        "Kubernetes Engine API has not been used"
+    )
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(ALL_REQUIRED_APIS)
+
+    result = validate_gcp_credentials(
+        project_id="my-project",
+        credential_source="service_account_key",
+        service_account_key=VALID_SA_KEY,
+    )
+
+    gke_check = next(c for c in result.checks if c.name == "gke_api_enabled")
+    assert gke_check.passed is False
+    assert result.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Missing required APIs are reported in iam_permissions check
+# ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
+@patch("app.services.gcp_config.storage")
+@patch("app.services.gcp_config.resourcemanager_v3")
+@patch("app.services.gcp_config.service_account")
+def test_missing_required_apis_reported(mock_sa, mock_rm, mock_storage, mock_gke, mock_su):
+    """When required APIs are not enabled, iam_permissions check reports them."""
+    mock_creds = MagicMock()
+    mock_sa.Credentials.from_service_account_info.return_value = mock_creds
+    mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
+    mock_storage.Client.return_value.list_buckets.return_value = []
+    mock_gke.ClusterManagerClient.return_value.list_clusters.return_value = MagicMock()
+
+    # Only some APIs enabled - missing iam and secretmanager
+    partial_apis = [
+        "cloudresourcemanager.googleapis.com",
+        "storage.googleapis.com",
+        "container.googleapis.com",
+        "compute.googleapis.com",
+    ]
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(partial_apis)
+
+    result = validate_gcp_credentials(
+        project_id="my-project",
+        credential_source="service_account_key",
+        service_account_key=VALID_SA_KEY,
+    )
+
+    iam_check = next(c for c in result.checks if c.name == "iam_permissions")
+    assert iam_check.passed is False
+    assert "iam.googleapis.com" in iam_check.message
+    assert "secretmanager.googleapis.com" in iam_check.message
+    assert result.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Test 10: storage_access is skipped when storage API is disabled
+# ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
+@patch("app.services.gcp_config.storage")
+@patch("app.services.gcp_config.resourcemanager_v3")
+@patch("app.services.gcp_config.service_account")
+def test_storage_access_skipped_when_storage_api_disabled(mock_sa, mock_rm, mock_storage, mock_gke, mock_su):
+    """When storage API check fails, storage_access is skipped."""
+    mock_creds = MagicMock()
+    mock_sa.Credentials.from_service_account_info.return_value = mock_creds
+    mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
+    mock_storage.Client.return_value.list_buckets.side_effect = Exception("Storage API disabled")
+    mock_gke.ClusterManagerClient.return_value.list_clusters.return_value = MagicMock()
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(ALL_REQUIRED_APIS)
+
+    result = validate_gcp_credentials(
+        project_id="my-project",
+        credential_source="service_account_key",
+        service_account_key=VALID_SA_KEY,
+    )
+
+    storage_access = next(c for c in result.checks if c.name == "storage_access")
+    assert storage_access.status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Test 11: All six checks are returned in expected order
+# ---------------------------------------------------------------------------
+@patch("app.services.gcp_config.service_usage_v1")
+@patch("app.services.gcp_config.container_v1")
+@patch("app.services.gcp_config.storage")
+@patch("app.services.gcp_config.resourcemanager_v3")
+@patch("app.services.gcp_config.service_account")
+def test_all_six_checks_returned_in_order(mock_sa, mock_rm, mock_storage, mock_gke, mock_su):
+    """Validation returns all six checks in the expected order."""
+    mock_creds = MagicMock()
+    mock_sa.Credentials.from_service_account_info.return_value = mock_creds
+    mock_rm.ProjectsClient.return_value.get_project.return_value = MagicMock()
+    mock_storage.Client.return_value.list_buckets.return_value = []
+    mock_gke.ClusterManagerClient.return_value.list_clusters.return_value = MagicMock()
+    mock_su.ServiceUsageClient.return_value.list_services.return_value = _mock_enabled_services(ALL_REQUIRED_APIS)
+
+    result = validate_gcp_credentials(
+        project_id="my-project",
+        credential_source="service_account_key",
+        service_account_key=VALID_SA_KEY,
+    )
+
+    expected_names = [
+        "credentials_loaded",
+        "project_accessible",
+        "storage_api_enabled",
+        "gke_api_enabled",
+        "iam_permissions",
+        "storage_access",
+    ]
+    actual_names = [c.name for c in result.checks]
+    assert actual_names == expected_names

--- a/frontend/src/app/settings/gcp/page.tsx
+++ b/frontend/src/app/settings/gcp/page.tsx
@@ -13,6 +13,7 @@ interface GCPConfig {
   gcp_credentials_configured: boolean;
   gcp_validation_status: string | null;
   gcp_credential_source: string;
+  gcp_service_account_email: string | null;
 }
 
 interface ValidationCheck {
@@ -56,6 +57,30 @@ function zonesForRegion(region: string): string[] {
   return GCP_ZONES[region] ?? [`${region}-a`, `${region}-b`, `${region}-c`];
 }
 
+const REQUIRED_APIS = [
+  { name: "cloudresourcemanager.googleapis.com", description: "Cloud Resource Manager" },
+  { name: "compute.googleapis.com", description: "Compute Engine" },
+  { name: "container.googleapis.com", description: "Kubernetes Engine" },
+  { name: "iam.googleapis.com", description: "Identity and Access Management" },
+  { name: "secretmanager.googleapis.com", description: "Secret Manager" },
+  { name: "servicenetworking.googleapis.com", description: "Service Networking" },
+  { name: "serviceusage.googleapis.com", description: "Service Usage" },
+  { name: "storage.googleapis.com", description: "Cloud Storage" },
+  { name: "sqladmin.googleapis.com", description: "Cloud SQL Admin" },
+  { name: "cloudbilling.googleapis.com", description: "Cloud Billing" },
+  { name: "file.googleapis.com", description: "Filestore" },
+];
+
+const REQUIRED_ROLES = [
+  "roles/container.admin",
+  "roles/compute.admin",
+  "roles/iam.serviceAccountUser",
+  "roles/storage.admin",
+  "roles/secretmanager.admin",
+  "roles/cloudsql.admin",
+  "roles/serviceusage.serviceUsageViewer",
+];
+
 export default function GcpSettingsPage() {
   const [projectId, setProjectId] = useState("");
   const [region, setRegion] = useState("us-central1");
@@ -63,6 +88,7 @@ export default function GcpSettingsPage() {
   const [orgSlug, setOrgSlug] = useState("");
   const [credentialSource, setCredentialSource] = useState<"vm_default" | "service_account_key">("vm_default");
   const [serviceAccountKey, setServiceAccountKey] = useState("");
+  const [serviceAccountEmail, setServiceAccountEmail] = useState("");
 
   const [orgSlugError, setOrgSlugError] = useState<string | null>(null);
   const [message, setMessage] = useState("");
@@ -70,6 +96,7 @@ export default function GcpSettingsPage() {
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
   const [validating, setValidating] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [showRequirements, setShowRequirements] = useState(false);
 
   useEffect(() => {
     api.get<GCPConfig>("/api/v1/settings/gcp").then((cfg) => {
@@ -78,6 +105,7 @@ export default function GcpSettingsPage() {
       setZone(cfg.gcp_zone ?? "us-central1-a");
       setOrgSlug(cfg.org_slug ?? "");
       setCredentialSource((cfg.gcp_credential_source as "vm_default" | "service_account_key") ?? "vm_default");
+      setServiceAccountEmail(cfg.gcp_service_account_email ?? "");
     });
   }, []);
 
@@ -100,6 +128,7 @@ export default function GcpSettingsPage() {
         service_account_key: credentialSource === "service_account_key" && serviceAccountKey
           ? serviceAccountKey
           : undefined,
+        gcp_service_account_email: serviceAccountEmail || undefined,
       });
       setMessage("GCP configuration saved");
       setValidationResult(null);
@@ -250,6 +279,29 @@ export default function GcpSettingsPage() {
                   />
                 </div>
               )}
+
+              {credentialSource === "vm_default" && (
+                <div className="mt-3">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Service Account Email
+                    <span className="ml-1 text-gray-400 font-normal text-xs">(optional -- for impersonation)</span>
+                  </label>
+                  <input
+                    data-testid="service-account-email-input"
+                    type="email"
+                    value={serviceAccountEmail}
+                    onChange={(e) => setServiceAccountEmail(e.target.value)}
+                    className="w-full px-3 py-2 border rounded"
+                    placeholder="bioaf-sa@my-project.iam.gserviceaccount.com"
+                  />
+                  <p className="mt-1 text-xs text-gray-500">
+                    If set, the VM default credentials will impersonate this service account.
+                    Useful when the VM default SA lacks required scopes. The VM SA must have
+                    the <code className="bg-gray-100 px-1 rounded">roles/iam.serviceAccountTokenCreator</code> role
+                    on the target account.
+                  </p>
+                </div>
+              )}
             </div>
 
             {/* Action buttons */}
@@ -290,7 +342,7 @@ export default function GcpSettingsPage() {
                 {validationResult.checks.map((check) => (
                   <li key={check.name} className="flex items-start gap-2 text-sm">
                     <span className={`mt-0.5 ${check.passed ? "text-green-600" : check.status === "skipped" ? "text-gray-400" : "text-red-600"}`}>
-                      {check.passed ? "✓" : check.status === "skipped" ? "–" : "✗"}
+                      {check.passed ? "\u2713" : check.status === "skipped" ? "\u2013" : "\u2717"}
                     </span>
                     <div>
                       <span className="font-medium">{check.name}</span>
@@ -301,6 +353,91 @@ export default function GcpSettingsPage() {
               </ul>
             </div>
           )}
+
+          {/* Requirements guidance */}
+          <div className="mt-6 max-w-2xl">
+            <button
+              data-testid="toggle-requirements-btn"
+              onClick={() => setShowRequirements(!showRequirements)}
+              className="text-sm text-bioaf-600 hover:text-bioaf-700 font-medium"
+            >
+              {showRequirements ? "Hide" : "Show"} GCP project requirements
+            </button>
+
+            {showRequirements && (
+              <div data-testid="requirements-section" className="mt-3 bg-white rounded-lg shadow p-6 space-y-4">
+                <h2 className="text-lg font-semibold">GCP Project Requirements</h2>
+
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-700 mb-2">Required APIs</h3>
+                  <p className="text-xs text-gray-500 mb-2">
+                    Enable these APIs in the GCP Console under APIs &amp; Services, or run:
+                  </p>
+                  <pre className="bg-gray-50 border rounded p-3 text-xs overflow-x-auto mb-2">
+{`gcloud services enable \\
+  ${REQUIRED_APIS.map(a => a.name).join(" \\\n  ")} \\
+  --project=YOUR_PROJECT_ID`}
+                  </pre>
+                  <ul className="text-xs text-gray-600 space-y-1">
+                    {REQUIRED_APIS.map((a) => (
+                      <li key={a.name}>
+                        <code className="bg-gray-100 px-1 rounded">{a.name}</code>
+                        <span className="ml-1 text-gray-400">-- {a.description}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-700 mb-2">Required IAM Roles</h3>
+                  <p className="text-xs text-gray-500 mb-2">
+                    The service account used by bioAF needs the following roles. Grant them with:
+                  </p>
+                  <pre className="bg-gray-50 border rounded p-3 text-xs overflow-x-auto mb-2">
+{`SA_EMAIL="your-sa@your-project.iam.gserviceaccount.com"
+PROJECT_ID="your-project-id"
+
+${REQUIRED_ROLES.map(r => `gcloud projects add-iam-policy-binding $PROJECT_ID \\
+  --member="serviceAccount:$SA_EMAIL" \\
+  --role="${r}"`).join("\n\n")}`}
+                  </pre>
+                  <ul className="text-xs text-gray-600 space-y-1">
+                    {REQUIRED_ROLES.map((r) => (
+                      <li key={r}>
+                        <code className="bg-gray-100 px-1 rounded">{r}</code>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-700 mb-2">VM Default Credentials with Impersonation</h3>
+                  <p className="text-xs text-gray-500">
+                    If your VM default service account does not have the required scopes or roles,
+                    create a dedicated service account with the roles above, then set its email in
+                    the &quot;Service Account Email&quot; field. The VM default SA will impersonate it.
+                    The VM SA needs the <code className="bg-gray-100 px-1 rounded">roles/iam.serviceAccountTokenCreator</code> role
+                    on the target service account.
+                  </p>
+                  <pre className="bg-gray-50 border rounded p-3 text-xs overflow-x-auto mt-2">
+{`# Create dedicated SA
+gcloud iam service-accounts create bioaf-sa \\
+  --display-name="bioAF Service Account" \\
+  --project=YOUR_PROJECT_ID
+
+# Grant required roles to the new SA
+# (use the IAM role commands above)
+
+# Allow VM default SA to impersonate it
+gcloud iam service-accounts add-iam-policy-binding \\
+  bioaf-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com \\
+  --member="serviceAccount:VM_DEFAULT_SA@YOUR_PROJECT_ID.iam.gserviceaccount.com" \\
+  --role="roles/iam.serviceAccountTokenCreator"`}
+                  </pre>
+                </div>
+              </div>
+            )}
+          </div>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes GCP validation failure when VM default credentials lack the `cloud-platform` scope. Adds service account impersonation support, implements the 3 missing validation checks, and provides user-facing guidance on required APIs and IAM roles.

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Infrastructure / Terraform
- [ ] Documentation
- [ ] CI / tooling
- [ ] Refactor (no functional change)

## Related Issues

Fixes #59

## What Changed

- **Service account email field**: New optional `gcp_service_account_email` config field (schema, API, migration 029, frontend). When set with VM default credentials, uses `google.auth.impersonated_credentials` to impersonate the target SA.
- **3 missing validation checks implemented**:
  - `gke_api_enabled` -- verifies Kubernetes Engine API is accessible via `container_v1.ClusterManagerClient.list_clusters()`
  - `iam_permissions` -- checks that all 6 required APIs are enabled via the Service Usage API
  - `storage_access` -- probes for bioaf-prefixed buckets to confirm storage write access
- **Requirements guidance section** on the frontend: collapsible panel showing the exact `gcloud` commands to enable required APIs, grant IAM roles, and set up SA impersonation
- **New dependency**: `google-cloud-service-usage>=1.8` in `requirements.txt`
- **Test coverage**: 11 service tests (up from 6), 13 API tests (up from 11), 22 schema tests (up from 17)

## How to Test

1. Deploy on a GCP VM with default credentials that lack `cloud-platform` scope
2. Navigate to Settings > GCP Configuration
3. Fill in project ID, region, zone, org slug
4. Set a dedicated service account email in the new field
5. Save and click Validate Connection -- all 6 checks should now run
6. Click "Show GCP project requirements" to verify guidance content
7. Run `cd backend && python3 -m pytest tests/ -x -q` -- all 896 tests pass

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [x] I have added/updated tests for my changes
- [x] All new and existing tests pass locally
- [x] I have updated documentation if needed
- [ ] Terraform changes include `terraform validate` output
- [x] Database migrations are reversible (if applicable)
- [x] No secrets, credentials, or API keys are committed
- [x] Audit log coverage: state-changing operations write to audit log (if applicable)

## Deployment Notes

- Run migration 029 (`alembic upgrade head`) to add the `gcp_service_account_email` platform_config key
- Rebuild backend container to pick up the new `google-cloud-service-usage` dependency