### PR TITLE
Add bulk file-to-experiment linking on Files page

### DIFF
--- a/frontend/src/app/data/files/page.test.tsx
+++ b/frontend/src/app/data/files/page.test.tsx
@@ -42,34 +42,35 @@ beforeEach(() => {
   mockPost.mockReset();
 });
 
+const makeFile = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  filename: "sample_R1.fastq.gz",
+  gcs_uri: "gs://bucket/sample_R1.fastq.gz",
+  size_bytes: 1048576,
+  md5_checksum: "abc123",
+  file_type: "fastq",
+  tags: [],
+  uploader: { id: 1, name: "Maria", email: "maria@test.com" },
+  experiment_id: null,
+  upload_timestamp: "2026-03-01T00:00:00Z",
+  created_at: "2026-03-01T00:00:00Z",
+  ...overrides,
+});
+
 const filesResponse = {
   files: [
-    {
-      id: 1,
-      filename: "sample_R1.fastq.gz",
-      gcs_uri: "gs://bucket/sample_R1.fastq.gz",
-      size_bytes: 1048576,
-      md5_checksum: "abc123",
-      file_type: "fastq",
-      tags: [],
-      uploader: { id: 1, name: "Maria", email: "maria@test.com" },
-      experiment_id: null,
-      upload_timestamp: "2026-03-01T00:00:00Z",
-      created_at: "2026-03-01T00:00:00Z",
-    },
-    {
+    makeFile(),
+    makeFile({
       id: 2,
       filename: "counts.h5ad",
       gcs_uri: "gs://bucket/counts.h5ad",
       size_bytes: 5242880,
       md5_checksum: "def456",
       file_type: "h5ad",
-      tags: [],
-      uploader: { id: 1, name: "Maria", email: "maria@test.com" },
       experiment_id: 10,
       upload_timestamp: "2026-03-02T00:00:00Z",
       created_at: "2026-03-02T00:00:00Z",
-    },
+    }),
   ],
   total: 2,
   page: 1,
@@ -164,7 +165,7 @@ test("formats file size in human-readable form", async () => {
   });
 });
 
-test("links file to experiment via modal", async () => {
+test("links single file to experiment via row Link button", async () => {
   mockGet.mockImplementation((path: string) => {
     if (path.startsWith("/api/files")) return Promise.resolve(filesResponse);
     if (path.startsWith("/api/experiments"))
@@ -200,4 +201,92 @@ test("links file to experiment via modal", async () => {
       experiment_id: 20,
     });
   });
+});
+
+test("bulk-links selected files to experiment", async () => {
+  const threeUnlinked = {
+    files: [
+      makeFile({ id: 1, filename: "a.fastq.gz" }),
+      makeFile({ id: 2, filename: "b.fastq.gz" }),
+      makeFile({ id: 3, filename: "c.fastq.gz" }),
+    ],
+    total: 3,
+    page: 1,
+    page_size: 25,
+  };
+
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) return Promise.resolve(threeUnlinked);
+    if (path.startsWith("/api/experiments"))
+      return Promise.resolve(experimentsResponse);
+    return Promise.resolve([]);
+  });
+  mockPost.mockResolvedValue({ status: "linked" });
+
+  render(<DataFilesPage />);
+
+  await waitFor(() => {
+    expect(screen.getByText("a.fastq.gz")).toBeInTheDocument();
+  });
+
+  // Select files 1 and 3 via checkboxes
+  const checkboxes = screen.getAllByRole("checkbox");
+  // checkboxes[0] is select-all, [1]-[3] are rows
+  fireEvent.click(checkboxes[1]);
+  fireEvent.click(checkboxes[3]);
+
+  // Bulk action bar should appear
+  expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+  // Click the bulk "Link to Experiment" button
+  fireEvent.click(screen.getByText("Link to Experiment"));
+
+  // Modal should appear
+  await waitFor(() => {
+    expect(
+      screen.getByText("Link 2 files to Experiment")
+    ).toBeInTheDocument();
+  });
+
+  // Select an experiment and save
+  const selects = screen.getAllByRole("combobox");
+  const modalSelect = selects[selects.length - 1];
+  fireEvent.change(modalSelect, { target: { value: "10" } });
+  fireEvent.click(screen.getByText("Save"));
+
+  await waitFor(() => {
+    expect(mockPost).toHaveBeenCalledTimes(2);
+    expect(mockPost).toHaveBeenCalledWith("/api/files/1/link", {
+      experiment_id: 10,
+    });
+    expect(mockPost).toHaveBeenCalledWith("/api/files/3/link", {
+      experiment_id: 10,
+    });
+  });
+});
+
+test("select-all checkbox toggles all rows", async () => {
+  mockGet.mockImplementation((path: string) => {
+    if (path.startsWith("/api/files")) return Promise.resolve(filesResponse);
+    if (path.startsWith("/api/experiments"))
+      return Promise.resolve(experimentsResponse);
+    return Promise.resolve([]);
+  });
+
+  render(<DataFilesPage />);
+
+  await waitFor(() => {
+    expect(screen.getByText("sample_R1.fastq.gz")).toBeInTheDocument();
+  });
+
+  const checkboxes = screen.getAllByRole("checkbox");
+  const selectAll = checkboxes[0];
+
+  // Check all
+  fireEvent.click(selectAll);
+  expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+  // Uncheck all
+  fireEvent.click(selectAll);
+  expect(screen.queryByText("2 selected")).not.toBeInTheDocument();
 });

