### PR TITLE
Fix Cost vs. Budget widget calling nonexistent endpoint

### DIFF
--- a/frontend/src/components/dashboard/CostBudgetWidget.tsx
+++ b/frontend/src/components/dashboard/CostBudgetWidget.tsx
@@ -3,10 +3,16 @@
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 
+interface CostSummaryResponse {
+  current_month_spend: number;
+  monthly_budget: number | null;
+  budget_remaining: number | null;
+  projected_month_end: number | null;
+}
+
 interface BudgetData {
   current_spend: number;
   monthly_budget: number;
-  currency: string;
 }
 
 export function CostBudgetWidget() {
@@ -16,8 +22,15 @@ export function CostBudgetWidget() {
 
   useEffect(() => {
     api
-      .get<BudgetData>("/api/cost-center/budget-summary")
-      .then(setData)
+      .get<CostSummaryResponse>("/api/costs/summary")
+      .then((res) => {
+        if (res.monthly_budget != null) {
+          setData({
+            current_spend: res.current_month_spend,
+            monthly_budget: res.monthly_budget,
+          });
+        }
+      })
       .catch(() => setError("Failed to load budget data"))
       .finally(() => setLoading(false));
   }, []);

--- a/frontend/tests/components/dashboard/widgets.test.tsx
+++ b/frontend/tests/components/dashboard/widgets.test.tsx
@@ -98,11 +98,25 @@ describe("Dashboard Widgets", () => {
   });
 
   describe("CostBudgetWidget", () => {
+    it("calls the correct endpoint", async () => {
+      mockApiGet.mockResolvedValueOnce({
+        current_month_spend: 500,
+        monthly_budget: 1000,
+        budget_remaining: 500,
+        projected_month_end: 800,
+      });
+      render(<CostBudgetWidget />);
+      await waitFor(() => {
+        expect(mockApiGet).toHaveBeenCalledWith("/api/costs/summary");
+      });
+    });
+
     it("renders with mock data", async () => {
       mockApiGet.mockResolvedValueOnce({
-        current_spend: 500,
+        current_month_spend: 500,
         monthly_budget: 1000,
-        currency: "USD",
+        budget_remaining: 500,
+        projected_month_end: 800,
       });
       render(<CostBudgetWidget />);
       await waitFor(() => {
@@ -113,6 +127,19 @@ describe("Dashboard Widgets", () => {
     });
 
     it("shows empty state when no budget configured", async () => {
+      mockApiGet.mockResolvedValueOnce({
+        current_month_spend: 200,
+        monthly_budget: null,
+        budget_remaining: null,
+        projected_month_end: null,
+      });
+      render(<CostBudgetWidget />);
+      await waitFor(() => {
+        expect(screen.getByTestId("widget-empty")).toBeInTheDocument();
+      });
+    });
+
+    it("handles error state", async () => {
       mockApiGet.mockRejectedValueOnce(new Error("fail"));
       render(<CostBudgetWidget />);
       await waitFor(() => {


### PR DESCRIPTION
## Summary

The dashboard's Cost vs. Budget widget always showed "Failed to load budget data" because it called a nonexistent API endpoint.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Infrastructure / Terraform
- [ ] Documentation
- [ ] CI / tooling
- [ ] Refactor (no functional change)

## Related Issues

Fixes #72

## What Changed

- `CostBudgetWidget` now calls `/api/costs/summary` instead of the nonexistent `/api/cost-center/budget-summary`
- Response field mapping: `current_month_spend` from the summary endpoint is used as `current_spend` for display
- When `monthly_budget` is null in the response (budget not configured), the widget shows the empty state instead of erroring

## How to Test

1. Deploy with a budget configured -- the widget should show current spend vs. budget with a progress bar
2. Deploy without a budget configured -- the widget should show "Budget not configured. Set up in Infrastructure > Cost Center."
3. Run `npm test -- --passWithNoTests` from `frontend/` -- all widget tests pass

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style conventions
- [x] I have added/updated tests for my changes
- [x] All new and existing tests pass locally
- [x] I have updated documentation if needed
- [ ] Terraform changes include `terraform validate` output
- [ ] Database migrations are reversible (if applicable)
- [x] No secrets, credentials, or API keys are committed
- [ ] Audit log coverage: state-changing operations write to audit log (if applicable)

## Screenshots / Outputs

N/A -- frontend-only fix

## Deployment Notes

None. Frontend-only change, no migrations or infrastructure changes needed.