### PR TITLE
Register pipeline output files and add file browser filters

### DIFF
--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -63,6 +63,10 @@ class ComputeProvider(ABC):
         """
         return False
 
+    def get_raw_bucket_name(self) -> str:
+        """Return the raw data bucket name, or empty string if unavailable."""
+        return ""
+
 
 class StorageProvider(ABC):
     """Abstract interface for storage backends (GCS, NFS)."""

--- a/backend/app/adapters/compute/kubernetes.py
+++ b/backend/app/adapters/compute/kubernetes.py
@@ -133,6 +133,10 @@ class KubernetesComputeProvider(ComputeProvider):
             return False
         return await self._k8s_persist_job_logs(job_id)
 
+    def get_raw_bucket_name(self) -> str:
+        cfg = self._cluster_config or {}
+        return cfg.get("raw_bucket_name", "")
+
     async def get_job_progress(self, job_id: str) -> dict:
         if self.is_local:
             return await self._local_get_job_progress(job_id)

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -251,6 +251,8 @@ async def list_files(
     file_type: str | None = None,
     experiment_id: int | None = None,
     project_id: int | None = None,
+    source_type: str | None = None,
+    sample_id: int | None = None,
     page: int = 1,
     page_size: int = 25,
     session: AsyncSession = Depends(get_session),
@@ -258,7 +260,9 @@ async def list_files(
     current_user = request.state.current_user
     org_id = int(current_user["org_id"])
 
-    files, total = await FileService.list_files(session, org_id, file_type, experiment_id, project_id, page, page_size)
+    files, total = await FileService.list_files(
+        session, org_id, file_type, experiment_id, project_id, source_type, sample_id, page, page_size
+    )
     file_ids = [f.id for f in files]
     sample_ids_map = await FileService.get_sample_ids_for_files(session, file_ids)
     return FileListResponse(

--- a/backend/app/cli/register_outputs.py
+++ b/backend/app/cli/register_outputs.py
@@ -1,0 +1,133 @@
+"""CLI script to register pipeline output files for completed runs.
+
+Backfills File records for pipeline runs whose outputs exist in GCS
+but were never registered in the database.
+
+Usage:
+    python -m app.cli.register_outputs              # all completed runs
+    python -m app.cli.register_outputs --run-id 42  # specific run
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.adapters.registry import get_storage_adapter, initialize_adapters
+from app.models.file import File
+from app.models.pipeline_run import PipelineRun
+from app.services.pipeline_output_service import PipelineOutputService
+
+
+async def register_outputs_for_run(
+    session: AsyncSession,
+    run: PipelineRun,
+) -> int:
+    """Collect and register output files for a single pipeline run.
+
+    Returns the number of newly registered files.
+    """
+    storage_adapter = get_storage_adapter()
+    outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+
+    collected = await storage_adapter.collect_outputs(
+        outdir,
+        {"id": run.id, "experiment_id": run.experiment_id},
+    )
+    if not collected:
+        return 0
+
+    files = await PipelineOutputService.register_outputs(session, run, collected)
+    return len(files)
+
+
+async def _main(args: argparse.Namespace) -> None:
+    database_url = os.environ.get("BIOAF_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: Set BIOAF_DATABASE_URL or DATABASE_URL environment variable.")
+        sys.exit(1)
+
+    engine = create_async_engine(database_url, echo=False)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as session:
+        await initialize_adapters(session, session_factory=factory)
+
+        if args.run_id:
+            # Register outputs for a specific run
+            result = await session.execute(
+                select(PipelineRun).where(PipelineRun.id == args.run_id)
+            )
+            run = result.scalar_one_or_none()
+            if not run:
+                print(f"ERROR: Pipeline run {args.run_id} not found.")
+                sys.exit(1)
+            if run.status not in ("completed", "failed"):
+                print(f"WARNING: Run {run.id} has status '{run.status}', skipping.")
+                sys.exit(0)
+
+            count = await register_outputs_for_run(session, run)
+            await session.commit()
+            print(f"Run {run.id}: registered {count} output files.")
+        else:
+            # Find all completed runs missing output File records
+            result = await session.execute(
+                select(PipelineRun).where(
+                    PipelineRun.status.in_(["completed", "failed"]),
+                )
+            )
+            runs = list(result.scalars().all())
+
+            if not runs:
+                print("No completed pipeline runs found.")
+                await engine.dispose()
+                return
+
+            total_registered = 0
+            for run in runs:
+                # Check if this run already has registered output files
+                existing = await session.execute(
+                    select(File.id).where(
+                        File.source_pipeline_run_id == run.id,
+                        File.source_type == "pipeline_output",
+                    ).limit(1)
+                )
+                if existing.first():
+                    if not args.force:
+                        continue
+
+                count = await register_outputs_for_run(session, run)
+                if count > 0:
+                    print(f"  Run {run.id} ({run.pipeline_name}): registered {count} files")
+                    total_registered += count
+
+            await session.commit()
+            print(f"\nDone. Registered {total_registered} files across {len(runs)} runs.")
+
+    await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Register pipeline output files from GCS into the database"
+    )
+    parser.add_argument(
+        "--run-id",
+        type=int,
+        default=None,
+        help="Register outputs for a specific pipeline run ID",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-register outputs even for runs that already have File records",
+    )
+    args = parser.parse_args()
+    asyncio.run(_main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/cli/register_outputs.py
+++ b/backend/app/cli/register_outputs.py
@@ -31,7 +31,12 @@ async def register_outputs_for_run(
     Returns the number of newly registered files.
     """
     storage_adapter = get_storage_adapter()
-    outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+
+    # Use the GCS outdir from pipeline parameters if available (set by K8s adapter
+    # at launch time), otherwise fall back to local-style path resolution.
+    outdir = (run.parameters_json or {}).get("outdir", "")
+    if not outdir:
+        outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
 
     collected = await storage_adapter.collect_outputs(
         outdir,

--- a/backend/app/cli/register_outputs.py
+++ b/backend/app/cli/register_outputs.py
@@ -29,14 +29,13 @@ async def _resolve_outdir(session: AsyncSession, run: PipelineRun) -> str:
     if outdir:
         return outdir
 
-    # Fall back: build the GCS URI from org_slug in platform_config
+    # Fall back: build the GCS URI from results_bucket_name in platform_config
     result = await session.execute(
-        text("SELECT value FROM platform_config WHERE key = 'org_slug'")
+        text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'")
     )
     row = result.first()
     if row:
-        org_slug = row[0]
-        return f"gs://bioaf-results-{org_slug}/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+        return f"gs://{row[0]}/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
 
     # Last resort: local-style path (GCS adapter will use its default bucket)
     return f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
@@ -53,10 +52,14 @@ async def register_outputs_for_run(
     storage_adapter = get_storage_adapter()
     outdir = await _resolve_outdir(session, run)
 
-    collected = await storage_adapter.collect_outputs(
-        outdir,
-        {"id": run.id, "experiment_id": run.experiment_id},
-    )
+    try:
+        collected = await storage_adapter.collect_outputs(
+            outdir,
+            {"id": run.id, "experiment_id": run.experiment_id},
+        )
+    except Exception as e:
+        print(f"  Run {run.id}: could not collect outputs from {outdir} -- {e}")
+        return 0
     if not collected:
         return 0
 

--- a/backend/app/cli/register_outputs.py
+++ b/backend/app/cli/register_outputs.py
@@ -13,13 +13,33 @@ import asyncio
 import os
 import sys
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.adapters.registry import get_storage_adapter, initialize_adapters
 from app.models.file import File
 from app.models.pipeline_run import PipelineRun
 from app.services.pipeline_output_service import PipelineOutputService
+
+
+async def _resolve_outdir(session: AsyncSession, run: PipelineRun) -> str:
+    """Resolve the GCS output directory for a pipeline run."""
+    # Prefer the outdir stored in parameters_json (set by K8s adapter at launch)
+    outdir = (run.parameters_json or {}).get("outdir", "")
+    if outdir:
+        return outdir
+
+    # Fall back: build the GCS URI from org_slug in platform_config
+    result = await session.execute(
+        text("SELECT value FROM platform_config WHERE key = 'org_slug'")
+    )
+    row = result.first()
+    if row:
+        org_slug = row[0]
+        return f"gs://bioaf-results-{org_slug}/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+
+    # Last resort: local-style path (GCS adapter will use its default bucket)
+    return f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
 
 
 async def register_outputs_for_run(
@@ -31,12 +51,7 @@ async def register_outputs_for_run(
     Returns the number of newly registered files.
     """
     storage_adapter = get_storage_adapter()
-
-    # Use the GCS outdir from pipeline parameters if available (set by K8s adapter
-    # at launch time), otherwise fall back to local-style path resolution.
-    outdir = (run.parameters_json or {}).get("outdir", "")
-    if not outdir:
-        outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+    outdir = await _resolve_outdir(session, run)
 
     collected = await storage_adapter.collect_outputs(
         outdir,

--- a/backend/app/cli/register_outputs.py
+++ b/backend/app/cli/register_outputs.py
@@ -30,9 +30,7 @@ async def _resolve_outdir(session: AsyncSession, run: PipelineRun) -> str:
         return outdir
 
     # Fall back: build the GCS URI from results_bucket_name in platform_config
-    result = await session.execute(
-        text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'")
-    )
+    result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'"))
     row = result.first()
     if row:
         return f"gs://{row[0]}/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
@@ -81,9 +79,7 @@ async def _main(args: argparse.Namespace) -> None:
 
         if args.run_id:
             # Register outputs for a specific run
-            result = await session.execute(
-                select(PipelineRun).where(PipelineRun.id == args.run_id)
-            )
+            result = await session.execute(select(PipelineRun).where(PipelineRun.id == args.run_id))
             run = result.scalar_one_or_none()
             if not run:
                 print(f"ERROR: Pipeline run {args.run_id} not found.")
@@ -113,10 +109,12 @@ async def _main(args: argparse.Namespace) -> None:
             for run in runs:
                 # Check if this run already has registered output files
                 existing = await session.execute(
-                    select(File.id).where(
+                    select(File.id)
+                    .where(
                         File.source_pipeline_run_id == run.id,
                         File.source_type == "pipeline_output",
-                    ).limit(1)
+                    )
+                    .limit(1)
                 )
                 if existing.first():
                     if not args.force:
@@ -134,9 +132,7 @@ async def _main(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Register pipeline output files from GCS into the database"
-    )
+    parser = argparse.ArgumentParser(description="Register pipeline output files from GCS into the database")
     parser.add_argument(
         "--run-id",
         type=int,

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -71,9 +71,13 @@ class FileService:
         file_type: str | None = None,
         experiment_id: int | None = None,
         project_id: int | None = None,
+        source_type: str | None = None,
+        sample_id: int | None = None,
         page: int = 1,
         page_size: int = 25,
     ) -> tuple[list[File], int]:
+        from app.models.sample import sample_files
+
         query = select(File).options(selectinload(File.uploader)).where(File.organization_id == org_id)
         count_query = select(func.count(File.id)).where(File.organization_id == org_id)
 
@@ -88,6 +92,18 @@ class FileService:
         if project_id is not None:
             query = query.where(File.project_id == project_id)
             count_query = count_query.where(File.project_id == project_id)
+
+        if source_type:
+            query = query.where(File.source_type == source_type)
+            count_query = count_query.where(File.source_type == source_type)
+
+        if sample_id is not None:
+            query = query.join(sample_files, sample_files.c.file_id == File.id).where(
+                sample_files.c.sample_id == sample_id
+            )
+            count_query = count_query.join(sample_files, sample_files.c.file_id == File.id).where(
+                sample_files.c.sample_id == sample_id
+            )
 
         total_result = await session.execute(count_query)
         total = total_result.scalar() or 0

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -27,6 +27,7 @@ class FileService:
         experiment_id: int | None = None,
         source_type: str = "upload",
         source_pipeline_run_id: int | None = None,
+        artifact_type: str | None = None,
     ) -> File:
         file = File(
             organization_id=org_id,
@@ -41,6 +42,7 @@ class FileService:
             experiment_id=experiment_id,
             source_type=source_type,
             source_pipeline_run_id=source_pipeline_run_id,
+            artifact_type=artifact_type,
         )
         session.add(file)
         await session.flush()

--- a/backend/app/services/file_type_utils.py
+++ b/backend/app/services/file_type_utils.py
@@ -1,0 +1,81 @@
+"""Shared file type detection and artifact classification utilities."""
+
+from pathlib import PurePosixPath
+
+# File type mapping by extension
+FILE_TYPE_MAP: dict[str, str] = {
+    ".fastq": "fastq",
+    ".fq": "fastq",
+    ".bam": "bam",
+    ".sam": "bam",
+    ".cram": "bam",
+    ".h5ad": "h5ad",
+    ".h5": "h5",
+    ".csv": "count_matrix",
+    ".tsv": "count_matrix",
+    ".mtx": "count_matrix",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".svg": "image",
+    ".tif": "image",
+    ".tiff": "image",
+    ".pdf": "document",
+    ".doc": "document",
+    ".docx": "document",
+    ".txt": "document",
+    ".md": "document",
+    ".html": "report",
+}
+
+# Extensions that imply compression - check inner extension too
+COMPRESSED_EXTS: set[str] = {".gz", ".bz2", ".xz", ".zip"}
+
+# Artifact type mapping - semantic categories for pipeline outputs
+ARTIFACT_TYPE_MAP: dict[str, str] = {
+    ".bam": "alignment",
+    ".sam": "alignment",
+    ".cram": "alignment",
+    ".h5ad": "anndata",
+    ".h5": "feature_matrix",
+    ".csv": "count_matrix",
+    ".tsv": "count_matrix",
+    ".mtx": "count_matrix",
+    ".fastq": "fastq",
+    ".fq": "fastq",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".svg": "image",
+    ".tif": "image",
+    ".tiff": "image",
+    ".pdf": "document",
+    ".html": "report",
+}
+
+
+def detect_file_type(filename: str) -> str:
+    """Map filename extension to file type category."""
+    p = PurePosixPath(filename)
+    ext = p.suffix.lower()
+
+    # Check for compressed double extensions like .fastq.gz
+    if ext in COMPRESSED_EXTS:
+        inner_ext = PurePosixPath(p.stem).suffix.lower()
+        if inner_ext in FILE_TYPE_MAP:
+            return FILE_TYPE_MAP[inner_ext]
+
+    return FILE_TYPE_MAP.get(ext, "other")
+
+
+def classify_artifact_type(filename: str) -> str:
+    """Map filename to a semantic artifact category for pipeline outputs."""
+    p = PurePosixPath(filename)
+    ext = p.suffix.lower()
+
+    if ext in COMPRESSED_EXTS:
+        inner_ext = PurePosixPath(p.stem).suffix.lower()
+        if inner_ext in ARTIFACT_TYPE_MAP:
+            return ARTIFACT_TYPE_MAP[inner_ext]
+
+    return ARTIFACT_TYPE_MAP.get(ext, "other")

--- a/backend/app/services/ingest_service.py
+++ b/backend/app/services/ingest_service.py
@@ -7,8 +7,6 @@ entities, and catalogs files in the database.
 
 import asyncio
 import logging
-from pathlib import PurePosixPath
-
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,51 +24,11 @@ from app.services.event_types import (
     UNCLAIMED_ENTITY,
     UNMATCHED_FILE,
 )
+from app.services.file_type_utils import detect_file_type
 from app.services.naming_profile_parser import match_filename, resolve_entities
 from app.services.naming_profile_service import NamingProfileService
 
 logger = logging.getLogger("bioaf.ingest_service")
-
-# File type mapping by extension
-FILE_TYPE_MAP = {
-    ".fastq": "fastq",
-    ".fq": "fastq",
-    ".bam": "bam",
-    ".sam": "bam",
-    ".cram": "bam",
-    ".h5ad": "h5ad",
-    ".csv": "count_matrix",
-    ".tsv": "count_matrix",
-    ".mtx": "count_matrix",
-    ".png": "image",
-    ".jpg": "image",
-    ".jpeg": "image",
-    ".svg": "image",
-    ".tif": "image",
-    ".tiff": "image",
-    ".pdf": "document",
-    ".doc": "document",
-    ".docx": "document",
-    ".txt": "document",
-    ".md": "document",
-}
-
-# Extensions that imply compression - check inner extension too
-COMPRESSED_EXTS = {".gz", ".bz2", ".xz", ".zip"}
-
-
-def detect_file_type(filename: str) -> str:
-    """Map filename extension to file type category."""
-    p = PurePosixPath(filename)
-    ext = p.suffix.lower()
-
-    # Check for compressed double extensions like .fastq.gz
-    if ext in COMPRESSED_EXTS:
-        inner_ext = PurePosixPath(p.stem).suffix.lower()
-        if inner_ext in FILE_TYPE_MAP:
-            return FILE_TYPE_MAP[inner_ext]
-
-    return FILE_TYPE_MAP.get(ext, "other")
 
 
 async def check_duplicate(md5_checksum: str | None, org_id: int, db: AsyncSession) -> File | None:

--- a/backend/app/services/pipeline_monitor_service.py
+++ b/backend/app/services/pipeline_monitor_service.py
@@ -289,13 +289,12 @@ class PipelineMonitorService:
             storage_adapter = get_storage_adapter()
             outdir = (run.parameters_json or {}).get("outdir", "")
             if not outdir:
-                # Fall back: resolve org_slug from platform_config
-                slug_row = (
-                    await session.execute(text("SELECT value FROM platform_config WHERE key = 'org_slug'"))
+                # Fall back: read results_bucket_name from platform_config
+                bucket_row = (
+                    await session.execute(text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'"))
                 ).first()
-                if slug_row:
-                    org_slug = slug_row[0]
-                    outdir = f"gs://bioaf-results-{org_slug}/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+                if bucket_row:
+                    outdir = f"gs://{bucket_row[0]}/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
                 else:
                     outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
             collected = await storage_adapter.collect_outputs(

--- a/backend/app/services/pipeline_monitor_service.py
+++ b/backend/app/services/pipeline_monitor_service.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -289,7 +289,15 @@ class PipelineMonitorService:
             storage_adapter = get_storage_adapter()
             outdir = (run.parameters_json or {}).get("outdir", "")
             if not outdir:
-                outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+                # Fall back: resolve org_slug from platform_config
+                slug_row = (
+                    await session.execute(text("SELECT value FROM platform_config WHERE key = 'org_slug'"))
+                ).first()
+                if slug_row:
+                    org_slug = slug_row[0]
+                    outdir = f"gs://bioaf-results-{org_slug}/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+                else:
+                    outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
             collected = await storage_adapter.collect_outputs(
                 outdir,
                 {"id": run.id, "experiment_id": run.experiment_id},

--- a/backend/app/services/pipeline_monitor_service.py
+++ b/backend/app/services/pipeline_monitor_service.py
@@ -294,6 +294,13 @@ class PipelineMonitorService:
             )
             if collected:
                 run.output_files_json = {"files": [f["filename"] for f in collected]}
+                try:
+                    from app.services.pipeline_output_service import PipelineOutputService
+
+                    await PipelineOutputService.register_outputs(session, run, collected)
+                    logger.info("Registered %d output files for run %d", len(collected), run.id)
+                except Exception as reg_err:
+                    logger.warning("Failed to register output files for run %d: %s", run.id, reg_err)
         except Exception as e:
             logger.warning("Failed to collect output files for run %d: %s", run.id, e)
 

--- a/backend/app/services/pipeline_monitor_service.py
+++ b/backend/app/services/pipeline_monitor_service.py
@@ -304,6 +304,18 @@ class PipelineMonitorService:
         except Exception as e:
             logger.warning("Failed to collect output files for run %d: %s", run.id, e)
 
+        # Register Nextflow report and trace from the raw bucket
+        if run.k8s_job_name:
+            try:
+                from app.services.pipeline_output_service import PipelineOutputService
+
+                compute_adapter = get_compute_adapter()
+                raw_bucket = compute_adapter.get_raw_bucket_name()
+                if raw_bucket:
+                    await PipelineOutputService.register_nextflow_metadata(session, run, raw_bucket)
+            except Exception as e:
+                logger.warning("Failed to register NF metadata for run %d: %s", run.id, e)
+
         # Audit log
         await log_action(
             session,

--- a/backend/app/services/pipeline_monitor_service.py
+++ b/backend/app/services/pipeline_monitor_service.py
@@ -287,7 +287,9 @@ class PipelineMonitorService:
         # Collect output files via storage adapter
         try:
             storage_adapter = get_storage_adapter()
-            outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
+            outdir = (run.parameters_json or {}).get("outdir", "")
+            if not outdir:
+                outdir = f"/data/results/experiments/{run.experiment_id}/pipeline-runs/{run.id}"
             collected = await storage_adapter.collect_outputs(
                 outdir,
                 {"id": run.id, "experiment_id": run.experiment_id},

--- a/backend/app/services/pipeline_output_service.py
+++ b/backend/app/services/pipeline_output_service.py
@@ -2,6 +2,11 @@
 
 import logging
 
+try:
+    from google.cloud import storage as gcs_storage
+except ImportError:
+    gcs_storage = None  # type: ignore[assignment]
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -88,3 +93,95 @@ class PipelineOutputService:
             len(collected_files) - len(created),
         )
         return created
+
+    @staticmethod
+    async def register_nextflow_metadata(
+        session: AsyncSession,
+        run: PipelineRun,
+        raw_bucket: str,
+    ) -> list[File]:
+        """Register Nextflow report.html and trace.tsv as File records.
+
+        These files live in the raw bucket at deterministic paths based
+        on the K8s job name.
+        """
+        if not run.k8s_job_name or not raw_bucket:
+            return []
+
+        metadata_files = [
+            {
+                "filename": "report.html",
+                "gcs_uri": f"gs://{raw_bucket}/nextflow-reports/{run.k8s_job_name}/report.html",
+                "artifact_type": "pipeline_report",
+                "file_type": "report",
+            },
+            {
+                "filename": "trace.tsv",
+                "gcs_uri": f"gs://{raw_bucket}/nextflow-traces/{run.k8s_job_name}/trace.tsv",
+                "artifact_type": "pipeline_trace",
+                "file_type": "count_matrix",
+            },
+        ]
+
+        # Check which URIs already exist in DB
+        uris = [f["gcs_uri"] for f in metadata_files]
+        existing = await session.execute(
+            select(File.gcs_uri).where(File.gcs_uri.in_(uris))
+        )
+        existing_uris: set[str] = {row[0] for row in existing.all()}
+
+        # Check which blobs exist in GCS
+        existing_blobs = await _check_gcs_blobs(raw_bucket, metadata_files)
+
+        created: list[File] = []
+        for meta in metadata_files:
+            gcs_uri = meta["gcs_uri"]
+            if gcs_uri in existing_uris:
+                continue
+            if gcs_uri not in existing_blobs:
+                continue
+
+            file_record = await FileService.create_file_record(
+                session,
+                org_id=run.organization_id,
+                user_id=run.submitted_by_user_id,
+                filename=meta["filename"],
+                gcs_uri=gcs_uri,
+                size_bytes=existing_blobs[gcs_uri],
+                md5_checksum=None,
+                file_type=meta["file_type"],
+                experiment_id=run.experiment_id,
+                source_type="pipeline_output",
+                source_pipeline_run_id=run.id,
+                artifact_type=meta["artifact_type"],
+            )
+            created.append(file_record)
+
+        if created:
+            logger.info(
+                "Registered %d Nextflow metadata files for run %d",
+                len(created),
+                run.id,
+            )
+        return created
+
+
+async def _check_gcs_blobs(bucket_name: str, metadata_files: list[dict]) -> dict[str, int | None]:
+    """Check which GCS blobs exist and return {gcs_uri: size_bytes} for existing ones."""
+    try:
+        if gcs_storage is None:
+            return {}
+        client = gcs_storage.Client()
+        bucket = client.bucket(bucket_name)
+        result: dict[str, int | None] = {}
+        for meta in metadata_files:
+            gcs_uri = meta["gcs_uri"]
+            blob_path = gcs_uri.replace(f"gs://{bucket_name}/", "")
+            blob = bucket.blob(blob_path)
+            if blob.exists():
+                blob.reload()
+                result[gcs_uri] = blob.size
+        return result
+    except Exception as e:
+        logger.warning("Could not check GCS blobs in %s: %s", bucket_name, e)
+        return {}

--- a/backend/app/services/pipeline_output_service.py
+++ b/backend/app/services/pipeline_output_service.py
@@ -1,0 +1,90 @@
+"""Register pipeline output files as File records in the database."""
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.file import File
+from app.models.pipeline_run import PipelineRun, PipelineRunSample
+from app.services.file_service import FileService
+from app.services.file_type_utils import classify_artifact_type, detect_file_type
+
+logger = logging.getLogger("bioaf.pipeline_output_service")
+
+
+class PipelineOutputService:
+    @staticmethod
+    async def register_outputs(
+        session: AsyncSession,
+        run: PipelineRun,
+        collected_files: list[dict],
+    ) -> list[File]:
+        """Create File records for pipeline outputs and link to the run's samples.
+
+        Args:
+            session: DB session (caller commits).
+            run: The completed PipelineRun.
+            collected_files: Dicts from storage_adapter.collect_outputs()
+                with keys: filename, gcs_uri, size_bytes, md5_hash.
+
+        Returns:
+            List of newly created File records.
+        """
+        if not collected_files:
+            return []
+
+        # Find samples linked to this run
+        result = await session.execute(
+            select(PipelineRunSample.sample_id).where(
+                PipelineRunSample.pipeline_run_id == run.id
+            )
+        )
+        sample_ids = [row[0] for row in result.all()]
+
+        # Collect existing gcs_uris to skip duplicates
+        uris = [f["gcs_uri"] for f in collected_files]
+        existing = await session.execute(
+            select(File.gcs_uri).where(File.gcs_uri.in_(uris))
+        )
+        existing_uris: set[str] = {row[0] for row in existing.all()}
+
+        created: list[File] = []
+
+        for file_dict in collected_files:
+            gcs_uri = file_dict["gcs_uri"]
+            if gcs_uri in existing_uris:
+                logger.debug("Skipping duplicate gcs_uri: %s", gcs_uri)
+                continue
+
+            filename = file_dict["filename"]
+            file_type = detect_file_type(filename)
+            artifact_type = classify_artifact_type(filename)
+
+            file_record = await FileService.create_file_record(
+                session,
+                org_id=run.organization_id,
+                user_id=run.submitted_by_user_id,
+                filename=filename,
+                gcs_uri=gcs_uri,
+                size_bytes=file_dict.get("size_bytes"),
+                md5_checksum=file_dict.get("md5_hash"),
+                file_type=file_type,
+                experiment_id=run.experiment_id,
+                source_type="pipeline_output",
+                source_pipeline_run_id=run.id,
+                artifact_type=artifact_type,
+            )
+
+            for sample_id in sample_ids:
+                await FileService.link_file_to_sample(session, file_record.id, sample_id)
+
+            created.append(file_record)
+
+        logger.info(
+            "Registered %d output files for pipeline run %d (skipped %d duplicates)",
+            len(created),
+            run.id,
+            len(collected_files) - len(created),
+        )
+        return created

--- a/backend/app/services/pipeline_output_service.py
+++ b/backend/app/services/pipeline_output_service.py
@@ -41,17 +41,13 @@ class PipelineOutputService:
 
         # Find samples linked to this run
         result = await session.execute(
-            select(PipelineRunSample.sample_id).where(
-                PipelineRunSample.pipeline_run_id == run.id
-            )
+            select(PipelineRunSample.sample_id).where(PipelineRunSample.pipeline_run_id == run.id)
         )
         sample_ids = [row[0] for row in result.all()]
 
         # Collect existing gcs_uris to skip duplicates
         uris = [f["gcs_uri"] for f in collected_files]
-        existing = await session.execute(
-            select(File.gcs_uri).where(File.gcs_uri.in_(uris))
-        )
+        existing = await session.execute(select(File.gcs_uri).where(File.gcs_uri.in_(uris)))
         existing_uris: set[str] = {row[0] for row in existing.all()}
 
         created: list[File] = []
@@ -125,9 +121,7 @@ class PipelineOutputService:
 
         # Check which URIs already exist in DB
         uris = [f["gcs_uri"] for f in metadata_files]
-        existing = await session.execute(
-            select(File.gcs_uri).where(File.gcs_uri.in_(uris))
-        )
+        existing = await session.execute(select(File.gcs_uri).where(File.gcs_uri.in_(uris)))
         existing_uris: set[str] = {row[0] for row in existing.all()}
 
         # Check which blobs exist in GCS

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.0"
+version = "0.3.1"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_file_type_utils.py
+++ b/backend/tests/test_file_type_utils.py
@@ -1,7 +1,5 @@
 """Tests for file type detection and artifact classification utilities."""
 
-import pytest
-
 from app.services.file_type_utils import classify_artifact_type, detect_file_type
 
 

--- a/backend/tests/test_file_type_utils.py
+++ b/backend/tests/test_file_type_utils.py
@@ -1,0 +1,94 @@
+"""Tests for file type detection and artifact classification utilities."""
+
+import pytest
+
+from app.services.file_type_utils import classify_artifact_type, detect_file_type
+
+
+class TestDetectFileType:
+    """Tests for detect_file_type() - maps filename extensions to file type categories."""
+
+    def test_fastq_extensions(self) -> None:
+        assert detect_file_type("sample_R1.fastq") == "fastq"
+        assert detect_file_type("sample_R2.fq") == "fastq"
+
+    def test_compressed_fastq(self) -> None:
+        assert detect_file_type("sample_R1.fastq.gz") == "fastq"
+        assert detect_file_type("sample_R2.fq.gz") == "fastq"
+        assert detect_file_type("reads.fastq.bz2") == "fastq"
+
+    def test_alignment_files(self) -> None:
+        assert detect_file_type("aligned.bam") == "bam"
+        assert detect_file_type("aligned.sam") == "bam"
+        assert detect_file_type("aligned.cram") == "bam"
+
+    def test_anndata(self) -> None:
+        assert detect_file_type("filtered.h5ad") == "h5ad"
+
+    def test_count_matrices(self) -> None:
+        assert detect_file_type("counts.csv") == "count_matrix"
+        assert detect_file_type("metrics.tsv") == "count_matrix"
+        assert detect_file_type("matrix.mtx") == "count_matrix"
+
+    def test_images(self) -> None:
+        assert detect_file_type("plot.png") == "image"
+        assert detect_file_type("figure.svg") == "image"
+        assert detect_file_type("photo.jpg") == "image"
+        assert detect_file_type("scan.tiff") == "image"
+
+    def test_documents(self) -> None:
+        assert detect_file_type("report.pdf") == "document"
+        assert detect_file_type("notes.txt") == "document"
+        assert detect_file_type("readme.md") == "document"
+
+    def test_unknown_extension(self) -> None:
+        assert detect_file_type("data.xyz") == "other"
+        assert detect_file_type("noext") == "other"
+
+    def test_case_insensitive(self) -> None:
+        assert detect_file_type("DATA.CSV") == "count_matrix"
+        assert detect_file_type("image.PNG") == "image"
+
+    def test_html(self) -> None:
+        assert detect_file_type("report.html") == "report"
+
+    def test_h5(self) -> None:
+        assert detect_file_type("filtered_feature_bc_matrix.h5") == "h5"
+
+
+class TestClassifyArtifactType:
+    """Tests for classify_artifact_type() - maps filenames to semantic artifact categories."""
+
+    def test_alignment_artifacts(self) -> None:
+        assert classify_artifact_type("aligned.bam") == "alignment"
+        assert classify_artifact_type("aligned.cram") == "alignment"
+        assert classify_artifact_type("aligned.sam") == "alignment"
+
+    def test_anndata_artifact(self) -> None:
+        assert classify_artifact_type("filtered.h5ad") == "anndata"
+
+    def test_feature_matrix(self) -> None:
+        assert classify_artifact_type("filtered_feature_bc_matrix.h5") == "feature_matrix"
+
+    def test_count_matrix_artifacts(self) -> None:
+        assert classify_artifact_type("counts.csv") == "count_matrix"
+        assert classify_artifact_type("metrics.tsv") == "count_matrix"
+        assert classify_artifact_type("matrix.mtx") == "count_matrix"
+
+    def test_fastq_artifact(self) -> None:
+        assert classify_artifact_type("reads.fastq") == "fastq"
+        assert classify_artifact_type("reads.fastq.gz") == "fastq"
+
+    def test_image_artifacts(self) -> None:
+        assert classify_artifact_type("plot.png") == "image"
+        assert classify_artifact_type("figure.svg") == "image"
+        assert classify_artifact_type("chart.pdf") == "document"
+
+    def test_report_artifact(self) -> None:
+        assert classify_artifact_type("report.html") == "report"
+
+    def test_trace_artifact(self) -> None:
+        assert classify_artifact_type("trace.tsv") == "count_matrix"
+
+    def test_unknown_artifact(self) -> None:
+        assert classify_artifact_type("data.xyz") == "other"

--- a/backend/tests/test_pipeline_monitor.py
+++ b/backend/tests/test_pipeline_monitor.py
@@ -318,6 +318,72 @@ async def test_k8s_monitor_sends_completion_audit(session, k8s_running_run):
     assert row[0] == "complete"
 
 
+# --- Output file registration on completion ---
+
+
+@pytest.mark.asyncio
+async def test_k8s_completion_registers_output_files(session, k8s_running_run):
+    """Completion creates File records for collected outputs."""
+    mock_compute = AsyncMock()
+    mock_compute.get_job_status.return_value = {
+        "status": "completed",
+        "pod_name": "bioaf-pipeline-99-xyz",
+    }
+    mock_compute.get_job_progress.return_value = {
+        "percent_complete": 100.0,
+        "processes": [],
+    }
+
+    run_id = k8s_running_run.id
+    exp_id = k8s_running_run.experiment_id
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = [
+        {
+            "filename": "filtered.h5ad",
+            "gcs_uri": f"gs://bioaf-results-test/experiments/{exp_id}/pipeline-runs/{run_id}/filtered.h5ad",
+            "size_bytes": 50_000_000,
+            "md5_hash": "abc123",
+            "experiment_id": exp_id,
+            "pipeline_run_id": run_id,
+        },
+        {
+            "filename": "qc_plot.png",
+            "gcs_uri": f"gs://bioaf-results-test/experiments/{exp_id}/pipeline-runs/{run_id}/qc_plot.png",
+            "size_bytes": 50_000,
+            "md5_hash": "def456",
+            "experiment_id": exp_id,
+            "pipeline_run_id": run_id,
+        },
+    ]
+
+    with (
+        patch("app.services.pipeline_monitor_service.get_compute_adapter", return_value=mock_compute),
+        patch("app.services.pipeline_monitor_service.get_storage_adapter", return_value=mock_storage),
+        patch("app.services.experiment_service.ExperimentService.update_status", new_callable=AsyncMock),
+    ):
+        await PipelineMonitorService.sync_run_statuses(session)
+
+    from sqlalchemy import select
+    from app.models.file import File
+
+    result = await session.execute(
+        select(File).where(
+            File.source_pipeline_run_id == run_id,
+            File.source_type == "pipeline_output",
+        )
+    )
+    files = list(result.scalars().all())
+    assert len(files) == 2
+
+    filenames = {f.filename for f in files}
+    assert filenames == {"filtered.h5ad", "qc_plot.png"}
+
+    h5ad = next(f for f in files if f.filename == "filtered.h5ad")
+    assert h5ad.file_type == "h5ad"
+    assert h5ad.artifact_type == "anndata"
+    assert h5ad.experiment_id == exp_id
+
+
 # --- Legacy Nextflow trace-based tests ---
 
 

--- a/backend/tests/test_pipeline_output_service.py
+++ b/backend/tests/test_pipeline_output_service.py
@@ -167,9 +167,7 @@ async def test_register_outputs_skips_duplicates(session, pipeline_run, experime
     assert len(files) == 2
 
     # Verify only one file with that gcs_uri exists
-    result = await session.execute(
-        select(File).where(File.gcs_uri == collected[0]["gcs_uri"])
-    )
+    result = await session.execute(select(File).where(File.gcs_uri == collected[0]["gcs_uri"]))
     all_matches = result.scalars().all()
     assert len(all_matches) == 1
 
@@ -231,9 +229,7 @@ async def test_register_nextflow_metadata_creates_records(session, pipeline_run,
     with patch("app.services.pipeline_output_service.gcs_storage") as mock_gcs:
         mock_gcs.Client.return_value = mock_client
 
-        files = await PipelineOutputService.register_nextflow_metadata(
-            session, pipeline_run, "bioaf-raw-testorg"
-        )
+        files = await PipelineOutputService.register_nextflow_metadata(session, pipeline_run, "bioaf-raw-testorg")
         await session.commit()
 
     assert len(files) == 2
@@ -261,9 +257,7 @@ async def test_register_nextflow_metadata_skips_missing_blobs(session, pipeline_
     with patch("app.services.pipeline_output_service.gcs_storage") as mock_gcs:
         mock_gcs.Client.return_value = mock_client
 
-        files = await PipelineOutputService.register_nextflow_metadata(
-            session, pipeline_run, "bioaf-raw-testorg"
-        )
+        files = await PipelineOutputService.register_nextflow_metadata(session, pipeline_run, "bioaf-raw-testorg")
 
     assert files == []
 
@@ -283,7 +277,5 @@ async def test_register_nextflow_metadata_skips_without_k8s_job(session, admin_u
     await session.flush()
     await session.commit()
 
-    files = await PipelineOutputService.register_nextflow_metadata(
-        session, run, "bioaf-raw-testorg"
-    )
+    files = await PipelineOutputService.register_nextflow_metadata(session, run, "bioaf-raw-testorg")
     assert files == []

--- a/backend/tests/test_pipeline_output_service.py
+++ b/backend/tests/test_pipeline_output_service.py
@@ -1,0 +1,207 @@
+"""Tests for PipelineOutputService - registers pipeline outputs as File records."""
+
+import pytest
+import pytest_asyncio
+
+from sqlalchemy import select, text
+
+from app.models.experiment import Experiment
+from app.models.file import File
+from app.models.pipeline_run import PipelineRun, PipelineRunSample
+from app.models.sample import Sample
+from app.services.pipeline_output_service import PipelineOutputService
+
+
+@pytest_asyncio.fixture
+async def experiment(session, admin_user):
+    """Create a test experiment."""
+    exp = Experiment(
+        name="Test Experiment",
+        organization_id=admin_user.organization_id,
+        owner_user_id=admin_user.id,
+        status="processing",
+    )
+    session.add(exp)
+    await session.flush()
+    return exp
+
+
+@pytest_asyncio.fixture
+async def samples(session, admin_user, experiment):
+    """Create two test samples linked to the experiment."""
+    s1 = Sample(
+        sample_id_external="Sample-001",
+        experiment_id=experiment.id,
+    )
+    s2 = Sample(
+        sample_id_external="Sample-002",
+        experiment_id=experiment.id,
+    )
+    session.add_all([s1, s2])
+    await session.flush()
+    return [s1, s2]
+
+
+@pytest_asyncio.fixture
+async def pipeline_run(session, admin_user, experiment, samples):
+    """Create a pipeline run linked to the experiment and samples."""
+    run = PipelineRun(
+        organization_id=admin_user.organization_id,
+        experiment_id=experiment.id,
+        submitted_by_user_id=admin_user.id,
+        pipeline_name="nf-core/scrnaseq",
+        pipeline_version="2.7.1",
+        status="completed",
+        k8s_job_name="nf-scrnaseq-abc123",
+    )
+    session.add(run)
+    await session.flush()
+
+    for s in samples:
+        session.add(PipelineRunSample(pipeline_run_id=run.id, sample_id=s.id))
+    await session.flush()
+    await session.commit()
+    return run
+
+
+def _make_collected(run_id: int, experiment_id: int) -> list[dict]:
+    """Build a sample collect_outputs() result."""
+    base = f"gs://bioaf-results-testorg/experiments/{experiment_id}/pipeline-runs/{run_id}"
+    return [
+        {
+            "filename": "filtered.h5ad",
+            "gcs_uri": f"{base}/filtered.h5ad",
+            "size_bytes": 50_000_000,
+            "md5_hash": "abc123",
+            "experiment_id": experiment_id,
+            "pipeline_run_id": run_id,
+        },
+        {
+            "filename": "aligned.bam",
+            "gcs_uri": f"{base}/aligned.bam",
+            "size_bytes": 200_000_000,
+            "md5_hash": "def456",
+            "experiment_id": experiment_id,
+            "pipeline_run_id": run_id,
+        },
+        {
+            "filename": "qc_plot.png",
+            "gcs_uri": f"{base}/qc_plot.png",
+            "size_bytes": 50_000,
+            "md5_hash": "ghi789",
+            "experiment_id": experiment_id,
+            "pipeline_run_id": run_id,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_register_outputs_creates_file_records(session, pipeline_run, experiment):
+    """File records are created with correct source_type, run ID, and types."""
+    collected = _make_collected(pipeline_run.id, experiment.id)
+
+    files = await PipelineOutputService.register_outputs(session, pipeline_run, collected)
+    await session.commit()
+
+    assert len(files) == 3
+
+    h5ad = next(f for f in files if f.filename == "filtered.h5ad")
+    assert h5ad.source_type == "pipeline_output"
+    assert h5ad.source_pipeline_run_id == pipeline_run.id
+    assert h5ad.experiment_id == experiment.id
+    assert h5ad.file_type == "h5ad"
+    assert h5ad.artifact_type == "anndata"
+
+    bam = next(f for f in files if f.filename == "aligned.bam")
+    assert bam.file_type == "bam"
+    assert bam.artifact_type == "alignment"
+
+    png = next(f for f in files if f.filename == "qc_plot.png")
+    assert png.file_type == "image"
+    assert png.artifact_type == "image"
+
+
+@pytest.mark.asyncio
+async def test_register_outputs_links_files_to_samples(session, pipeline_run, experiment, samples):
+    """Each output file is linked to all samples from the pipeline run."""
+    collected = _make_collected(pipeline_run.id, experiment.id)
+
+    files = await PipelineOutputService.register_outputs(session, pipeline_run, collected)
+    await session.commit()
+
+    sample_ids = {s.id for s in samples}
+
+    for f in files:
+        rows = await session.execute(
+            text("SELECT sample_id FROM sample_files WHERE file_id = :fid"),
+            {"fid": f.id},
+        )
+        linked_ids = {row[0] for row in rows.all()}
+        assert linked_ids == sample_ids, f"File {f.filename} not linked to all samples"
+
+
+@pytest.mark.asyncio
+async def test_register_outputs_skips_duplicates(session, pipeline_run, experiment, admin_user):
+    """Files with an already-existing gcs_uri are not duplicated."""
+    collected = _make_collected(pipeline_run.id, experiment.id)
+
+    # Pre-create one file with the same gcs_uri
+    existing = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri=collected[0]["gcs_uri"],
+        filename="filtered.h5ad",
+        size_bytes=50_000_000,
+        file_type="h5ad",
+        source_type="upload",
+    )
+    session.add(existing)
+    await session.flush()
+    await session.commit()
+
+    files = await PipelineOutputService.register_outputs(session, pipeline_run, collected)
+    await session.commit()
+
+    # Only 2 new files created (the duplicate was skipped)
+    assert len(files) == 2
+
+    # Verify only one file with that gcs_uri exists
+    result = await session.execute(
+        select(File).where(File.gcs_uri == collected[0]["gcs_uri"])
+    )
+    all_matches = result.scalars().all()
+    assert len(all_matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_register_outputs_handles_empty_list(session, pipeline_run):
+    """Empty collected list returns empty result without errors."""
+    files = await PipelineOutputService.register_outputs(session, pipeline_run, [])
+    assert files == []
+
+
+@pytest.mark.asyncio
+async def test_register_outputs_no_samples(session, admin_user, experiment):
+    """Works when the pipeline run has no linked samples."""
+    run = PipelineRun(
+        organization_id=admin_user.organization_id,
+        experiment_id=experiment.id,
+        submitted_by_user_id=admin_user.id,
+        pipeline_name="nf-core/scrnaseq",
+        status="completed",
+    )
+    session.add(run)
+    await session.flush()
+    await session.commit()
+
+    collected = _make_collected(run.id, experiment.id)
+    files = await PipelineOutputService.register_outputs(session, run, collected)
+    await session.commit()
+
+    assert len(files) == 3
+    # No sample links, but files are still created
+    for f in files:
+        rows = await session.execute(
+            text("SELECT sample_id FROM sample_files WHERE file_id = :fid"),
+            {"fid": f.id},
+        )
+        assert rows.all() == []

--- a/backend/tests/test_pipeline_output_service.py
+++ b/backend/tests/test_pipeline_output_service.py
@@ -1,5 +1,7 @@
 """Tests for PipelineOutputService - registers pipeline outputs as File records."""
 
+from unittest.mock import patch, MagicMock
+
 import pytest
 import pytest_asyncio
 
@@ -205,3 +207,83 @@ async def test_register_outputs_no_samples(session, admin_user, experiment):
             {"fid": f.id},
         )
         assert rows.all() == []
+
+
+# --- Nextflow metadata registration ---
+
+
+def _mock_blob(exists: bool = True, size: int = 1000) -> MagicMock:
+    blob = MagicMock()
+    blob.exists.return_value = exists
+    blob.size = size
+    return blob
+
+
+@pytest.mark.asyncio
+async def test_register_nextflow_metadata_creates_records(session, pipeline_run, experiment):
+    """Report and trace files are registered when blobs exist in GCS."""
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = _mock_blob(exists=True, size=5000)
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("app.services.pipeline_output_service.gcs_storage") as mock_gcs:
+        mock_gcs.Client.return_value = mock_client
+
+        files = await PipelineOutputService.register_nextflow_metadata(
+            session, pipeline_run, "bioaf-raw-testorg"
+        )
+        await session.commit()
+
+    assert len(files) == 2
+    filenames = {f.filename for f in files}
+    assert filenames == {"report.html", "trace.tsv"}
+
+    report = next(f for f in files if f.filename == "report.html")
+    assert report.artifact_type == "pipeline_report"
+    assert report.source_type == "pipeline_output"
+    assert report.source_pipeline_run_id == pipeline_run.id
+
+    trace = next(f for f in files if f.filename == "trace.tsv")
+    assert trace.artifact_type == "pipeline_trace"
+
+
+@pytest.mark.asyncio
+async def test_register_nextflow_metadata_skips_missing_blobs(session, pipeline_run):
+    """No records created when blobs do not exist."""
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = _mock_blob(exists=False)
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch("app.services.pipeline_output_service.gcs_storage") as mock_gcs:
+        mock_gcs.Client.return_value = mock_client
+
+        files = await PipelineOutputService.register_nextflow_metadata(
+            session, pipeline_run, "bioaf-raw-testorg"
+        )
+
+    assert files == []
+
+
+@pytest.mark.asyncio
+async def test_register_nextflow_metadata_skips_without_k8s_job(session, admin_user, experiment):
+    """No records created when run has no k8s_job_name."""
+    run = PipelineRun(
+        organization_id=admin_user.organization_id,
+        experiment_id=experiment.id,
+        submitted_by_user_id=admin_user.id,
+        pipeline_name="nf-core/scrnaseq",
+        status="completed",
+        k8s_job_name=None,
+    )
+    session.add(run)
+    await session.flush()
+    await session.commit()
+
+    files = await PipelineOutputService.register_nextflow_metadata(
+        session, run, "bioaf-raw-testorg"
+    )
+    assert files == []

--- a/backend/tests/test_register_outputs_cli.py
+++ b/backend/tests/test_register_outputs_cli.py
@@ -1,0 +1,95 @@
+"""Tests for the register-outputs CLI module."""
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+
+from app.cli.register_outputs import register_outputs_for_run
+from app.models.experiment import Experiment
+from app.models.file import File
+from app.models.pipeline_run import PipelineRun, PipelineRunSample
+from app.models.sample import Sample
+
+
+@pytest_asyncio.fixture
+async def completed_run(session, admin_user):
+    """Create a completed pipeline run with a sample."""
+    exp = Experiment(
+        organization_id=admin_user.organization_id,
+        name="CLI Test Experiment",
+        owner_user_id=admin_user.id,
+        status="analysis",
+    )
+    session.add(exp)
+    await session.flush()
+
+    sample = Sample(
+        sample_id_external="CLI-Sample-001",
+        experiment_id=exp.id,
+    )
+    session.add(sample)
+    await session.flush()
+
+    run = PipelineRun(
+        organization_id=admin_user.organization_id,
+        experiment_id=exp.id,
+        submitted_by_user_id=admin_user.id,
+        pipeline_name="nf-core/scrnaseq",
+        pipeline_version="2.7.1",
+        status="completed",
+    )
+    session.add(run)
+    await session.flush()
+
+    session.add(PipelineRunSample(pipeline_run_id=run.id, sample_id=sample.id))
+    await session.flush()
+    await session.commit()
+    return run
+
+
+@pytest.mark.asyncio
+async def test_register_outputs_for_run_creates_files(session, completed_run):
+    """CLI helper creates File records from collected outputs."""
+    run = completed_run
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = [
+        {
+            "filename": "results.h5ad",
+            "gcs_uri": f"gs://bucket/experiments/{run.experiment_id}/pipeline-runs/{run.id}/results.h5ad",
+            "size_bytes": 10_000_000,
+            "md5_hash": "aaa111",
+            "experiment_id": run.experiment_id,
+            "pipeline_run_id": run.id,
+        },
+    ]
+
+    with patch("app.cli.register_outputs.get_storage_adapter", return_value=mock_storage):
+        count = await register_outputs_for_run(session, run)
+
+    await session.commit()
+    assert count == 1
+
+    result = await session.execute(
+        select(File).where(
+            File.source_pipeline_run_id == run.id,
+            File.source_type == "pipeline_output",
+        )
+    )
+    files = list(result.scalars().all())
+    assert len(files) == 1
+    assert files[0].filename == "results.h5ad"
+    assert files[0].artifact_type == "anndata"
+
+
+@pytest.mark.asyncio
+async def test_register_outputs_for_run_no_files(session, completed_run):
+    """Returns 0 when no outputs are found in GCS."""
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = []
+
+    with patch("app.cli.register_outputs.get_storage_adapter", return_value=mock_storage):
+        count = await register_outputs_for_run(session, completed_run)
+
+    assert count == 0

--- a/bioaf
+++ b/bioaf
@@ -422,6 +422,11 @@ cmd_reset_db() {
     green "Database reset complete. Run './bioaf setup' to create a new admin account."
 }
 
+cmd_register_outputs() {
+    bold "=== Register Pipeline Output Files ==="
+    $DC exec -T backend python -m app.cli.register_outputs "$@"
+}
+
 cmd_help() {
     bold "bioAF Management"
     echo ""
@@ -448,6 +453,10 @@ cmd_help() {
     bold "Debugging:"
     echo "  shell [service]     Open a shell in a container (default: backend)"
     echo "  dbshell             Open a psql session to the database"
+    echo ""
+    bold "Pipeline:"
+    echo "  register-outputs [--run-id N] [--force]"
+    echo "                      Register pipeline output files from GCS into the database"
     echo ""
     bold "Maintenance:"
     echo "  update              Pull latest code, rebuild containers, and run migrations"
@@ -489,6 +498,7 @@ case "$command" in
     dbshell)  cmd_dbshell ;;
     update)   cmd_update ;;
     reset-db) cmd_reset_db ;;
+    register-outputs) cmd_register_outputs "$@" ;;
     help|-h|--help) cmd_help ;;
     *)
         red "Unknown command: $command"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/components/files/FileBrowser.tsx
+++ b/frontend/src/components/files/FileBrowser.tsx
@@ -37,6 +37,9 @@ export function FileBrowser({ experimentId, projectId }: Props) {
   const [projects, setProjects] = useState<{ id: number; name: string }[]>([]);
   const [experiments, setExperiments] = useState<{ id: number; name: string }[]>([]);
   const [filterType, setFilterType] = useState("");
+  const [filterSource, setFilterSource] = useState("");
+  const [filterSampleId, setFilterSampleId] = useState("");
+  const [samples, setSamples] = useState<{ id: number; label: string }[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [viewingFile, setViewingFile] = useState<FileResponse | null>(null);
   const [showProvenance, setShowProvenance] = useState(false);
@@ -65,6 +68,8 @@ export function FileBrowser({ experimentId, projectId }: Props) {
     try {
       const params = new URLSearchParams();
       if (filterType) params.set("file_type", filterType);
+      if (filterSource) params.set("source_type", filterSource);
+      if (filterSampleId) params.set("sample_id", filterSampleId);
       if (experimentId != null) params.set("experiment_id", String(experimentId));
       if (projectId != null) params.set("project_id", String(projectId));
       params.set("page", String(page));
@@ -78,7 +83,7 @@ export function FileBrowser({ experimentId, projectId }: Props) {
     } finally {
       setLoading(false);
     }
-  }, [experimentId, projectId, filterType, page]);
+  }, [experimentId, projectId, filterType, filterSource, filterSampleId, page]);
 
   const fetchMeta = useCallback(async () => {
     try {
@@ -97,6 +102,25 @@ export function FileBrowser({ experimentId, projectId }: Props) {
     fetchFiles();
     fetchMeta();
   }, [fetchFiles, fetchMeta]);
+
+  // Fetch samples when viewing files for an experiment
+  useEffect(() => {
+    if (!experimentId) {
+      setSamples([]);
+      return;
+    }
+    api
+      .get<SampleBrief[]>(`/api/experiments/${experimentId}/samples`)
+      .then((data) =>
+        setSamples(
+          data.map((s) => ({
+            id: s.id,
+            label: s.sample_id_external ?? `Sample #${s.id}`,
+          })),
+        ),
+      )
+      .catch(() => setSamples([]));
+  }, [experimentId]);
 
   // Reload link experiments when link project changes
   useEffect(() => {
@@ -255,6 +279,10 @@ export function FileBrowser({ experimentId, projectId }: Props) {
         return file.uploader
           ? `Uploaded by ${file.uploader.name ?? file.uploader.email}`
           : "Uploaded";
+      case "pipeline_output":
+        return `Nextflow${file.source_pipeline_run_id ? ` (run #${file.source_pipeline_run_id})` : ""}`;
+      case "notebook_output":
+        return `RStudio${file.source_notebook_session_id ? ` (session #${file.source_notebook_session_id})` : ""}`;
       case "qc_dashboard":
         return `QC Dashboard${file.source_pipeline_run_id ? ` (run #${file.source_pipeline_run_id})` : ""}`;
       case "plot_archive":
@@ -282,11 +310,36 @@ export function FileBrowser({ experimentId, projectId }: Props) {
   };
 
   const fileTypes = Array.from(new Set(files.map((f) => f.file_type))).sort();
+  const sourceTypes: { value: string; label: string }[] = [
+    { value: "upload", label: "Upload" },
+    { value: "pipeline_output", label: "Nextflow" },
+    { value: "notebook_output", label: "RStudio" },
+    { value: "qc_dashboard", label: "QC Dashboard" },
+    { value: "plot_archive", label: "Plot Archive" },
+  ];
   const linkModalHasSelection = !!(linkProjectId || linkExperimentId || linkSampleId);
 
   return (
     <div className="space-y-4">
       <div className="flex gap-4 items-center flex-wrap">
+        {samples.length > 0 && (
+          <select
+            value={filterSampleId}
+            onChange={(e) => {
+              setFilterSampleId(e.target.value);
+              setPage(1);
+            }}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+          >
+            <option value="">All samples</option>
+            {samples.map((s) => (
+              <option key={s.id} value={String(s.id)}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        )}
+
         <select
           value={filterType}
           onChange={(e) => {
@@ -299,6 +352,22 @@ export function FileBrowser({ experimentId, projectId }: Props) {
           {fileTypes.map((t) => (
             <option key={t} value={t}>
               {t}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={filterSource}
+          onChange={(e) => {
+            setFilterSource(e.target.value);
+            setPage(1);
+          }}
+          className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+        >
+          <option value="">All sources</option>
+          {sourceTypes.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
             </option>
           ))}
         </select>
@@ -416,13 +485,7 @@ export function FileBrowser({ experimentId, projectId }: Props) {
                     {file.uploader?.name ?? file.uploader?.email ?? "-"}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500">
-                    {file.source_type === "upload"
-                      ? "Upload"
-                      : file.source_type === "qc_dashboard"
-                        ? "QC Dashboard"
-                        : file.source_type === "plot_archive"
-                          ? "Plot Archive"
-                          : file.source_type}
+                    {sourceLabel(file)}
                   </td>
                   <td className="px-4 py-3 text-sm" onClick={(e) => e.stopPropagation()}>
                     {associationLabel(file) ? (


### PR DESCRIPTION
## Summary

- Register Nextflow pipeline output files as proper `File` records in the database on pipeline completion, linked to samples and pipeline runs
- Add `bioaf register-outputs` CLI command to backfill File records for past completed runs
- Add sample, file type, and source filters to the experiment files page
- Update source_type display labels (Nextflow, RStudio, QC Dashboard, etc.)

## Changes

**Backend**
- Extract `detect_file_type()` into shared `file_type_utils.py`, add `classify_artifact_type()` for semantic categories (alignment, anndata, count_matrix, etc.)
- Add `artifact_type` parameter to `FileService.create_file_record()`
- New `PipelineOutputService` with `register_outputs()` and `register_nextflow_metadata()` methods
- Wire output registration into `PipelineMonitorService._handle_completion()`
- Add `source_type` and `sample_id` filter params to files API
- Add `get_raw_bucket_name()` to `ComputeProvider` base class
- Resolve output bucket from `results_bucket_name` in platform_config

**Frontend**
- Add sample, file type, and source dropdown filters to FileBrowser
- Update source column to show human-readable labels with run/session IDs

**CLI**
- `bioaf register-outputs [--run-id N] [--force]` for backfilling past runs

## Test plan

- [x] `pytest tests/` -- 1466 passed (1 pre-existing error in test_access_logs.py)
- [x] `ruff format --check .` -- clean
- [x] `ruff check .` -- clean
- [x] `mypy . --ignore-missing-imports` -- clean
- [x] `npx tsc --noEmit` -- clean
- [x] `npm test` -- 371 passed
- [x] `markdownlint-cli` -- clean
- [x] Verified backfill with `./bioaf register-outputs --run-id 2` -- 62 files registered, zero duplicates