--- a/frontend/src/app/data/files/page.tsx
+++ b/frontend/src/app/data/files/page.tsx
@@ -24,7 +24,8 @@ export default function DataFilesPage() {
     { id: number; name: string }[]
   >([]);
   const [filterType, setFilterType] = useState("");
-  const [linkingFile, setLinkingFile] = useState<FileResponse | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [linkingFileIds, setLinkingFileIds] = useState<number[]>([]);
   const [selectedExperimentId, setSelectedExperimentId] = useState<string>("");
 
   const fetchFiles = useCallback(async () => {
@@ -33,6 +34,7 @@ export default function DataFilesPage() {
       const params = filterType ? `?file_type=${filterType}` : "";
       const data = await api.get<FileListResponse>(`/api/files${params}`);
       setFiles(data.files);
+      setSelectedIds(new Set());
     } catch {
       // ignore
     } finally {
@@ -58,17 +60,43 @@ export default function DataFilesPage() {
     fetchExperiments();
   }, [fetchFiles, fetchExperiments]);
 
+  const openLinkModal = (fileIds: number[]) => {
+    setLinkingFileIds(fileIds);
+    setSelectedExperimentId("");
+  };
+
   const handleLink = async () => {
-    if (!linkingFile || !selectedExperimentId) return;
+    if (linkingFileIds.length === 0 || !selectedExperimentId) return;
     try {
-      await api.post(`/api/files/${linkingFile.id}/link`, {
-        experiment_id: Number(selectedExperimentId),
-      });
-      setLinkingFile(null);
+      await Promise.all(
+        linkingFileIds.map((id) =>
+          api.post(`/api/files/${id}/link`, {
+            experiment_id: Number(selectedExperimentId),
+          })
+        )
+      );
+      setLinkingFileIds([]);
       setSelectedExperimentId("");
       fetchFiles();
     } catch {
       // ignore
+    }
+  };
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedIds.size === files.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(files.map((f) => f.id)));
     }
   };
 
@@ -101,6 +129,22 @@ export default function DataFilesPage() {
                   </option>
                 ))}
               </select>
+
+              {selectedIds.size > 0 && (
+                <div className="flex items-center gap-3 ml-4">
+                  <span className="text-sm text-gray-600">
+                    {selectedIds.size} selected
+                  </span>
+                  <button
+                    onClick={() =>
+                      openLinkModal(Array.from(selectedIds))
+                    }
+                    className="px-3 py-1.5 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700"
+                  >
+                    Link to Experiment
+                  </button>
+                </div>
+              )}
             </div>
 
             {loading ? (
@@ -112,6 +156,16 @@ export default function DataFilesPage() {
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
+                      <th className="px-4 py-3 w-10">
+                        <input
+                          type="checkbox"
+                          checked={
+                            files.length > 0 &&
+                            selectedIds.size === files.length
+                          }
+                          onChange={toggleSelectAll}
+                        />
+                      </th>
                       <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
                         Filename
                       </th>
@@ -135,6 +189,13 @@ export default function DataFilesPage() {
                   <tbody className="divide-y divide-gray-200">
                     {files.map((file) => (
                       <tr key={file.id} className="hover:bg-gray-50">
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(file.id)}
+                            onChange={() => toggleSelect(file.id)}
+                          />
+                        </td>
                         <td className="px-4 py-3 text-sm font-medium">
                           {file.filename}
                         </td>
@@ -163,10 +224,7 @@ export default function DataFilesPage() {
                                 Unlinked
                               </span>
                               <button
-                                onClick={() => {
-                                  setLinkingFile(file);
-                                  setSelectedExperimentId("");
-                                }}
+                                onClick={() => openLinkModal([file.id])}
                                 className="text-blue-600 text-xs hover:underline"
                               >
                                 Link
@@ -182,15 +240,28 @@ export default function DataFilesPage() {
             )}
           </div>
 
-          {linkingFile && (
+          {linkingFileIds.length > 0 && (
             <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
               <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
                 <h2 className="text-lg font-semibold mb-4">
-                  Link to Experiment
+                  {linkingFileIds.length === 1
+                    ? "Link to Experiment"
+                    : `Link ${linkingFileIds.length} files to Experiment`}
                 </h2>
-                <p className="text-sm text-gray-600 mb-4">
-                  {linkingFile.filename}
-                </p>
+                {linkingFileIds.length === 1 && (
+                  <p className="text-sm text-gray-600 mb-4">
+                    {files.find((f) => f.id === linkingFileIds[0])?.filename}
+                  </p>
+                )}
+                {linkingFileIds.length > 1 && (
+                  <ul className="text-sm text-gray-600 mb-4 list-disc pl-5 max-h-32 overflow-y-auto">
+                    {linkingFileIds.map((id) => (
+                      <li key={id}>
+                        {files.find((f) => f.id === id)?.filename}
+                      </li>
+                    ))}
+                  </ul>
+                )}
                 <select
                   value={selectedExperimentId}
                   onChange={(e) => setSelectedExperimentId(e.target.value)}
@@ -205,7 +276,7 @@ export default function DataFilesPage() {
                 </select>
                 <div className="flex justify-end gap-3">
                   <button
-                    onClick={() => setLinkingFile(null)}
+                    onClick={() => setLinkingFileIds([])}
                     className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
                   >
                     Cancel


### PR DESCRIPTION
Stacked on #106

## Summary

- Added checkboxes to each file row plus a select-all toggle in the header
- When files are selected, a bulk "Link to Experiment" button appears showing the count (e.g., "3 selected")
- Clicking it opens the same link modal, listing all selected filenames, and links them all in parallel via `Promise.all`
- Per-row "Link" button still works for single files

## Test plan

- [x] New test: bulk-links selected files to experiment (verifies parallel API calls)
- [x] New test: select-all checkbox toggles all rows
- [x] Existing single-link test still passes
- [x] All 309 frontend tests pass
- [x] `tsc --noEmit` clean