### PR TITLE
Add missing projects/experiments/new page to fix blank screen on experiment creation

### DIFF
--- a/frontend/src/app/projects/experiments/new/page.tsx
+++ b/frontend/src/app/projects/experiments/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/experiments/new/page";

--- a/frontend/tests/redirects.test.ts
+++ b/frontend/tests/redirects.test.ts
@@ -3,6 +3,9 @@
  * These verify the redirect configuration is correct by importing and checking the config.
  */
 
+import * as fs from "fs";
+import * as path from "path";
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const nextConfig = require("../next.config.js");
 
@@ -82,6 +85,23 @@ describe("Route Redirects", () => {
     expect(redirect).toBeDefined();
     expect(redirect!.destination).toBe("/projects/experiments/:id");
     expect(redirect!.permanent).toBe(true);
+  });
+
+  it("routes /experiments/new to /projects/experiments/new via the :id pattern", () => {
+    // The /experiments/:id redirect catches /experiments/new and sends it to
+    // /projects/experiments/new. That page must exist or Next.js falls through
+    // to [id]/page.tsx with id="new", showing "Experiment not found".
+    const idRedirect = redirects.find(
+      (r: Redirect) => r.source === "/experiments/:id",
+    );
+    expect(idRedirect).toBeDefined();
+    expect(idRedirect!.destination).toBe("/projects/experiments/:id");
+
+    const newPagePath = path.resolve(
+      __dirname,
+      "../src/app/projects/experiments/new/page.tsx",
+    );
+    expect(fs.existsSync(newPagePath)).toBe(true);
   });
 
   it("contains all expected redirect sources", () => {


### PR DESCRIPTION
## Summary

Clicking \"New Experiment\" showed a blank white screen with \"Experiment not found\" instead of the creation form.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #74

## What Changed

- Added `frontend/src/app/projects/experiments/new/page.tsx` — a one-line re-export of `@/app/experiments/new/page`, matching the pattern used by the list and detail pages under `projects/experiments/`
- Added a regression test to `tests/redirects.test.ts` that asserts the file exists, preventing future deletion from silently breaking the route

## How to Test

1. Log in to bioAF
2. Navigate to Experiments (via sidebar or `/projects/experiments`)
3. Click "New Experiment"
4. Verify the experiment creation form renders instead of "Experiment not found"

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project's style conventions
- [x] I have added/updated tests for my changes
- [x] All new and existing tests pass locally
- [x] I have updated documentation if needed
- [x] Terraform changes include `terraform validate` output
- [x] Database migrations are reversible (if applicable)
- [x] No secrets, credentials, or API keys are committed
- [x] Audit log coverage: state-changing operations write to audit log (if applicable)

## Screenshots / Outputs

N/A

## Deployment Notes

No migration or infrastructure changes. Frontend-only fix; a new build is required.