### PR TITLE
Fix upload bucket naming and dataset service crash

### DIFF
--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -42,16 +42,19 @@ async def initiate_upload(
     org_id = int(current_user["org_id"])
     user_id = int(current_user["sub"])
 
-    result = await UploadService.initiate_upload(
-        session,
-        org_id,
-        user_id,
-        filename=body.filename,
-        expected_size=body.expected_size_bytes,
-        expected_md5=body.expected_md5,
-        experiment_id=body.experiment_id,
-        sample_ids=body.sample_ids,
-    )
+    try:
+        result = await UploadService.initiate_upload(
+            session,
+            org_id,
+            user_id,
+            filename=body.filename,
+            expected_size=body.expected_size_bytes,
+            expected_md5=body.expected_md5,
+            experiment_id=body.experiment_id,
+            sample_ids=body.sample_ids,
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
     return FileUploadInitiateResponse(**result)
 
 

--- a/backend/app/services/dataset_service.py
+++ b/backend/app/services/dataset_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -9,7 +9,6 @@ from app.models.experiment import Experiment
 from app.models.file import File
 from app.models.pipeline_run import PipelineRun
 from app.models.qc_dashboard import QCDashboard
-from app.models.sample import Sample
 
 logger = logging.getLogger("bioaf.dataset_service")
 
@@ -74,14 +73,11 @@ class DatasetService:
             if chemistry and not any(s.chemistry_version == chemistry for s in samples):
                 continue
 
-            # Get file count and size via sample_files junction table (LEFT JOIN
-            # so that experiments with 0 linked files return 0 instead of crashing)
+            # Get file count and size via File.experiment_id (direct FK)
             file_result = await session.execute(
-                select(func.count(File.id), func.coalesce(func.sum(File.size_bytes), 0))
-                .select_from(Sample)
-                .outerjoin(text("sample_files ON sample_files.sample_id = samples.id"))
-                .outerjoin(File, File.id == text("sample_files.file_id"))
-                .where(Sample.experiment_id == exp.id)
+                select(func.count(File.id), func.coalesce(func.sum(File.size_bytes), 0)).where(
+                    File.experiment_id == exp.id
+                )
             )
             file_row = file_result.first()
             file_count = file_row[0] if file_row else 0

--- a/backend/app/services/plot_archive_service.py
+++ b/backend/app/services/plot_archive_service.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timezone
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -141,9 +141,17 @@ class PlotArchiveService:
             orgs_result = await session.execute(select(Organization))
             orgs = list(orgs_result.scalars().all())
 
+            cfg_result = await session.execute(
+                text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'")
+            )
+            results_bucket = cfg_result.scalar_one_or_none()
+            if not results_bucket or results_bucket == "null":
+                logger.warning("results_bucket_name not configured in platform_config, skipping plot scan")
+                return 0
+
             for org in orgs:
                 org_id = org.id
-                bucket_name = f"bioaf-{org_id}-results"
+                bucket_name = results_bucket
                 last = _last_scan.get(org_id)
 
                 try:

--- a/backend/app/services/qc_dashboard_service.py
+++ b/backend/app/services/qc_dashboard_service.py
@@ -2,7 +2,7 @@ import io
 import logging
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pipeline_run import PipelineRun
@@ -213,9 +213,19 @@ class QCDashboardService:
         return summary
 
     @staticmethod
+    async def _get_results_bucket(session: AsyncSession) -> str | None:
+        """Read results bucket name from platform_config."""
+        result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'"))
+        name = result.scalar_one_or_none()
+        if not name or name == "null":
+            return None
+        return name
+
+    @staticmethod
     async def _generate_plots(session: AsyncSession, org_id: int, dashboard_id: int, metrics: dict) -> list[dict]:
         """Generate QC plot images and upload to GCS."""
         plots_meta = []
+        results_bucket = await QCDashboardService._get_results_bucket(session)
 
         try:
             # Lazy import matplotlib
@@ -275,7 +285,9 @@ class QCDashboardService:
                         org_id=org_id,
                         user_id=None,
                         filename=plot_filename,
-                        gcs_uri=f"gs://bioaf-{org_id}-results/qc_plots/{plot_filename}",
+                        gcs_uri=f"gs://{results_bucket}/qc_plots/{plot_filename}"
+                        if results_bucket
+                        else f"gs://unset/{plot_filename}",
                         size_bytes=buf.getbuffer().nbytes,
                         md5_checksum=None,
                         file_type="png",

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -3,6 +3,7 @@ import logging
 import re
 import uuid
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.file import File
@@ -43,6 +44,15 @@ class UploadService:
         return lower.endswith(".fastq.gz") or lower.endswith(".fq.gz")
 
     @staticmethod
+    async def _get_ingest_bucket(session: AsyncSession) -> str:
+        """Read ingest bucket name from platform_config."""
+        result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'ingest_bucket_name'"))
+        name = result.scalar_one_or_none()
+        if not name or name == "null":
+            raise ValueError("Ingest bucket not configured. Deploy storage infrastructure first.")
+        return name
+
+    @staticmethod
     async def initiate_upload(
         session: AsyncSession,
         org_id: int,
@@ -55,7 +65,7 @@ class UploadService:
     ) -> dict:
         """Initiate an upload, returning upload_id and signed URL."""
         upload_id = str(uuid.uuid4())
-        bucket_name = f"bioaf-{org_id}-data"
+        bucket_name = await UploadService._get_ingest_bucket(session)
         gcs_path = f"uploads/{upload_id}/{filename}"
         gcs_uri = f"gs://{bucket_name}/{gcs_path}"
 
@@ -160,7 +170,7 @@ class UploadService:
     ) -> File:
         """Simple single-request upload for small files."""
         upload_id = str(uuid.uuid4())
-        bucket_name = f"bioaf-{org_id}-data"
+        bucket_name = await UploadService._get_ingest_bucket(session)
         gcs_path = f"uploads/{upload_id}/{filename}"
         gcs_uri = f"gs://{bucket_name}/{gcs_path}"
 

--- a/backend/tests/test_datasets.py
+++ b/backend/tests/test_datasets.py
@@ -1,0 +1,69 @@
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def experiment_with_files(session, admin_user):
+    from app.models.experiment import Experiment
+    from app.models.file import File
+
+    exp = Experiment(
+        organization_id=admin_user.organization_id,
+        name="Dataset Test Experiment",
+        owner_user_id=admin_user.id,
+        status="fastq_uploaded",
+    )
+    session.add(exp)
+    await session.flush()
+
+    f = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri="gs://test-bucket/sample.fastq.gz",
+        filename="sample.fastq.gz",
+        size_bytes=500_000_000,
+        file_type="fastq",
+        uploader_user_id=admin_user.id,
+        experiment_id=exp.id,
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+    return exp, f
+
+
+@pytest.mark.asyncio
+async def test_search_datasets_returns_200(client, admin_token, experiment_with_files):
+    resp = await client.get(
+        "/api/datasets",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_search_datasets_aggregates_file_count(client, admin_token, experiment_with_files):
+    exp, f = experiment_with_files
+    resp = await client.get(
+        "/api/datasets",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    match = next((d for d in data["experiments"] if d["experiment_id"] == exp.id), None)
+    assert match is not None
+    assert match["file_count"] == 1
+    assert match["total_size_bytes"] == 500_000_000
+
+
+@pytest.mark.asyncio
+async def test_search_datasets_empty_org(client, admin_token):
+    resp = await client.get(
+        "/api/datasets",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "experiments" in data
+    assert "total" in data

--- a/backend/tests/test_upload_ingest_bucket.py
+++ b/backend/tests/test_upload_ingest_bucket.py
@@ -1,0 +1,57 @@
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def configured_ingest_bucket(session, admin_user):
+    """Insert ingest_bucket_name into platform_config for this org's deployment."""
+    from app.models.component import PlatformConfig
+
+    cfg = PlatformConfig(key="ingest_bucket_name", value="bioaf-ingest-test-abc123")
+    session.add(cfg)
+    await session.flush()
+    await session.commit()
+    return "bioaf-ingest-test-abc123"
+
+
+@pytest.mark.asyncio
+async def test_initiate_upload_requires_bucket_config(client, admin_token):
+    """Upload initiate must return 400 when ingest_bucket_name is not configured."""
+    resp = await client.post(
+        "/api/files/upload/initiate",
+        json={"filename": "sample.fastq.gz", "expected_size_bytes": 1_000_000},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 400
+    assert "bucket" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_initiate_upload_uses_configured_bucket(client, admin_token, configured_ingest_bucket):
+    """Upload initiate must use the bucket name stored in platform_config."""
+    resp = await client.post(
+        "/api/files/upload/initiate",
+        json={"filename": "sample.fastq.gz", "expected_size_bytes": 1_000_000},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert configured_ingest_bucket in data["gcs_uri"]
+
+
+@pytest.mark.asyncio
+async def test_initiate_upload_rejects_null_bucket(client, admin_token, session):
+    """platform_config row with value 'null' is treated as not configured."""
+    from app.models.component import PlatformConfig
+
+    cfg = PlatformConfig(key="ingest_bucket_name", value="null")
+    session.add(cfg)
+    await session.flush()
+    await session.commit()
+
+    resp = await client.post(
+        "/api/files/upload/initiate",
+        json={"filename": "sample.fastq.gz", "expected_size_bytes": 1_000_000},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- `upload_service`, `plot_archive_service`, and `qc_dashboard_service` were constructing GCS bucket names from a hardcoded pattern (`bioaf-{org_id}-data`, `bioaf-{org_id}-results`) that doesn't match what Terraform deploys. All three services now read the actual bucket name from `platform_config`. The upload initiate endpoint returns 400 when storage is not yet deployed.
- `DatasetService.search_datasets` was using `text()` as an ORM join target (invalid in SQLAlchemy 2.0), crashing the Dataset Browser page for all users. Fixed by querying `File.experiment_id` directly instead of joining through the unmapped `sample_files` junction table.

Closes #83, closes #84

## Test plan
- [ ] `test_datasets.py`: `GET /api/datasets` returns 200 and correctly aggregates file count and size
- [ ] `test_upload_ingest_bucket.py`: upload initiate returns 400 when bucket not configured; returns 200 with correct `gcs_uri` when configured; treats `value="null"` as not configured
- [ ] Full backend suite: `cd backend && python3 -m pytest tests/ -x -q` (926 tests pass)