### PR TITLE
Fix billing export dataset location and table prefix matching

### DIFF
--- a/backend/app/services/billing_export_service.py
+++ b/backend/app/services/billing_export_service.py
@@ -47,7 +47,7 @@ class BillingExportService:
             client = bigquery.Client(project=project_id, credentials=credentials)
             tables = list(client.list_tables(f"{project_id}.{dataset_id}"))
             for table in tables:
-                if table.table_id.startswith("gcp_billing_export_v1_"):
+                if table.table_id.startswith(("gcp_billing_export_v1_", "gcp_billing_export_resource_v1_")):
                     return {"found": True, "table_id": table.table_id}
             return {"found": False}
 

--- a/backend/terraform/modules/billing_export/main.tf
+++ b/backend/terraform/modules/billing_export/main.tf
@@ -17,7 +17,7 @@ provider "google" {
 resource "google_bigquery_dataset" "billing_export" {
   dataset_id  = "billing_export"
   project     = var.project_id
-  location    = var.region
+  location    = "US"
   description = "BigQuery billing export dataset managed by bioAF"
 
   labels = {

--- a/backend/tests/test_billing_export.py
+++ b/backend/tests/test_billing_export.py
@@ -235,6 +235,24 @@ async def test_query_mtd_costs_returns_mapped_data():
 
 
 @pytest.mark.asyncio
+async def test_verify_dataset_finds_resource_prefix_table():
+    """verify_dataset should match detailed usage cost tables (resource_v1_ prefix)."""
+    from app.services.billing_export_service import BillingExportService
+
+    resource_table = MagicMock()
+    resource_table.table_id = "gcp_billing_export_resource_v1_DEADBEEF"
+
+    mock_bq_client = MagicMock()
+    mock_bq_client.list_tables.return_value = [resource_table]
+
+    with patch("app.services.billing_export_service.bigquery.Client", return_value=mock_bq_client):
+        result = await BillingExportService.verify_dataset("proj", "ds")
+
+    assert result["found"] is True
+    assert result["table_id"] == "gcp_billing_export_resource_v1_DEADBEEF"
+
+
+@pytest.mark.asyncio
 async def test_verify_dataset_passes_credentials_to_bq_client():
     """verify_dataset must pass explicit credentials to the BQ client."""
     from app.services.billing_export_service import BillingExportService


### PR DESCRIPTION
Closes #111

## Summary
- **Dataset location**: Terraform `billing_export` dataset was created in `var.region` (single-region like `us-central1`), but detailed usage cost export requires a multi-region location. Changed to `"US"`.
- **Table prefix mismatch**: `verify_dataset` only checked for `gcp_billing_export_v1_` (standard export), missing `gcp_billing_export_resource_v1_` (detailed usage cost export). Now matches both prefixes.

## Test plan
- [x] New unit test `test_verify_dataset_finds_resource_prefix_table` confirms the resource prefix is detected
- [x] All 1111 backend tests pass
- [x] All 349 frontend tests pass
- [x] Ruff format/lint, mypy, tsc all clean
- [ ] Redeploy with updated Terraform and verify dataset is created in `US` multi-region
- [ ] Enable detailed usage cost export in GCP console and confirm verify endpoint finds the table