### PR TITLE
Fix vocabulary API response shape mismatch crashing Add Sample form

### DIFF
--- a/frontend/src/components/shared/VocabularySelect.tsx
+++ b/frontend/src/components/shared/VocabularySelect.tsx
@@ -37,8 +37,8 @@ export function VocabularySelect({
     >
       {allowEmpty && <option value="">{placeholder || `Select ${fieldName.replace(/_/g, " ")}...`}</option>}
       {values.map((v) => (
-        <option key={v.id} value={v.allowed_value}>
-          {v.display_label || v.allowed_value}
+        <option key={v.id} value={v.value}>
+          {v.display_label || v.value}
         </option>
       ))}
     </select>

--- a/frontend/src/hooks/useVocabulary.ts
+++ b/frontend/src/hooks/useVocabulary.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
-import type { ControlledVocabularyValue } from "@/lib/types";
+import type { ControlledVocabularyValue, ControlledVocabularyResponse } from "@/lib/types";
 
 const cache = new Map<string, { data: ControlledVocabularyValue[]; ts: number }>();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -21,11 +21,11 @@ export function useVocabulary(fieldName: string) {
 
     (async () => {
       try {
-        const data = await api.get<ControlledVocabularyValue[]>(
+        const data = await api.get<ControlledVocabularyResponse>(
           `/api/vocabularies?field=${encodeURIComponent(fieldName)}&active_only=true`
         );
-        cache.set(fieldName, { data, ts: Date.now() });
-        setValues(data);
+        cache.set(fieldName, { data: data.values, ts: Date.now() });
+        setValues(data.values);
       } catch {
         // ignore - field may not have vocabulary values yet
       } finally {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -963,12 +963,16 @@ export type ReviewVerdict = "approved" | "approved_with_caveats" | "rejected" | 
 
 export interface ControlledVocabularyValue {
   id: number;
-  field_name: string;
-  allowed_value: string;
+  value: string;
   display_label: string | null;
   display_order: number;
   is_default: boolean;
   is_active: boolean;
+}
+
+export interface ControlledVocabularyResponse {
+  field_name: string;
+  values: ControlledVocabularyValue[];
 }
 
 export interface ControlledVocabularyFieldsResponse {

--- a/frontend/tests/components/shared/VocabularySelect.test.tsx
+++ b/frontend/tests/components/shared/VocabularySelect.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { VocabularySelect } from "@/components/shared/VocabularySelect";
+
+// Mock useVocabulary so the test is not coupled to the API
+jest.mock("@/hooks/useVocabulary", () => ({
+  useVocabulary: (fieldName: string) => {
+    if (fieldName === "molecule_type") {
+      return {
+        values: [
+          { id: 1, value: "total RNA", display_label: null, display_order: 1, is_default: true, is_active: true },
+          { id: 2, value: "polyA RNA", display_label: "polyA RNA (enriched)", display_order: 2, is_default: false, is_active: true },
+        ],
+        loading: false,
+      };
+    }
+    return { values: [], loading: false };
+  },
+}));
+
+describe("VocabularySelect", () => {
+  it("renders options using the value field from the API response", () => {
+    render(
+      <VocabularySelect
+        fieldName="molecule_type"
+        value={null}
+        onChange={jest.fn()}
+        placeholder="Molecule Type..."
+      />
+    );
+    expect(screen.getByRole("option", { name: "total RNA" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "polyA RNA (enriched)" })).toBeInTheDocument();
+  });
+
+  it("uses display_label when present, falls back to value", () => {
+    render(
+      <VocabularySelect
+        fieldName="molecule_type"
+        value={null}
+        onChange={jest.fn()}
+      />
+    );
+    // display_label is null for total RNA — falls back to value
+    expect(screen.getByRole("option", { name: "total RNA" })).toBeInTheDocument();
+    // display_label is set for polyA RNA
+    expect(screen.getByRole("option", { name: "polyA RNA (enriched)" })).toBeInTheDocument();
+  });
+
+  it("renders empty select for a field with no vocabulary values", () => {
+    render(
+      <VocabularySelect
+        fieldName="unknown_field"
+        value={null}
+        onChange={jest.fn()}
+        placeholder="Pick one..."
+        allowEmpty
+      />
+    );
+    // Only the empty/placeholder option
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Pick one...");
+  });
+});


### PR DESCRIPTION
## Summary

The Add Sample form crashed immediately with `TypeError: x.map is not a function`. The vocabulary hook was treating the full API response object as an array and passing it to `VocabularySelect`, which called `.map()` on it. A secondary mismatch meant option values would render as empty strings even after fixing the array issue.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #76

## What Changed

- `types.ts`: updated `ControlledVocabularyValue` to use `value` (matching the backend schema's `ControlledVocabularyValueResponse`); added `ControlledVocabularyResponse` wrapper type `{ field_name, values }`
- `useVocabulary.ts`: types the fetch as `ControlledVocabularyResponse` and extracts `.values` before storing/setting state
- `VocabularySelect.tsx`: reads `v.value` instead of `v.allowed_value`
- `VocabularySelect.test.tsx`: new test file covering option rendering with `value`/`display_label` and the empty-field case

## How to Test

1. Log in to bioAF
2. Open any experiment → Samples tab → Add Sample
3. Verify the form opens without crashing
4. Verify Molecule Type, Library Prep, Library Layout dropdowns are populated with vocabulary values

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project's style conventions
- [x] I have added/updated tests for my changes
- [x] All new and existing tests pass locally
- [x] I have updated documentation if needed
- [x] Terraform changes include `terraform validate` output
- [x] Database migrations are reversible (if applicable)
- [x] No secrets, credentials, or API keys are committed
- [x] Audit log coverage: state-changing operations write to audit log (if applicable)

## Screenshots / Outputs

N/A

## Deployment Notes

Frontend-only change. New build required; no migrations or infrastructure changes.