### PR TITLE
Fix Documents page crash from response shape mismatch

### DIFF
--- a/frontend/src/app/data/documents/page.test.tsx
+++ b/frontend/src/app/data/documents/page.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import DataDocumentsPage from "./page";
+
+// Mock next/link
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+// Mock layout components
+jest.mock("@/components/layout/Sidebar", () => ({
+  Sidebar: () => <nav data-testid="sidebar" />,
+}));
+jest.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+// Mock the api module
+jest.mock("@/lib/api", () => ({
+  api: {
+    get: jest.fn(),
+  },
+}));
+
+// Mock auth
+jest.mock("@/lib/auth", () => ({
+  getToken: () => "fake-token",
+  removeToken: jest.fn(),
+}));
+
+import { api } from "@/lib/api";
+
+const mockGet = api.get as jest.Mock;
+
+beforeEach(() => {
+  mockGet.mockReset();
+  window.confirm = jest.fn(() => true);
+});
+
+test("renders documents from paginated response", async () => {
+  mockGet.mockResolvedValue({
+    documents: [
+      { id: 1, title: "Protocol v2", created_at: "2026-03-01T00:00:00Z" },
+      { id: 2, title: "Lab Notes", created_at: "2026-03-02T00:00:00Z" },
+    ],
+    total: 2,
+    page: 1,
+    page_size: 25,
+  });
+
+  render(<DataDocumentsPage />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Protocol v2")).toBeInTheDocument();
+    expect(screen.getByText("Lab Notes")).toBeInTheDocument();
+  });
+});
+
+test("shows empty state when no documents", async () => {
+  mockGet.mockResolvedValue({
+    documents: [],
+    total: 0,
+    page: 1,
+    page_size: 25,
+  });
+
+  render(<DataDocumentsPage />);
+
+  await waitFor(() => {
+    expect(screen.getByText("No documents found.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/data/documents/page.tsx
+++ b/frontend/src/app/data/documents/page.tsx
@@ -21,8 +21,8 @@ export default function DataDocumentsPage() {
         );
         setDocuments(data.documents);
       } else {
-        const data = await api.get<DocumentResponse[]>("/api/documents");
-        setDocuments(data);
+        const data = await api.get<DocumentSearchResponse>("/api/documents");
+        setDocuments(data.documents);
       }
     } catch {
       // ignore


### PR DESCRIPTION
Closes #103

## Summary

- The `GET /api/documents` endpoint returns a paginated `DocumentSearchResponse` (`{ documents, total, page, page_size }`), but the Documents page was treating the response as a plain `DocumentResponse[]` array and calling `.map()` on it directly, causing a client-side crash.
- Unpacked `data.documents` from the wrapper before setting state, matching how the search path already worked.
- Added tests for the Documents page covering both populated and empty states.

## Test plan

- [x] New frontend test: renders documents from paginated response
- [x] New frontend test: shows empty state when no documents
- [x] All 301 frontend tests pass
- [x] All 948 backend tests pass
- [x] `tsc --noEmit` clean
- [x] `ruff format --check`, `ruff check`, `mypy` all clean