### PR TITLE
Fix Ingest Status widget showing no count or detail

### DIFF
--- a/frontend/src/components/dashboard/IngestStatusWidget.test.tsx
+++ b/frontend/src/components/dashboard/IngestStatusWidget.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { IngestStatusWidget } from "./IngestStatusWidget";
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+// Mock the api module
+jest.mock("@/lib/api", () => ({
+  api: {
+    get: jest.fn(),
+  },
+}));
+
+// Mock auth so the token is always set
+jest.mock("@/lib/auth", () => ({
+  getToken: () => "fake-token",
+  removeToken: jest.fn(),
+}));
+
+import { api } from "@/lib/api";
+
+const mockGet = api.get as jest.Mock;
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+test("renders file count from /api/files endpoint", async () => {
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) {
+      return Promise.resolve({ files: [], total: 14, page: 1, page_size: 1 });
+    }
+    // ingest endpoints return arrays
+    return Promise.resolve([]);
+  });
+
+  render(<IngestStatusWidget />);
+
+  await waitFor(() => {
+    expect(screen.getByText("14")).toBeInTheDocument();
+  });
+
+  expect(screen.getByText("Files ingested")).toBeInTheDocument();
+});
+
+test("renders zero file count explicitly", async () => {
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) {
+      return Promise.resolve({ files: [], total: 0, page: 1, page_size: 1 });
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<IngestStatusWidget />);
+
+  await waitFor(() => {
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});
+
+test("renders unmatched count from array response", async () => {
+  const unmatchedEvents = [
+    { id: 1, ingest_status: "unmatched", source_path: "a.fastq" },
+    { id: 2, ingest_status: "unmatched", source_path: "b.fastq" },
+  ];
+
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) {
+      return Promise.resolve({ files: [], total: 5, page: 1, page_size: 1 });
+    }
+    if (path === "/api/ingest/unmatched") {
+      return Promise.resolve(unmatchedEvents);
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<IngestStatusWidget />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Unmatched")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+});
+
+test("renders unclaimed count from array response", async () => {
+  const unclaimedEntities = [
+    { entity_type: "project", entity_id: 1, name: "P1", created_at: "" },
+  ];
+
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) {
+      return Promise.resolve({ files: [], total: 3, page: 1, page_size: 1 });
+    }
+    if (path === "/api/ingest/unclaimed") {
+      return Promise.resolve(unclaimedEntities);
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<IngestStatusWidget />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Unclaimed")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+});
+
+test("shows loading state initially", () => {
+  mockGet.mockImplementation(() => new Promise(() => {})); // never resolves
+  render(<IngestStatusWidget />);
+  expect(screen.getByTestId("widget-loading")).toBeInTheDocument();
+});
+
+test("degrades gracefully when all fetches fail", async () => {
+  mockGet.mockRejectedValue(new Error("network error"));
+
+  render(<IngestStatusWidget />);
+
+  // Individual catch handlers return fallback values, so widget shows zeros
+  await waitFor(() => {
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  expect(screen.queryByTestId("widget-error")).not.toBeInTheDocument();
+});
+
+test("hides unmatched and unclaimed when both are zero", async () => {
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) {
+      return Promise.resolve({ files: [], total: 7, page: 1, page_size: 1 });
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<IngestStatusWidget />);
+
+  await waitFor(() => {
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  expect(screen.queryByText("Unmatched")).not.toBeInTheDocument();
+  expect(screen.queryByText("Unclaimed")).not.toBeInTheDocument();
+});
+
+test("links to ingest activity page", async () => {
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) {
+      return Promise.resolve({ files: [], total: 0, page: 1, page_size: 1 });
+    }
+    return Promise.resolve([]);
+  });
+
+  render(<IngestStatusWidget />);
+
+  await waitFor(() => {
+    const link = screen.getByText("View ingest activity");
+    expect(link).toHaveAttribute("href", "/data/upload");
+  });
+});

--- a/frontend/src/components/dashboard/IngestStatusWidget.tsx
+++ b/frontend/src/components/dashboard/IngestStatusWidget.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { api } from "@/lib/api";
 
 interface IngestStats {
-  files_today: number;
+  totalFiles: number;
   unmatched: number;
   unclaimed: number;
 }
@@ -17,19 +17,15 @@ export function IngestStatusWidget() {
 
   useEffect(() => {
     Promise.all([
-      api.get<{ total: number }>("/api/ingest/events?page_size=1").catch(() => ({ total: 0 })),
-      api.get<{ files: unknown[] }>("/api/ingest/unmatched").catch(() => ({ files: [] })),
-      api.get<{ entities: unknown[] }>("/api/ingest/unclaimed").catch(() => ({ entities: [] })),
+      api.get<{ total: number }>("/api/files?page_size=1").catch(() => ({ total: 0 })),
+      api.get<unknown[]>("/api/ingest/unmatched").catch(() => []),
+      api.get<unknown[]>("/api/ingest/unclaimed").catch(() => []),
     ])
-      .then(([events, unmatched, unclaimed]) => {
+      .then(([filesResp, unmatched, unclaimed]) => {
         setStats({
-          files_today: (events as { total: number }).total,
-          unmatched: Array.isArray((unmatched as { files: unknown[] }).files)
-            ? (unmatched as { files: unknown[] }).files.length
-            : 0,
-          unclaimed: Array.isArray((unclaimed as { entities: unknown[] }).entities)
-            ? (unclaimed as { entities: unknown[] }).entities.length
-            : 0,
+          totalFiles: (filesResp as { total: number }).total ?? 0,
+          unmatched: Array.isArray(unmatched) ? unmatched.length : 0,
+          unclaimed: Array.isArray(unclaimed) ? unclaimed.length : 0,
         });
       })
       .catch(() => setError("Failed to load ingest data"))
@@ -57,7 +53,7 @@ export function IngestStatusWidget() {
         <div className="space-y-2">
           <div className="flex justify-between">
             <span className="text-sm text-gray-600">Files ingested</span>
-            <span className="text-sm font-medium">{stats.files_today}</span>
+            <span className="text-sm font-medium">{stats.totalFiles}</span>
           </div>
           {stats.unmatched > 0 && (
             <div className="flex justify-between">


### PR DESCRIPTION
## Summary

Closes #90.

- **Files count**: Widget was fetching `/api/ingest/events?page_size=1` expecting a `{ total }` wrapper, but the endpoint returns a plain array and uses `limit` not `page_size`. Browser uploads also never create IngestEvent records, so the count was always empty. Now fetches from `/api/files?page_size=1` which returns `{ total }` covering both manual uploads and auto-ingested files.
- **Unmatched/Unclaimed counts**: Widget expected `{ files: [] }` and `{ entities: [] }` wrappers but the backend returns plain arrays. Now handles array responses directly.
- Added 8 tests covering all widget states (counts, zero, unmatched, unclaimed, loading, error degradation, link target).

## Test plan

- [ ] Verify `npm test` passes (299 tests including 8 new)
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Deploy and confirm the Ingest Status widget shows the correct file count after uploading files
- [ ] Confirm unmatched/unclaimed rows appear when applicable