### PR TITLE
Slack OAuth integration with guided setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A turnkey computational biology platform for small biotech companies (5-50 resea
 - **Data Management** - File upload/download, dataset browser, GCS storage integration, GEO export, SuperSeries cross-experiment packaging
 - **Results & Visualization** - QC dashboards, cellxgene single-cell viewer, plot archive, search
 - **SSH Access** - One-click kubectl exec into running pipeline jobs and notebook sessions
-- **Notifications** - Event-driven alerts via in-app, email (SMTP), and Slack webhooks
+- **Notifications** - Event-driven alerts via in-app, email (SMTP), and Slack (OAuth integration)
 - **Cost Center** - GCP billing integration, budget alerts, component cost breakdown, projections
 - **Backup & Recovery** - Tiered backups (Cloud SQL PITR, GCS versioning, config exports), one-click restore
 - **Session Credentials** - Per-user RStudio credentials with PAM authentication, auto-generated usernames

--- a/backend/alembic/versions/051_slack_oauth_installation.py
+++ b/backend/alembic/versions/051_slack_oauth_installation.py
@@ -1,0 +1,47 @@
+"""Add Slack OAuth installation and channel mapping tables.
+
+Revision ID: 051
+Revises: 050
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "051"
+down_revision = "050"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "slack_installations",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("organization_id", sa.Integer, sa.ForeignKey("organizations.id"), nullable=False, unique=True),
+        sa.Column("team_id", sa.String(50), nullable=False),
+        sa.Column("team_name", sa.String(255), nullable=False),
+        sa.Column("bot_token", sa.String(500), nullable=False),
+        sa.Column("bot_user_id", sa.String(50), nullable=False),
+        sa.Column("authed_user_id", sa.String(50), nullable=True),
+        sa.Column("installed_by", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("enabled", sa.Boolean, server_default="true", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "slack_channel_mappings",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("organization_id", sa.Integer, sa.ForeignKey("organizations.id"), nullable=False),
+        sa.Column("channel_id", sa.String(50), nullable=False),
+        sa.Column("channel_name", sa.String(255), nullable=False),
+        sa.Column("event_types_json", JSONB, server_default="[]", nullable=False),
+        sa.Column("enabled", sa.Boolean, server_default="true", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_index("ix_slack_channel_mappings_org", "slack_channel_mappings", ["organization_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_slack_channel_mappings_org")
+    op.drop_table("slack_channel_mappings")
+    op.drop_table("slack_installations")

--- a/backend/alembic/versions/052_slack_credentials_on_org.py
+++ b/backend/alembic/versions/052_slack_credentials_on_org.py
@@ -1,0 +1,23 @@
+"""Add Slack OAuth credentials to organizations table.
+
+Revision ID: 052
+Revises: 051
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "052"
+down_revision = "051"
+
+
+def upgrade() -> None:
+    op.add_column("organizations", sa.Column("slack_client_id", sa.String(255), server_default="", nullable=False))
+    op.add_column("organizations", sa.Column("slack_client_secret", sa.String(500), server_default="", nullable=False))
+    op.add_column("organizations", sa.Column("slack_signing_secret", sa.String(255), server_default="", nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "slack_signing_secret")
+    op.drop_column("organizations", "slack_client_secret")
+    op.drop_column("organizations", "slack_client_id")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -61,6 +61,7 @@ from app.api.work_nodes import router as work_nodes_router
 from app.api.work_nodes import settings_router as work_node_settings_router
 from app.api.provenance_reports import router as provenance_reports_router
 from app.api.data_export import router as data_export_router
+from app.api.slack_oauth import router as slack_oauth_router
 
 api_router = APIRouter()
 
@@ -125,3 +126,4 @@ api_router.include_router(work_nodes_router)
 api_router.include_router(work_node_settings_router)
 api_router.include_router(provenance_reports_router)
 api_router.include_router(data_export_router)
+api_router.include_router(slack_oauth_router)

--- a/backend/app/api/slack_oauth.py
+++ b/backend/app/api/slack_oauth.py
@@ -3,6 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sqlalchemy import select
@@ -159,11 +160,12 @@ async def get_auth_url(
 
 @router.get("/callback")
 async def oauth_callback(
+    request: Request,
     code: str = Query(...),
     state: str = Query(...),
     session: AsyncSession = Depends(get_session),
 ):
-    """Handle the OAuth redirect from Slack. No auth header -- state carries identity."""
+    """Handle the OAuth redirect from Slack, then redirect back to bioAF."""
     try:
         claims = SlackOAuthService.decode_state(state)
     except Exception:
@@ -179,14 +181,17 @@ async def oauth_callback(
     except ValueError as e:
         raise HTTPException(400, str(e))
 
-    install = await SlackOAuthService.save_installation(session, org_id, user_id, token_data)
+    await SlackOAuthService.save_installation(session, org_id, user_id, token_data)
     await session.commit()
 
-    return {
-        "status": "connected",
-        "team_name": install.team_name,
-        "team_id": install.team_id,
-    }
+    # Redirect browser back to the Slack settings page
+    callback_path = "/api/notifications/slack/callback"
+    request_url = str(request.url).split("?")[0]
+    if request_url.endswith(callback_path):
+        origin = request_url[: -len(callback_path)]
+    else:
+        origin = str(request.base_url).rstrip("/")
+    return RedirectResponse(url=f"{origin}/settings/slack?connected=true")
 
 
 @router.get("/status", response_model=SlackStatusResponse)

--- a/backend/app/api/slack_oauth.py
+++ b/backend/app/api/slack_oauth.py
@@ -5,18 +5,33 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy import select
+
 from app.config import settings
 from app.database import get_session
 from app.api.dependencies import require_permission
+from app.models.organization import Organization
 from app.schemas.notification import (
     SlackAuthUrlResponse,
     SlackChannelMappingCreate,
     SlackChannelMappingResponse,
     SlackChannelMappingUpdate,
     SlackChannelResponse,
+    SlackCredentialsResponse,
+    SlackCredentialsSave,
     SlackStatusResponse,
 )
 from app.services.slack_oauth_service import SlackOAuthService
+
+
+async def _get_slack_credentials(session: AsyncSession, org_id: int) -> tuple[str, str]:
+    """Return (client_id, client_secret), preferring org DB values over env vars."""
+    result = await session.execute(select(Organization).where(Organization.id == org_id))
+    org = result.scalar_one_or_none()
+    if org and org.slack_client_id and org.slack_client_secret:
+        return org.slack_client_id, org.slack_client_secret
+    return settings.slack_client_id, settings.slack_client_secret
+
 
 logger = logging.getLogger("bioaf.api.slack_oauth")
 
@@ -56,19 +71,59 @@ async def get_manifest(
     }
 
 
+@router.get("/credentials", response_model=SlackCredentialsResponse)
+async def get_credentials(
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Check whether Slack credentials are configured."""
+    client_id, client_secret = await _get_slack_credentials(session, current_user["org_id"])
+    configured = bool(client_id and client_secret)
+    preview = (client_id[:6] + "..." + client_id[-4:]) if client_id and len(client_id) > 10 else None
+    return SlackCredentialsResponse(configured=configured, client_id_preview=preview)
+
+
+@router.post("/credentials", response_model=SlackCredentialsResponse)
+async def save_credentials(
+    body: SlackCredentialsSave,
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Save Slack App credentials for this organization."""
+    result = await session.execute(select(Organization).where(Organization.id == current_user["org_id"]))
+    org = result.scalar_one_or_none()
+    if not org:
+        raise HTTPException(404, "Organization not found")
+
+    org.slack_client_id = body.client_id.strip()
+    org.slack_client_secret = body.client_secret.strip()
+    org.slack_signing_secret = body.signing_secret.strip()
+    await session.flush()
+
+    # Hot-patch runtime settings so auth-url works immediately
+    settings.slack_client_id = org.slack_client_id
+    settings.slack_client_secret = org.slack_client_secret
+    settings.slack_signing_secret = org.slack_signing_secret
+
+    await session.commit()
+
+    preview = org.slack_client_id[:6] + "..." + org.slack_client_id[-4:] if len(org.slack_client_id) > 10 else None
+    return SlackCredentialsResponse(configured=True, client_id_preview=preview)
+
+
 @router.get("/auth-url", response_model=SlackAuthUrlResponse)
 async def get_auth_url(
     current_user: dict = require_permission("notifications", "configure"),
     session: AsyncSession = Depends(get_session),
 ):
-    if not settings.slack_client_id or not settings.slack_client_secret:
-        raise HTTPException(
-            400, "Slack OAuth is not configured. Set BIOAF_SLACK_CLIENT_ID and BIOAF_SLACK_CLIENT_SECRET."
-        )
+    client_id, client_secret = await _get_slack_credentials(session, current_user["org_id"])
+    if not client_id or not client_secret:
+        raise HTTPException(400, "Slack App credentials have not been saved yet.")
 
     auth_url = SlackOAuthService.build_auth_url(
         org_id=current_user["org_id"],
         user_id=int(current_user["sub"]),
+        client_id_override=client_id,
     )
     return SlackAuthUrlResponse(auth_url=auth_url)
 
@@ -88,8 +143,10 @@ async def oauth_callback(
     org_id = claims["org_id"]
     user_id = claims["user_id"]
 
+    client_id, client_secret = await _get_slack_credentials(session, org_id)
+
     try:
-        token_data = await SlackOAuthService.exchange_code(code)
+        token_data = await SlackOAuthService.exchange_code(code, client_id, client_secret)
     except ValueError as e:
         raise HTTPException(400, str(e))
 

--- a/backend/app/api/slack_oauth.py
+++ b/backend/app/api/slack_oauth.py
@@ -29,7 +29,9 @@ async def get_auth_url(
     session: AsyncSession = Depends(get_session),
 ):
     if not settings.slack_client_id or not settings.slack_client_secret:
-        raise HTTPException(400, "Slack OAuth is not configured. Set BIOAF_SLACK_CLIENT_ID and BIOAF_SLACK_CLIENT_SECRET.")
+        raise HTTPException(
+            400, "Slack OAuth is not configured. Set BIOAF_SLACK_CLIENT_ID and BIOAF_SLACK_CLIENT_SECRET."
+        )
 
     auth_url = SlackOAuthService.build_auth_url(
         org_id=current_user["org_id"],
@@ -124,9 +126,7 @@ async def create_channel_mapping(
     if not install:
         raise HTTPException(404, "Slack not connected")
 
-    mapping = await SlackOAuthService.create_channel_mapping(
-        session, current_user["org_id"], body.model_dump()
-    )
+    mapping = await SlackOAuthService.create_channel_mapping(session, current_user["org_id"], body.model_dump())
     await session.commit()
     return SlackChannelMappingResponse.model_validate(mapping)
 
@@ -153,9 +153,7 @@ async def delete_channel_mapping(
     current_user: dict = require_permission("notifications", "configure"),
     session: AsyncSession = Depends(get_session),
 ):
-    deleted = await SlackOAuthService.delete_channel_mapping(
-        session, mapping_id, current_user["org_id"]
-    )
+    deleted = await SlackOAuthService.delete_channel_mapping(session, mapping_id, current_user["org_id"])
     if not deleted:
         raise HTTPException(404, "Channel mapping not found")
     await session.commit()

--- a/backend/app/api/slack_oauth.py
+++ b/backend/app/api/slack_oauth.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -21,6 +21,39 @@ from app.services.slack_oauth_service import SlackOAuthService
 logger = logging.getLogger("bioaf.api.slack_oauth")
 
 router = APIRouter(prefix="/api/notifications/slack", tags=["slack"])
+
+
+@router.get("/manifest")
+async def get_manifest(
+    request: Request,
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Generate the Slack App manifest JSON based on the current deployment URL."""
+    origin = str(request.base_url).rstrip("/")
+    callback_url = f"{origin}/api/notifications/slack/callback"
+
+    return {
+        "display_information": {
+            "name": "bioAF",
+            "description": "Bioinformatics analysis platform notifications",
+        },
+        "features": {
+            "bot_user": {
+                "display_name": "bioAF",
+                "always_online": True,
+            }
+        },
+        "oauth_config": {
+            "scopes": {"bot": ["chat:write", "channels:read", "groups:read"]},
+            "redirect_urls": [callback_url],
+        },
+        "settings": {
+            "org_deploy_enabled": False,
+            "socket_mode_enabled": False,
+            "token_rotation_enabled": False,
+        },
+    }
 
 
 @router.get("/auth-url", response_model=SlackAuthUrlResponse)

--- a/backend/app/api/slack_oauth.py
+++ b/backend/app/api/slack_oauth.py
@@ -1,0 +1,162 @@
+"""Slack OAuth API endpoints: auth URL, callback, status, disconnect, channels, mappings."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_session
+from app.api.dependencies import require_permission
+from app.schemas.notification import (
+    SlackAuthUrlResponse,
+    SlackChannelMappingCreate,
+    SlackChannelMappingResponse,
+    SlackChannelMappingUpdate,
+    SlackChannelResponse,
+    SlackStatusResponse,
+)
+from app.services.slack_oauth_service import SlackOAuthService
+
+logger = logging.getLogger("bioaf.api.slack_oauth")
+
+router = APIRouter(prefix="/api/notifications/slack", tags=["slack"])
+
+
+@router.get("/auth-url", response_model=SlackAuthUrlResponse)
+async def get_auth_url(
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    if not settings.slack_client_id or not settings.slack_client_secret:
+        raise HTTPException(400, "Slack OAuth is not configured. Set BIOAF_SLACK_CLIENT_ID and BIOAF_SLACK_CLIENT_SECRET.")
+
+    auth_url = SlackOAuthService.build_auth_url(
+        org_id=current_user["org_id"],
+        user_id=int(current_user["sub"]),
+    )
+    return SlackAuthUrlResponse(auth_url=auth_url)
+
+
+@router.get("/callback")
+async def oauth_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    session: AsyncSession = Depends(get_session),
+):
+    """Handle the OAuth redirect from Slack. No auth header -- state carries identity."""
+    try:
+        claims = SlackOAuthService.decode_state(state)
+    except Exception:
+        raise HTTPException(400, "Invalid or expired state token")
+
+    org_id = claims["org_id"]
+    user_id = claims["user_id"]
+
+    try:
+        token_data = await SlackOAuthService.exchange_code(code)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+    install = await SlackOAuthService.save_installation(session, org_id, user_id, token_data)
+    await session.commit()
+
+    return {
+        "status": "connected",
+        "team_name": install.team_name,
+        "team_id": install.team_id,
+    }
+
+
+@router.get("/status", response_model=SlackStatusResponse)
+async def get_status(
+    current_user: dict = require_permission("notifications", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    status = await SlackOAuthService.get_status(session, current_user["org_id"])
+    return SlackStatusResponse(**status)
+
+
+@router.delete("/disconnect")
+async def disconnect(
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    removed = await SlackOAuthService.disconnect(session, current_user["org_id"])
+    if not removed:
+        raise HTTPException(404, "No Slack installation found")
+    await session.commit()
+    return {"disconnected": True}
+
+
+@router.get("/channels", response_model=list[SlackChannelResponse])
+async def list_channels(
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    install = await SlackOAuthService.get_installation(session, current_user["org_id"])
+    if not install:
+        raise HTTPException(404, "Slack not connected")
+
+    channels = await SlackOAuthService.list_channels(session, current_user["org_id"])
+    return [SlackChannelResponse(**ch) for ch in channels]
+
+
+# ---- Channel mappings ----
+
+
+@router.get("/channel-mappings", response_model=list[SlackChannelMappingResponse])
+async def list_channel_mappings(
+    current_user: dict = require_permission("notifications", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    mappings = await SlackOAuthService.list_channel_mappings(session, current_user["org_id"])
+    return [SlackChannelMappingResponse.model_validate(m) for m in mappings]
+
+
+@router.post("/channel-mappings", response_model=SlackChannelMappingResponse)
+async def create_channel_mapping(
+    body: SlackChannelMappingCreate,
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    install = await SlackOAuthService.get_installation(session, current_user["org_id"])
+    if not install:
+        raise HTTPException(404, "Slack not connected")
+
+    mapping = await SlackOAuthService.create_channel_mapping(
+        session, current_user["org_id"], body.model_dump()
+    )
+    await session.commit()
+    return SlackChannelMappingResponse.model_validate(mapping)
+
+
+@router.put("/channel-mappings/{mapping_id}", response_model=SlackChannelMappingResponse)
+async def update_channel_mapping(
+    mapping_id: int,
+    body: SlackChannelMappingUpdate,
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    mapping = await SlackOAuthService.update_channel_mapping(
+        session, mapping_id, current_user["org_id"], body.model_dump(exclude_unset=True)
+    )
+    if not mapping:
+        raise HTTPException(404, "Channel mapping not found")
+    await session.commit()
+    return SlackChannelMappingResponse.model_validate(mapping)
+
+
+@router.delete("/channel-mappings/{mapping_id}")
+async def delete_channel_mapping(
+    mapping_id: int,
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    deleted = await SlackOAuthService.delete_channel_mapping(
+        session, mapping_id, current_user["org_id"]
+    )
+    if not deleted:
+        raise HTTPException(404, "Channel mapping not found")
+    await session.commit()
+    return {"deleted": True}

--- a/backend/app/api/slack_oauth.py
+++ b/backend/app/api/slack_oauth.py
@@ -41,12 +41,13 @@ router = APIRouter(prefix="/api/notifications/slack", tags=["slack"])
 @router.get("/manifest")
 async def get_manifest(
     request: Request,
+    origin: str = Query(""),
     current_user: dict = require_permission("notifications", "configure"),
     session: AsyncSession = Depends(get_session),
 ):
-    """Generate the Slack App manifest JSON based on the current deployment URL."""
-    origin = str(request.base_url).rstrip("/")
-    callback_url = f"{origin}/api/notifications/slack/callback"
+    """Generate the Slack App manifest JSON. Uses ?origin= from the frontend."""
+    base = origin.rstrip("/") if origin else str(request.base_url).rstrip("/")
+    callback_url = f"{base}/api/notifications/slack/callback"
 
     return {
         "display_information": {

--- a/backend/app/api/slack_oauth.py
+++ b/backend/app/api/slack_oauth.py
@@ -112,6 +112,34 @@ async def save_credentials(
     return SlackCredentialsResponse(configured=True, client_id_preview=preview)
 
 
+@router.delete("/credentials")
+async def clear_credentials(
+    current_user: dict = require_permission("notifications", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Clear saved Slack credentials and disconnect if connected."""
+    org_id = current_user["org_id"]
+
+    # Disconnect installation and mappings if any
+    await SlackOAuthService.disconnect(session, org_id)
+
+    # Clear org credentials
+    result = await session.execute(select(Organization).where(Organization.id == org_id))
+    org = result.scalar_one_or_none()
+    if org:
+        org.slack_client_id = ""
+        org.slack_client_secret = ""
+        org.slack_signing_secret = ""
+
+    # Clear runtime settings
+    settings.slack_client_id = ""
+    settings.slack_client_secret = ""
+    settings.slack_signing_secret = ""
+
+    await session.commit()
+    return {"cleared": True}
+
+
 @router.get("/auth-url", response_model=SlackAuthUrlResponse)
 async def get_auth_url(
     current_user: dict = require_permission("notifications", "configure"),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     smtp_encryption: str = "starttls"
     smtp_configured: bool = False
 
+    # Slack OAuth
+    slack_client_id: str = ""
+    slack_client_secret: str = ""
+    slack_signing_secret: str = ""
+
     # Rate limiting
     rate_limit_login: int = 10
     rate_limit_verify: int = 5

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -16,6 +16,7 @@ PUBLIC_PATHS = {
     "/api/bootstrap/status",
     "/api/bootstrap/create-admin",
     "/api/users/accept-invite",
+    "/api/notifications/slack/callback",
     "/docs",
     "/openapi.json",
 }

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -32,6 +32,8 @@ from app.models.notification import (
     NotificationRule,
     NotificationPreference,
     SlackWebhook,
+    SlackInstallation,
+    SlackChannelMapping,
     NotificationDeliveryLog,
 )
 from app.models.upgrade_history import UpgradeHistory
@@ -93,6 +95,8 @@ __all__ = [
     "NotificationRule",
     "NotificationPreference",
     "SlackWebhook",
+    "SlackInstallation",
+    "SlackChannelMapping",
     "NotificationDeliveryLog",
     "UpgradeHistory",
     "AccessLog",

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -68,6 +68,40 @@ class SlackWebhook(Base):
     organization = relationship("Organization")
 
 
+class SlackInstallation(Base):
+    __tablename__ = "slack_installations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("organizations.id"), nullable=False, unique=True
+    )
+    team_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    team_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    bot_token: Mapped[str] = mapped_column(String(500), nullable=False)
+    bot_user_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    authed_user_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    installed_by: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, server_default="true", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    organization = relationship("Organization")
+    installer = relationship("User")
+
+
+class SlackChannelMapping(Base):
+    __tablename__ = "slack_channel_mappings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
+    channel_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    channel_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    event_types_json: Mapped[list] = mapped_column(JSONB, server_default="[]", nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, server_default="true", nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    organization = relationship("Organization")
+
+
 class NotificationDeliveryLog(Base):
     __tablename__ = "notification_delivery_log"
 

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -72,9 +72,7 @@ class SlackInstallation(Base):
     __tablename__ = "slack_installations"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    organization_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("organizations.id"), nullable=False, unique=True
-    )
+    organization_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False, unique=True)
     team_id: Mapped[str] = mapped_column(String(50), nullable=False)
     team_name: Mapped[str] = mapped_column(String(255), nullable=False)
     bot_token: Mapped[str] = mapped_column(String(500), nullable=False)

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -19,4 +19,7 @@ class Organization(Base):
     smtp_password: Mapped[str] = mapped_column(String(500), default="")
     smtp_from_address: Mapped[str] = mapped_column(String(255), default="")
     smtp_encryption: Mapped[str] = mapped_column(String(20), default="starttls")
+    slack_client_id: Mapped[str] = mapped_column(String(255), default="")
+    slack_client_secret: Mapped[str] = mapped_column(String(500), default="")
+    slack_signing_secret: Mapped[str] = mapped_column(String(255), default="")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -108,3 +108,47 @@ class TestDeliveryResponse(BaseModel):
     status: str
     detail: str | None = None
     webhooks: list[dict] | None = None
+
+
+# ---- Slack OAuth ----
+
+
+class SlackAuthUrlResponse(BaseModel):
+    auth_url: str
+
+
+class SlackStatusResponse(BaseModel):
+    connected: bool
+    team_name: str | None = None
+    team_id: str | None = None
+    installed_by: str | None = None
+    installed_at: datetime | None = None
+    enabled: bool = False
+
+
+class SlackChannelResponse(BaseModel):
+    id: str
+    name: str
+    is_private: bool = False
+
+
+class SlackChannelMappingResponse(BaseModel):
+    id: int
+    channel_id: str
+    channel_name: str
+    event_types_json: list[str]
+    enabled: bool
+
+    model_config = {"from_attributes": True}
+
+
+class SlackChannelMappingCreate(BaseModel):
+    channel_id: str
+    channel_name: str
+    event_types: list[str] = []
+    enabled: bool = True
+
+
+class SlackChannelMappingUpdate(BaseModel):
+    event_types: list[str] | None = None
+    enabled: bool | None = None

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -153,3 +153,14 @@ class SlackChannelMappingCreate(BaseModel):
 class SlackChannelMappingUpdate(BaseModel):
     event_types: list[str] | None = None
     enabled: bool | None = None
+
+
+class SlackCredentialsSave(BaseModel):
+    client_id: str
+    client_secret: str
+    signing_secret: str
+
+
+class SlackCredentialsResponse(BaseModel):
+    configured: bool
+    client_id_preview: str | None = None

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -118,6 +118,7 @@ class SlackAuthUrlResponse(BaseModel):
 
 
 class SlackStatusResponse(BaseModel):
+    configured: bool = False
     connected: bool
     team_name: str | None = None
     team_id: str | None = None

--- a/backend/app/services/notification_channels/slack_adapter.py
+++ b/backend/app/services/notification_channels/slack_adapter.py
@@ -1,4 +1,4 @@
-"""Slack notification channel adapter using webhook POST."""
+"""Slack notification channel adapter supporting bot token (chat.postMessage) and legacy webhooks."""
 
 import asyncio
 import logging
@@ -10,6 +10,8 @@ logger = logging.getLogger("bioaf.notifications.slack")
 MAX_RETRIES = 3
 BACKOFF_BASE = 2  # seconds: 2, 8, 32
 
+SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
+
 SEVERITY_COLORS = {
     "info": "#36a64f",  # green
     "warning": "#f2c744",  # yellow
@@ -17,14 +19,88 @@ SEVERITY_COLORS = {
 }
 
 
+def _build_blocks(title: str, message: str, severity: str) -> list[dict]:
+    """Build Slack Block Kit blocks for a notification."""
+    color = SEVERITY_COLORS.get(severity, "#36a64f")
+    return [
+        {
+            "color": color,
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": f"*{title}*"},
+                },
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": message},
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {"type": "mrkdwn", "text": f"Severity: *{severity.capitalize()}*"},
+                        {"type": "mrkdwn", "text": "bioAF Platform"},
+                    ],
+                },
+            ],
+        }
+    ]
+
+
 class SlackChannel:
     @staticmethod
     async def deliver(
+        bot_token: str,
+        channel_id: str,
+        title: str,
+        message: str,
+        severity: str,
+    ) -> bool:
+        """Send a notification via Slack's chat.postMessage API using a bot token."""
+        payload = {
+            "channel": channel_id,
+            "text": f"{title}: {message}",
+            "attachments": _build_blocks(title, message, severity),
+        }
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    response = await client.post(
+                        SLACK_POST_MESSAGE_URL,
+                        json=payload,
+                        headers={"Authorization": f"Bearer {bot_token}"},
+                    )
+                    data = response.json()
+                    if data.get("ok"):
+                        logger.info("Slack notification sent to %s: %s", channel_id, title)
+                        return True
+                    logger.warning("Slack API error: %s", data.get("error"))
+                    # Do not retry on auth/channel errors
+                    if data.get("error") in ("channel_not_found", "not_in_channel", "invalid_auth", "token_revoked"):
+                        return False
+            except Exception as e:
+                backoff = BACKOFF_BASE ** (attempt * 2 + 1)
+                logger.warning(
+                    "Slack attempt %d/%d failed: %s (backoff %ds)",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    e,
+                    backoff,
+                )
+                if attempt < MAX_RETRIES - 1:
+                    await asyncio.sleep(backoff)
+
+        logger.error("Slack delivery failed after %d attempts", MAX_RETRIES)
+        return False
+
+    @staticmethod
+    async def deliver_webhook(
         webhook_url: str,
         title: str,
         message: str,
         severity: str,
     ) -> bool:
+        """Legacy webhook delivery for backward compatibility."""
         color = SEVERITY_COLORS.get(severity, "#36a64f")
         payload = {
             "attachments": [
@@ -49,12 +125,12 @@ class SlackChannel:
                 async with httpx.AsyncClient(timeout=10.0) as client:
                     response = await client.post(webhook_url, json=payload)
                     response.raise_for_status()
-                logger.info("Slack notification sent: %s", title)
+                logger.info("Slack webhook notification sent: %s", title)
                 return True
             except Exception as e:
                 backoff = BACKOFF_BASE ** (attempt * 2 + 1)
                 logger.warning(
-                    "Slack attempt %d/%d failed: %s (backoff %ds)",
+                    "Slack webhook attempt %d/%d failed: %s (backoff %ds)",
                     attempt + 1,
                     MAX_RETRIES,
                     e,
@@ -63,5 +139,5 @@ class SlackChannel:
                 if attempt < MAX_RETRIES - 1:
                     await asyncio.sleep(backoff)
 
-        logger.error("Slack delivery failed after %d attempts", MAX_RETRIES)
+        logger.error("Slack webhook delivery failed after %d attempts", MAX_RETRIES)
         return False

--- a/backend/app/services/notification_channels/slack_adapter.py
+++ b/backend/app/services/notification_channels/slack_adapter.py
@@ -54,14 +54,18 @@ class SlackChannel:
         title: str,
         message: str,
         severity: str,
-    ) -> bool:
-        """Send a notification via Slack's chat.postMessage API using a bot token."""
+    ) -> tuple[bool, str]:
+        """Send a notification via Slack's chat.postMessage API.
+
+        Returns (success, error_code). error_code is empty on success.
+        """
         payload = {
             "channel": channel_id,
             "text": f"{title}: {message}",
             "attachments": _build_blocks(title, message, severity),
         }
 
+        last_error = ""
         for attempt in range(MAX_RETRIES):
             try:
                 async with httpx.AsyncClient(timeout=10.0) as client:
@@ -73,12 +77,19 @@ class SlackChannel:
                     data = response.json()
                     if data.get("ok"):
                         logger.info("Slack notification sent to %s: %s", channel_id, title)
-                        return True
-                    logger.warning("Slack API error: %s", data.get("error"))
+                        return True, ""
+                    last_error = data.get("error", "unknown_error")
+                    logger.warning("Slack API error: %s", last_error)
                     # Do not retry on auth/channel errors
-                    if data.get("error") in ("channel_not_found", "not_in_channel", "invalid_auth", "token_revoked"):
-                        return False
+                    if last_error in (
+                        "channel_not_found",
+                        "not_in_channel",
+                        "invalid_auth",
+                        "token_revoked",
+                    ):
+                        return False, last_error
             except Exception as e:
+                last_error = str(e)
                 backoff = BACKOFF_BASE ** (attempt * 2 + 1)
                 logger.warning(
                     "Slack attempt %d/%d failed: %s (backoff %ds)",
@@ -91,7 +102,7 @@ class SlackChannel:
                     await asyncio.sleep(backoff)
 
         logger.error("Slack delivery failed after %d attempts", MAX_RETRIES)
-        return False
+        return False, last_error
 
     @staticmethod
     async def deliver_webhook(

--- a/backend/app/services/notification_router.py
+++ b/backend/app/services/notification_router.py
@@ -11,6 +11,8 @@ from app.models.notification import (
     NotificationDeliveryLog,
     NotificationPreference,
     NotificationRule,
+    SlackChannelMapping,
+    SlackInstallation,
     SlackWebhook,
 )
 from app.models.activity_feed import ActivityFeedEntry
@@ -208,7 +210,45 @@ class NotificationRouter:
         message: str,
         severity: str,
     ) -> None:
-        """Deliver to all matching Slack webhooks for the org."""
+        """Deliver via OAuth bot token (preferred) or legacy webhooks (fallback)."""
+        # Try OAuth installation first
+        install_result = await session.execute(
+            select(SlackInstallation).where(
+                SlackInstallation.organization_id == org_id,
+                SlackInstallation.enabled == True,  # noqa: E712
+            )
+        )
+        install = install_result.scalar_one_or_none()
+
+        if install:
+            mappings_result = await session.execute(
+                select(SlackChannelMapping).where(
+                    SlackChannelMapping.organization_id == org_id,
+                    SlackChannelMapping.enabled == True,  # noqa: E712
+                )
+            )
+            mappings = list(mappings_result.scalars().all())
+
+            for mapping in mappings:
+                if mapping.event_types_json and event_type not in mapping.event_types_json:
+                    continue
+
+                success = await SlackChannel.deliver(
+                    bot_token=install.bot_token,
+                    channel_id=mapping.channel_id,
+                    title=title,
+                    message=message,
+                    severity=severity,
+                )
+                await self._log_delivery(
+                    session,
+                    notification_id,
+                    "slack",
+                    "sent" if success else "failed",
+                )
+            return
+
+        # Fallback to legacy webhooks
         result = await session.execute(
             select(SlackWebhook).where(
                 SlackWebhook.organization_id == org_id,
@@ -218,11 +258,10 @@ class NotificationRouter:
         webhooks = list(result.scalars().all())
 
         for webhook in webhooks:
-            # Check event type filter
             if webhook.event_types_json and event_type not in webhook.event_types_json:
                 continue
 
-            success = await SlackChannel.deliver(
+            success = await SlackChannel.deliver_webhook(
                 webhook_url=webhook.webhook_url,
                 title=title,
                 message=message,

--- a/backend/app/services/notification_router.py
+++ b/backend/app/services/notification_router.py
@@ -233,7 +233,7 @@ class NotificationRouter:
                 if mapping.event_types_json and event_type not in mapping.event_types_json:
                     continue
 
-                success = await SlackChannel.deliver(
+                success, _error = await SlackChannel.deliver(
                     bot_token=install.bot_token,
                     channel_id=mapping.channel_id,
                     title=title,

--- a/backend/app/services/notification_router.py
+++ b/backend/app/services/notification_router.py
@@ -80,6 +80,8 @@ class NotificationRouter:
             recipients = await self._resolve_recipients(session, org_id, rules, payload)
 
             # Deliver to each recipient via each channel
+            slack_delivered_via_rule = False
+            first_notification_id = None
             for recipient_user in recipients:
                 # In-app always delivered
                 notification = await InAppChannel.deliver(
@@ -92,6 +94,8 @@ class NotificationRouter:
                     severity=severity,
                     metadata=metadata,
                 )
+                if first_notification_id is None:
+                    first_notification_id = notification.id
 
                 # Check email/slack delivery per rules and preferences
                 for rule in rules:
@@ -126,6 +130,7 @@ class NotificationRouter:
                             "sent" if success else "failed",
                         )
                     elif rule.channel == "slack":
+                        slack_delivered_via_rule = True
                         await self._deliver_slack(
                             session,
                             org_id,
@@ -135,6 +140,18 @@ class NotificationRouter:
                             message,
                             severity,
                         )
+
+            # Deliver to Slack via OAuth channel mappings (independent of rules)
+            if not slack_delivered_via_rule and first_notification_id is not None:
+                await self._deliver_slack(
+                    session,
+                    org_id,
+                    event_type,
+                    first_notification_id,
+                    title,
+                    message,
+                    severity,
+                )
 
             await session.commit()
 

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -11,6 +11,8 @@ from app.models.notification import (
     NotificationDeliveryLog,
     NotificationPreference,
     NotificationRule,
+    SlackChannelMapping,
+    SlackInstallation,
     SlackWebhook,
 )
 from app.services.notification_channels.email_adapter import EmailChannel
@@ -260,6 +262,48 @@ class NotificationService:
                 return {"channel": "email", "status": "failed", "detail": "SMTP not configured"}
             return {"channel": "email", "status": "configured", "detail": "SMTP is configured"}
         elif channel == "slack":
+            # Try OAuth installation first
+            install_result = await session.execute(
+                select(SlackInstallation).where(
+                    SlackInstallation.organization_id == org_id,
+                    SlackInstallation.enabled == True,  # noqa: E712
+                )
+            )
+            install = install_result.scalar_one_or_none()
+
+            if install:
+                mappings_result = await session.execute(
+                    select(SlackChannelMapping).where(
+                        SlackChannelMapping.organization_id == org_id,
+                        SlackChannelMapping.enabled == True,  # noqa: E712
+                    )
+                )
+                mappings = list(mappings_result.scalars().all())
+                if not mappings:
+                    return {
+                        "channel": "slack",
+                        "status": "failed",
+                        "detail": "Slack connected but no channel mappings configured",
+                    }
+
+                results = []
+                for mapping in mappings:
+                    success = await SlackChannel.deliver(
+                        bot_token=install.bot_token,
+                        channel_id=mapping.channel_id,
+                        title=title,
+                        message=message,
+                        severity=severity,
+                    )
+                    results.append(
+                        {
+                            "webhook": mapping.channel_name,
+                            "status": "sent" if success else "failed",
+                        }
+                    )
+                return {"channel": "slack", "status": "sent", "webhooks": results}
+
+            # Fallback to legacy webhooks
             webhooks_result = await session.execute(
                 select(SlackWebhook).where(
                     SlackWebhook.organization_id == org_id,
@@ -268,11 +312,11 @@ class NotificationService:
             )
             webhooks = list(webhooks_result.scalars().all())
             if not webhooks:
-                return {"channel": "slack", "status": "failed", "detail": "No Slack webhooks configured"}
+                return {"channel": "slack", "status": "failed", "detail": "Slack not connected"}
 
             results = []
             for webhook in webhooks:
-                success = await SlackChannel.deliver(
+                success = await SlackChannel.deliver_webhook(
                     webhook_url=webhook.webhook_url,
                     title=title,
                     message=message,

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -20,6 +20,19 @@ from app.services.notification_channels.slack_adapter import SlackChannel
 
 logger = logging.getLogger("bioaf.notification_service")
 
+SLACK_ERROR_MESSAGES = {
+    "not_in_channel": (
+        'The bioAF app is not in this channel. Open the channel in Slack and type "@bioAF" to invite it.'
+    ),
+    "channel_not_found": ("This channel no longer exists in Slack. Remove this mapping and add the correct channel."),
+    "invalid_auth": (
+        "The Slack connection is no longer valid. Disconnect and reconnect from the Slack Integration page."
+    ),
+    "token_revoked": (
+        "The Slack connection has been revoked. Disconnect and reconnect from the Slack Integration page."
+    ),
+}
+
 
 class NotificationService:
     # ---- Notifications CRUD ----
@@ -287,21 +300,32 @@ class NotificationService:
                     }
 
                 results = []
+                any_sent = False
                 for mapping in mappings:
-                    success = await SlackChannel.deliver(
+                    success, error_code = await SlackChannel.deliver(
                         bot_token=install.bot_token,
                         channel_id=mapping.channel_id,
                         title=title,
                         message=message,
                         severity=severity,
                     )
+                    if success:
+                        any_sent = True
+                    detail = ""
+                    if not success:
+                        detail = SLACK_ERROR_MESSAGES.get(error_code, f"Delivery failed ({error_code})")
                     results.append(
                         {
                             "webhook": mapping.channel_name,
                             "status": "sent" if success else "failed",
+                            "detail": detail,
                         }
                     )
-                return {"channel": "slack", "status": "sent", "webhooks": results}
+                return {
+                    "channel": "slack",
+                    "status": "sent" if any_sent else "failed",
+                    "webhooks": results,
+                }
 
             # Fallback to legacy webhooks
             webhooks_result = await session.execute(

--- a/backend/app/services/slack_oauth_service.py
+++ b/backend/app/services/slack_oauth_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.models.notification import SlackChannelMapping, SlackInstallation
+from app.models.organization import Organization
 from app.models.user import User
 
 logger = logging.getLogger("bioaf.slack_oauth")
@@ -22,7 +23,7 @@ SLACK_SCOPES = "chat:write,channels:read,groups:read"
 
 class SlackOAuthService:
     @staticmethod
-    def build_auth_url(org_id: int, user_id: int) -> str:
+    def build_auth_url(org_id: int, user_id: int, client_id_override: str = "") -> str:
         """Build the Slack OAuth authorization URL with signed state."""
         state = jwt.encode(
             {"org_id": org_id, "user_id": user_id},
@@ -30,7 +31,7 @@ class SlackOAuthService:
             algorithm=settings.jwt_algorithm,
         )
         params = {
-            "client_id": settings.slack_client_id,
+            "client_id": client_id_override or settings.slack_client_id,
             "scope": SLACK_SCOPES,
             "state": state,
         }
@@ -49,14 +50,18 @@ class SlackOAuthService:
             raise ValueError(f"Invalid state token: {e}") from e
 
     @staticmethod
-    async def exchange_code(code: str) -> dict:
+    async def exchange_code(
+        code: str,
+        client_id: str = "",
+        client_secret: str = "",
+    ) -> dict:
         """Exchange an authorization code for a bot token."""
         async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 SLACK_TOKEN_URL,
                 data={
-                    "client_id": settings.slack_client_id,
-                    "client_secret": settings.slack_client_secret,
+                    "client_id": client_id or settings.slack_client_id,
+                    "client_secret": client_secret or settings.slack_client_secret,
                     "code": code,
                 },
             )
@@ -66,6 +71,15 @@ class SlackOAuthService:
             logger.error("Slack token exchange failed: %s", error)
             raise ValueError(f"Slack OAuth error: {error}")
         return data
+
+    @staticmethod
+    async def get_org_credentials(session: AsyncSession, org_id: int) -> tuple[str, str]:
+        """Return (client_id, client_secret) from org DB or env var fallback."""
+        result = await session.execute(select(Organization).where(Organization.id == org_id))
+        org = result.scalar_one_or_none()
+        if org and org.slack_client_id and org.slack_client_secret:
+            return org.slack_client_id, org.slack_client_secret
+        return settings.slack_client_id, settings.slack_client_secret
 
     @staticmethod
     async def save_installation(
@@ -213,7 +227,8 @@ class SlackOAuthService:
     @staticmethod
     async def get_status(session: AsyncSession, org_id: int) -> dict:
         """Get the current Slack connection status for an org."""
-        configured = bool(settings.slack_client_id and settings.slack_client_secret)
+        client_id, client_secret = await SlackOAuthService.get_org_credentials(session, org_id)
+        configured = bool(client_id and client_secret)
         install = await SlackOAuthService.get_installation(session, org_id)
         if not install:
             return {

--- a/backend/app/services/slack_oauth_service.py
+++ b/backend/app/services/slack_oauth_service.py
@@ -1,0 +1,246 @@
+"""Slack OAuth service - token exchange, channel listing, installation management."""
+
+import logging
+from urllib.parse import urlencode
+
+import httpx
+from jose import JWTError, jwt
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models.notification import SlackChannelMapping, SlackInstallation
+from app.models.user import User
+
+logger = logging.getLogger("bioaf.slack_oauth")
+
+SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize"
+SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
+SLACK_CONVERSATIONS_URL = "https://slack.com/api/conversations.list"
+SLACK_SCOPES = "chat:write,channels:read,groups:read"
+
+
+class SlackOAuthService:
+    @staticmethod
+    def build_auth_url(org_id: int, user_id: int) -> str:
+        """Build the Slack OAuth authorization URL with signed state."""
+        state = jwt.encode(
+            {"org_id": org_id, "user_id": user_id},
+            settings.jwt_secret_key,
+            algorithm=settings.jwt_algorithm,
+        )
+        params = {
+            "client_id": settings.slack_client_id,
+            "scope": SLACK_SCOPES,
+            "state": state,
+        }
+        return f"{SLACK_OAUTH_URL}?{urlencode(params)}"
+
+    @staticmethod
+    def decode_state(state: str) -> dict:
+        """Decode and verify the signed state token."""
+        try:
+            return jwt.decode(
+                state,
+                settings.jwt_secret_key,
+                algorithms=[settings.jwt_algorithm],
+            )
+        except JWTError as e:
+            raise ValueError(f"Invalid state token: {e}") from e
+
+    @staticmethod
+    async def exchange_code(code: str) -> dict:
+        """Exchange an authorization code for a bot token."""
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(
+                SLACK_TOKEN_URL,
+                data={
+                    "client_id": settings.slack_client_id,
+                    "client_secret": settings.slack_client_secret,
+                    "code": code,
+                },
+            )
+        data = response.json()
+        if not data.get("ok"):
+            error = data.get("error", "unknown_error")
+            logger.error("Slack token exchange failed: %s", error)
+            raise ValueError(f"Slack OAuth error: {error}")
+        return data
+
+    @staticmethod
+    async def save_installation(
+        session: AsyncSession,
+        org_id: int,
+        user_id: int,
+        token_data: dict,
+    ) -> SlackInstallation:
+        """Store or replace the Slack installation for an org."""
+        # Remove existing installation if any
+        await session.execute(
+            delete(SlackInstallation).where(SlackInstallation.organization_id == org_id)
+        )
+
+        install = SlackInstallation(
+            organization_id=org_id,
+            team_id=token_data["team"]["id"],
+            team_name=token_data["team"]["name"],
+            bot_token=token_data["access_token"],
+            bot_user_id=token_data.get("bot_user_id", ""),
+            authed_user_id=token_data.get("authed_user", {}).get("id"),
+            installed_by=user_id,
+        )
+        session.add(install)
+        await session.flush()
+        return install
+
+    @staticmethod
+    async def get_installation(session: AsyncSession, org_id: int) -> SlackInstallation | None:
+        result = await session.execute(
+            select(SlackInstallation).where(SlackInstallation.organization_id == org_id)
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def disconnect(session: AsyncSession, org_id: int) -> bool:
+        """Remove installation and all channel mappings for an org."""
+        install = await SlackOAuthService.get_installation(session, org_id)
+        if not install:
+            return False
+
+        await session.execute(
+            delete(SlackChannelMapping).where(SlackChannelMapping.organization_id == org_id)
+        )
+        await session.delete(install)
+        await session.flush()
+        return True
+
+    @staticmethod
+    async def list_channels(session: AsyncSession, org_id: int) -> list[dict]:
+        """Fetch channels from Slack using the stored bot token."""
+        install = await SlackOAuthService.get_installation(session, org_id)
+        if not install:
+            return []
+
+        channels: list[dict] = []
+        cursor = None
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            while True:
+                params: dict[str, str | int] = {
+                    "types": "public_channel,private_channel",
+                    "exclude_archived": "true",
+                    "limit": 200,
+                }
+                if cursor:
+                    params["cursor"] = cursor
+
+                response = await client.get(
+                    SLACK_CONVERSATIONS_URL,
+                    params=params,
+                    headers={"Authorization": f"Bearer {install.bot_token}"},
+                )
+                data = response.json()
+                if not data.get("ok"):
+                    logger.warning("Slack conversations.list failed: %s", data.get("error"))
+                    break
+
+                for ch in data.get("channels", []):
+                    channels.append({
+                        "id": ch["id"],
+                        "name": ch["name"],
+                        "is_private": ch.get("is_private", False),
+                    })
+
+                cursor = data.get("response_metadata", {}).get("next_cursor")
+                if not cursor:
+                    break
+
+        return channels
+
+    # ---- Channel mapping CRUD ----
+
+    @staticmethod
+    async def list_channel_mappings(session: AsyncSession, org_id: int) -> list[SlackChannelMapping]:
+        result = await session.execute(
+            select(SlackChannelMapping).where(SlackChannelMapping.organization_id == org_id)
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def create_channel_mapping(
+        session: AsyncSession, org_id: int, data: dict
+    ) -> SlackChannelMapping:
+        mapping = SlackChannelMapping(
+            organization_id=org_id,
+            channel_id=data["channel_id"],
+            channel_name=data["channel_name"],
+            event_types_json=data.get("event_types", []),
+            enabled=data.get("enabled", True),
+        )
+        session.add(mapping)
+        await session.flush()
+        return mapping
+
+    @staticmethod
+    async def update_channel_mapping(
+        session: AsyncSession, mapping_id: int, org_id: int, data: dict
+    ) -> SlackChannelMapping | None:
+        result = await session.execute(
+            select(SlackChannelMapping).where(
+                SlackChannelMapping.id == mapping_id,
+                SlackChannelMapping.organization_id == org_id,
+            )
+        )
+        mapping = result.scalar_one_or_none()
+        if not mapping:
+            return None
+
+        if "event_types" in data:
+            mapping.event_types_json = data["event_types"]
+        if "enabled" in data:
+            mapping.enabled = data["enabled"]
+
+        await session.flush()
+        return mapping
+
+    @staticmethod
+    async def delete_channel_mapping(session: AsyncSession, mapping_id: int, org_id: int) -> bool:
+        result = await session.execute(
+            select(SlackChannelMapping).where(
+                SlackChannelMapping.id == mapping_id,
+                SlackChannelMapping.organization_id == org_id,
+            )
+        )
+        mapping = result.scalar_one_or_none()
+        if mapping:
+            await session.delete(mapping)
+            await session.flush()
+            return True
+        return False
+
+    @staticmethod
+    async def get_status(session: AsyncSession, org_id: int) -> dict:
+        """Get the current Slack connection status for an org."""
+        install = await SlackOAuthService.get_installation(session, org_id)
+        if not install:
+            return {
+                "connected": False,
+                "team_name": None,
+                "team_id": None,
+                "installed_by": None,
+                "installed_at": None,
+                "enabled": False,
+            }
+
+        # Look up installer email
+        result = await session.execute(select(User.email).where(User.id == install.installed_by))
+        installer_email = result.scalar_one_or_none()
+
+        return {
+            "connected": True,
+            "team_name": install.team_name,
+            "team_id": install.team_id,
+            "installed_by": installer_email,
+            "installed_at": install.created_at,
+            "enabled": install.enabled,
+        }

--- a/backend/app/services/slack_oauth_service.py
+++ b/backend/app/services/slack_oauth_service.py
@@ -213,9 +213,11 @@ class SlackOAuthService:
     @staticmethod
     async def get_status(session: AsyncSession, org_id: int) -> dict:
         """Get the current Slack connection status for an org."""
+        configured = bool(settings.slack_client_id and settings.slack_client_secret)
         install = await SlackOAuthService.get_installation(session, org_id)
         if not install:
             return {
+                "configured": configured,
                 "connected": False,
                 "team_name": None,
                 "team_id": None,
@@ -229,6 +231,7 @@ class SlackOAuthService:
         installer_email = result.scalar_one_or_none()
 
         return {
+            "configured": configured,
             "connected": True,
             "team_name": install.team_name,
             "team_id": install.team_id,

--- a/backend/app/services/slack_oauth_service.py
+++ b/backend/app/services/slack_oauth_service.py
@@ -76,9 +76,7 @@ class SlackOAuthService:
     ) -> SlackInstallation:
         """Store or replace the Slack installation for an org."""
         # Remove existing installation if any
-        await session.execute(
-            delete(SlackInstallation).where(SlackInstallation.organization_id == org_id)
-        )
+        await session.execute(delete(SlackInstallation).where(SlackInstallation.organization_id == org_id))
 
         install = SlackInstallation(
             organization_id=org_id,
@@ -95,9 +93,7 @@ class SlackOAuthService:
 
     @staticmethod
     async def get_installation(session: AsyncSession, org_id: int) -> SlackInstallation | None:
-        result = await session.execute(
-            select(SlackInstallation).where(SlackInstallation.organization_id == org_id)
-        )
+        result = await session.execute(select(SlackInstallation).where(SlackInstallation.organization_id == org_id))
         return result.scalar_one_or_none()
 
     @staticmethod
@@ -107,9 +103,7 @@ class SlackOAuthService:
         if not install:
             return False
 
-        await session.execute(
-            delete(SlackChannelMapping).where(SlackChannelMapping.organization_id == org_id)
-        )
+        await session.execute(delete(SlackChannelMapping).where(SlackChannelMapping.organization_id == org_id))
         await session.delete(install)
         await session.flush()
         return True
@@ -145,11 +139,13 @@ class SlackOAuthService:
                     break
 
                 for ch in data.get("channels", []):
-                    channels.append({
-                        "id": ch["id"],
-                        "name": ch["name"],
-                        "is_private": ch.get("is_private", False),
-                    })
+                    channels.append(
+                        {
+                            "id": ch["id"],
+                            "name": ch["name"],
+                            "is_private": ch.get("is_private", False),
+                        }
+                    )
 
                 cursor = data.get("response_metadata", {}).get("next_cursor")
                 if not cursor:
@@ -161,15 +157,11 @@ class SlackOAuthService:
 
     @staticmethod
     async def list_channel_mappings(session: AsyncSession, org_id: int) -> list[SlackChannelMapping]:
-        result = await session.execute(
-            select(SlackChannelMapping).where(SlackChannelMapping.organization_id == org_id)
-        )
+        result = await session.execute(select(SlackChannelMapping).where(SlackChannelMapping.organization_id == org_id))
         return list(result.scalars().all())
 
     @staticmethod
-    async def create_channel_mapping(
-        session: AsyncSession, org_id: int, data: dict
-    ) -> SlackChannelMapping:
+    async def create_channel_mapping(session: AsyncSession, org_id: int, data: dict) -> SlackChannelMapping:
         mapping = SlackChannelMapping(
             organization_id=org_id,
             channel_id=data["channel_id"],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.0"
+version = "0.3.1"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_slack_oauth.py
+++ b/backend/tests/test_slack_oauth.py
@@ -48,7 +48,7 @@ async def test_slack_auth_url_missing_client_id(client: AsyncClient, admin_token
             headers={"Authorization": f"Bearer {admin_token}"},
         )
     assert response.status_code == 400
-    assert "not configured" in response.json()["detail"].lower()
+    assert "not" in response.json()["detail"].lower()
 
 
 # ---- Status ----

--- a/backend/tests/test_slack_oauth.py
+++ b/backend/tests/test_slack_oauth.py
@@ -376,7 +376,7 @@ async def test_slack_adapter_chat_post_message():
         mock_client.post.return_value = mock_response
         mock_client_cls.return_value = mock_client
 
-        result = await SlackChannel.deliver(
+        success, error_code = await SlackChannel.deliver(
             bot_token="xoxb-test-token",
             channel_id="C001",
             title="Pipeline Complete",
@@ -384,7 +384,8 @@ async def test_slack_adapter_chat_post_message():
             severity="info",
         )
 
-    assert result is True
+    assert success is True
+    assert error_code == ""
     call_kwargs = mock_client.post.call_args
     assert "chat.postMessage" in str(call_kwargs)
 

--- a/backend/tests/test_slack_oauth.py
+++ b/backend/tests/test_slack_oauth.py
@@ -119,7 +119,9 @@ async def test_slack_callback_exchanges_code(client: AsyncClient, admin_token: s
         "authed_user": {"id": "UAUTH99"},
     }
 
-    with patch("app.services.slack_oauth_service.SlackOAuthService.exchange_code", new_callable=AsyncMock) as mock_exchange:
+    with patch(
+        "app.services.slack_oauth_service.SlackOAuthService.exchange_code", new_callable=AsyncMock
+    ) as mock_exchange:
         mock_exchange.return_value = token_data
 
         response = await client.get(

--- a/backend/tests/test_slack_oauth.py
+++ b/backend/tests/test_slack_oauth.py
@@ -126,12 +126,12 @@ async def test_slack_callback_exchanges_code(client: AsyncClient, admin_token: s
 
         response = await client.get(
             f"/api/notifications/slack/callback?code=test-code&state={state}",
+            follow_redirects=False,
         )
 
-    assert response.status_code == 200
-    data = response.json()
-    assert data["status"] == "connected"
-    assert data["team_name"] == "New Workspace"
+    # Callback redirects browser back to the Slack settings page
+    assert response.status_code == 307
+    assert "/settings/slack?connected=true" in response.headers["location"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_slack_oauth.py
+++ b/backend/tests/test_slack_oauth.py
@@ -1,0 +1,461 @@
+"""Tests for Slack OAuth integration: auth URL, callback, status, disconnect, channels, mappings."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+# ---- Auth URL ----
+
+
+@pytest.mark.asyncio
+async def test_slack_auth_url_returns_url(client: AsyncClient, admin_token: str):
+    """Auth URL endpoint returns a valid Slack OAuth URL."""
+    with (
+        patch("app.api.slack_oauth.settings") as api_settings,
+        patch("app.services.slack_oauth_service.settings") as svc_settings,
+    ):
+        for s in (api_settings, svc_settings):
+            s.slack_client_id = "test-client-id"
+            s.slack_client_secret = "test-secret"
+            s.jwt_secret_key = "dev-secret-key-change-in-production"
+            s.jwt_algorithm = "HS256"
+
+        response = await client.get(
+            "/api/notifications/slack/auth-url",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert "auth_url" in data
+    assert "https://slack.com/oauth/v2/authorize" in data["auth_url"]
+    assert "client_id=test-client-id" in data["auth_url"]
+    # Scopes are URL-encoded (colons become %3A)
+    assert "chat" in data["auth_url"]
+    assert "channels" in data["auth_url"]
+
+
+@pytest.mark.asyncio
+async def test_slack_auth_url_missing_client_id(client: AsyncClient, admin_token: str):
+    """Auth URL returns 400 when Slack client ID is not configured."""
+    with patch("app.api.slack_oauth.settings") as mock_settings:
+        mock_settings.slack_client_id = ""
+        mock_settings.slack_client_secret = ""
+
+        response = await client.get(
+            "/api/notifications/slack/auth-url",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 400
+    assert "not configured" in response.json()["detail"].lower()
+
+
+# ---- Status ----
+
+
+@pytest.mark.asyncio
+async def test_slack_status_not_connected(client: AsyncClient, admin_token: str):
+    """Status returns connected=false when no installation exists."""
+    response = await client.get(
+        "/api/notifications/slack/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["connected"] is False
+    assert data["team_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_slack_status_connected(client: AsyncClient, admin_token: str, admin_user, session):
+    """Status returns connected=true with team info when installation exists."""
+    from app.models.notification import SlackInstallation
+
+    install = SlackInstallation(
+        organization_id=admin_user.organization_id,
+        team_id="T12345",
+        team_name="Test Workspace",
+        bot_token="xoxb-test-token",
+        bot_user_id="U12345",
+        installed_by=admin_user.id,
+    )
+    session.add(install)
+    await session.flush()
+    await session.commit()
+
+    response = await client.get(
+        "/api/notifications/slack/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["connected"] is True
+    assert data["team_name"] == "Test Workspace"
+    assert data["team_id"] == "T12345"
+    assert data["enabled"] is True
+
+
+# ---- OAuth callback ----
+
+
+@pytest.mark.asyncio
+async def test_slack_callback_exchanges_code(client: AsyncClient, admin_token: str, admin_user):
+    """Callback exchanges auth code for token and stores installation."""
+    from jose import jwt as jose_jwt
+    from app.config import settings
+
+    state = jose_jwt.encode(
+        {"org_id": admin_user.organization_id, "user_id": admin_user.id},
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
+
+    token_data = {
+        "ok": True,
+        "access_token": "xoxb-new-bot-token",
+        "team": {"id": "T99999", "name": "New Workspace"},
+        "bot_user_id": "UBOT99",
+        "authed_user": {"id": "UAUTH99"},
+    }
+
+    with patch("app.services.slack_oauth_service.SlackOAuthService.exchange_code", new_callable=AsyncMock) as mock_exchange:
+        mock_exchange.return_value = token_data
+
+        response = await client.get(
+            f"/api/notifications/slack/callback?code=test-code&state={state}",
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "connected"
+    assert data["team_name"] == "New Workspace"
+
+
+@pytest.mark.asyncio
+async def test_slack_callback_invalid_state(client: AsyncClient):
+    """Callback rejects invalid state token."""
+    response = await client.get(
+        "/api/notifications/slack/callback?code=test-code&state=bad-state",
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_slack_callback_missing_code(client: AsyncClient):
+    """Callback rejects missing code parameter."""
+    response = await client.get(
+        "/api/notifications/slack/callback?state=something",
+    )
+    assert response.status_code == 422 or response.status_code == 400
+
+
+# ---- Disconnect ----
+
+
+@pytest.mark.asyncio
+async def test_slack_disconnect(client: AsyncClient, admin_token: str, admin_user, session):
+    """Disconnect removes the Slack installation and channel mappings."""
+    from app.models.notification import SlackInstallation, SlackChannelMapping
+
+    install = SlackInstallation(
+        organization_id=admin_user.organization_id,
+        team_id="T12345",
+        team_name="Test Workspace",
+        bot_token="xoxb-test-token",
+        bot_user_id="U12345",
+        installed_by=admin_user.id,
+    )
+    session.add(install)
+
+    mapping = SlackChannelMapping(
+        organization_id=admin_user.organization_id,
+        channel_id="C12345",
+        channel_name="#general",
+    )
+    session.add(mapping)
+    await session.flush()
+    await session.commit()
+
+    response = await client.delete(
+        "/api/notifications/slack/disconnect",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["disconnected"] is True
+
+    # Verify status is now disconnected
+    response = await client.get(
+        "/api/notifications/slack/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.json()["connected"] is False
+
+
+@pytest.mark.asyncio
+async def test_slack_disconnect_not_connected(client: AsyncClient, admin_token: str):
+    """Disconnect returns 404 when no installation exists."""
+    response = await client.delete(
+        "/api/notifications/slack/disconnect",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+
+# ---- Channel listing ----
+
+
+@pytest.mark.asyncio
+async def test_slack_list_channels(client: AsyncClient, admin_token: str, admin_user, session):
+    """List channels returns Slack channels from the workspace."""
+    from app.models.notification import SlackInstallation
+
+    install = SlackInstallation(
+        organization_id=admin_user.organization_id,
+        team_id="T12345",
+        team_name="Test Workspace",
+        bot_token="xoxb-test-token",
+        bot_user_id="U12345",
+        installed_by=admin_user.id,
+    )
+    session.add(install)
+    await session.flush()
+    await session.commit()
+
+    mock_channels = [
+        {"id": "C001", "name": "general", "is_private": False},
+        {"id": "C002", "name": "comp-bio", "is_private": False},
+        {"id": "C003", "name": "alerts", "is_private": True},
+    ]
+
+    with patch(
+        "app.services.slack_oauth_service.SlackOAuthService.list_channels",
+        new_callable=AsyncMock,
+        return_value=mock_channels,
+    ):
+        response = await client.get(
+            "/api/notifications/slack/channels",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    channels = response.json()
+    assert len(channels) == 3
+    assert channels[0]["name"] == "general"
+    assert channels[2]["is_private"] is True
+
+
+@pytest.mark.asyncio
+async def test_slack_list_channels_not_connected(client: AsyncClient, admin_token: str):
+    """List channels returns 404 when not connected."""
+    response = await client.get(
+        "/api/notifications/slack/channels",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+
+# ---- Channel mappings CRUD ----
+
+
+@pytest.mark.asyncio
+async def test_slack_channel_mapping_crud(client: AsyncClient, admin_token: str, admin_user, session):
+    """Full CRUD cycle for channel mappings."""
+    from app.models.notification import SlackInstallation
+
+    install = SlackInstallation(
+        organization_id=admin_user.organization_id,
+        team_id="T12345",
+        team_name="Test Workspace",
+        bot_token="xoxb-test-token",
+        bot_user_id="U12345",
+        installed_by=admin_user.id,
+    )
+    session.add(install)
+    await session.flush()
+    await session.commit()
+
+    # Create
+    response = await client.post(
+        "/api/notifications/slack/channel-mappings",
+        json={
+            "channel_id": "C001",
+            "channel_name": "#comp-bio",
+            "event_types": ["pipeline.completed", "pipeline.failed"],
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    mapping_id = response.json()["id"]
+    assert response.json()["channel_name"] == "#comp-bio"
+    assert len(response.json()["event_types_json"]) == 2
+
+    # List
+    response = await client.get(
+        "/api/notifications/slack/channel-mappings",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+    # Update
+    response = await client.put(
+        f"/api/notifications/slack/channel-mappings/{mapping_id}",
+        json={"event_types": ["pipeline.completed"]},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert len(response.json()["event_types_json"]) == 1
+
+    # Delete
+    response = await client.delete(
+        f"/api/notifications/slack/channel-mappings/{mapping_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["deleted"] is True
+
+    # Verify empty
+    response = await client.get(
+        "/api/notifications/slack/channel-mappings",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert len(response.json()) == 0
+
+
+@pytest.mark.asyncio
+async def test_slack_channel_mapping_not_connected(client: AsyncClient, admin_token: str):
+    """Channel mapping creation fails when not connected."""
+    response = await client.post(
+        "/api/notifications/slack/channel-mappings",
+        json={"channel_id": "C001", "channel_name": "#test"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+
+# ---- Viewer forbidden ----
+
+
+@pytest.mark.asyncio
+async def test_slack_endpoints_forbidden_for_viewer(client: AsyncClient, viewer_token: str):
+    """Viewer role cannot access Slack configuration endpoints."""
+    endpoints = [
+        ("GET", "/api/notifications/slack/auth-url"),
+        ("GET", "/api/notifications/slack/channels"),
+        ("DELETE", "/api/notifications/slack/disconnect"),
+        ("POST", "/api/notifications/slack/channel-mappings"),
+    ]
+    for method, url in endpoints:
+        if method == "GET":
+            response = await client.get(url, headers={"Authorization": f"Bearer {viewer_token}"})
+        elif method == "DELETE":
+            response = await client.delete(url, headers={"Authorization": f"Bearer {viewer_token}"})
+        else:
+            response = await client.post(url, json={}, headers={"Authorization": f"Bearer {viewer_token}"})
+        assert response.status_code == 403, f"{method} {url} should be forbidden for viewer"
+
+
+# ---- Slack adapter with bot token ----
+
+
+@pytest.mark.asyncio
+async def test_slack_adapter_chat_post_message():
+    """SlackChannel.deliver posts via chat.postMessage API."""
+    from app.services.notification_channels.slack_adapter import SlackChannel
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"ok": True}
+
+    with patch("app.services.notification_channels.slack_adapter.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = await SlackChannel.deliver(
+            bot_token="xoxb-test-token",
+            channel_id="C001",
+            title="Pipeline Complete",
+            message="nf-core/rnaseq finished successfully",
+            severity="info",
+        )
+
+    assert result is True
+    call_kwargs = mock_client.post.call_args
+    assert "chat.postMessage" in str(call_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_slack_adapter_webhook_fallback():
+    """SlackChannel.deliver_webhook still works for legacy webhook URLs."""
+    from app.services.notification_channels.slack_adapter import SlackChannel
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("app.services.notification_channels.slack_adapter.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = await SlackChannel.deliver_webhook(
+            webhook_url="https://hooks.slack.com/services/T00/B00/xxx",
+            title="Test",
+            message="Test message",
+            severity="info",
+        )
+
+    assert result is True
+
+
+# ---- Test delivery uses new OAuth path ----
+
+
+@pytest.mark.asyncio
+async def test_test_delivery_slack_oauth(client: AsyncClient, admin_token: str, admin_user, session):
+    """Test delivery uses OAuth installation when available."""
+    from app.models.notification import SlackInstallation, SlackChannelMapping
+
+    install = SlackInstallation(
+        organization_id=admin_user.organization_id,
+        team_id="T12345",
+        team_name="Test Workspace",
+        bot_token="xoxb-test-token",
+        bot_user_id="U12345",
+        installed_by=admin_user.id,
+    )
+    session.add(install)
+
+    mapping = SlackChannelMapping(
+        organization_id=admin_user.organization_id,
+        channel_id="C001",
+        channel_name="#alerts",
+    )
+    session.add(mapping)
+    await session.flush()
+    await session.commit()
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"ok": True}
+
+    with patch("app.services.notification_channels.slack_adapter.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        response = await client.post(
+            "/api/notifications/test",
+            json={"channel": "slack"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["channel"] == "slack"
+    assert data["status"] == "sent"

--- a/docs/user-guide-admin.md
+++ b/docs/user-guide-admin.md
@@ -57,14 +57,16 @@ Navigate to **Infrastructure > Backup & Recovery**:
 
 ## Notifications
 
-### Slack Webhooks (Settings)
+### Slack Integration (Settings)
 
-1. Go to **Settings**
-2. Under Slack Webhooks, add a webhook:
-   - Name (e.g., "Alerts Channel")
-   - Webhook URL from Slack
-   - Channel name
-3. Test with the "Test Slack" button
+1. Go to **Settings > Slack Integration**
+2. Click **Generate Slack App Manifest** and copy the JSON
+3. Go to [api.slack.com/apps](https://api.slack.com/apps), click **Create New App > From a manifest**, paste the JSON
+4. Copy the Client ID, Client Secret, and Signing Secret from the app's Basic Information page
+5. Paste them into the credentials form in bioAF and click **Save Credentials**
+6. Click **Add to Slack** and approve the app for your workspace
+7. Add channel mappings to choose which channels receive which event types
+8. Click **Test Channel Mappings** to verify delivery
 
 ### Notification Rules
 
@@ -104,7 +106,7 @@ Navigate to **Settings > Audit Log**:
 The **Settings** page centralizes:
 
 - SMTP configuration
-- Slack webhook management
+- Slack integration (OAuth setup, channel mappings)
 - Platform version and upgrades
 - Test notification delivery
 
@@ -112,5 +114,5 @@ The **Settings** page centralizes:
 
 - The **Dashboard** shows admin-specific metrics: cost summary, system health, experiment counts
 - Use **Activity Feed** to monitor team activity
-- Set up Slack webhooks early for real-time alerts
+- Set up Slack integration early for real-time alerts
 - Review access logs periodically for security compliance

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -8,13 +8,9 @@ import { isAuthenticated } from "@/lib/auth";
 import { usePermissions } from "@/hooks/usePermissions";
 import { api } from "@/lib/api";
 
-interface SlackWebhook {
-  id: number;
-  name: string;
-  webhook_url: string;
-  channel_name: string | null;
-  event_types_json: string[];
-  enabled: boolean;
+interface SlackStatus {
+  connected: boolean;
+  team_name: string | null;
 }
 
 interface UpdateCheck {
@@ -48,11 +44,8 @@ export default function SettingsPage() {
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
 
-  // Slack webhooks
-  const [webhooks, setWebhooks] = useState<SlackWebhook[]>([]);
-  const [newWebhookName, setNewWebhookName] = useState("");
-  const [newWebhookUrl, setNewWebhookUrl] = useState("");
-  const [newWebhookChannel, setNewWebhookChannel] = useState("");
+  // Slack status
+  const [slackStatus, setSlackStatus] = useState<SlackStatus | null>(null);
 
   // Upgrade system
   const [updateCheck, setUpdateCheck] = useState<UpdateCheck | null>(null);
@@ -66,13 +59,13 @@ export default function SettingsPage() {
 
     const load = async () => {
       try {
-        const [wh, version, history, smtp] = await Promise.all([
-          api.get<SlackWebhook[]>("/api/notifications/slack-webhooks"),
+        const [slack, version, history, smtp] = await Promise.all([
+          api.get<SlackStatus>("/api/notifications/slack/status"),
           api.get<UpdateCheck>("/api/upgrades/check"),
           api.get<{ upgrades: UpgradeHistoryItem[] }>("/api/upgrades/history"),
           api.get<{ host: string; port: number; username: string; password?: string; from_address: string; encryption: string }>("/api/bootstrap/smtp-settings"),
         ]);
-        setWebhooks(wh);
+        setSlackStatus(slack);
         setUpdateCheck(version);
         setUpgradeHistory(history.upgrades);
         if (smtp.host) {
@@ -107,33 +100,6 @@ export default function SettingsPage() {
       setMessage("SMTP configuration saved");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to save SMTP settings");
-    }
-  };
-
-  const handleAddWebhook = async () => {
-    if (!newWebhookName || !newWebhookUrl) return;
-    try {
-      const wh = await api.post<SlackWebhook>("/api/notifications/slack-webhooks", {
-        name: newWebhookName,
-        webhook_url: newWebhookUrl,
-        channel_name: newWebhookChannel || null,
-        event_types: [],
-      });
-      setWebhooks([...webhooks, wh]);
-      setNewWebhookName("");
-      setNewWebhookUrl("");
-      setNewWebhookChannel("");
-    } catch {
-      setError("Failed to add webhook");
-    }
-  };
-
-  const handleDeleteWebhook = async (id: number) => {
-    try {
-      await api.delete(`/api/notifications/slack-webhooks/${id}`);
-      setWebhooks(webhooks.filter((w) => w.id !== id));
-    } catch {
-      setError("Failed to delete webhook");
     }
   };
 
@@ -235,71 +201,23 @@ export default function SettingsPage() {
             </div>
           </div>
 
-          {/* Slack Webhook Management */}
+          {/* Slack Integration */}
           <div className="bg-white rounded-lg shadow p-6 mb-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">Slack Webhooks</h2>
-              <button
-                onClick={() => handleTestNotification("slack")}
+              <h2 className="text-lg font-semibold">Slack Integration</h2>
+              <a
+                href="/settings/slack"
                 className="text-sm text-bioaf-600 hover:text-bioaf-700"
               >
-                Test Slack
-              </button>
+                Manage
+              </a>
             </div>
-
-            {webhooks.length > 0 && (
-              <div className="mb-4 space-y-2">
-                {webhooks.map((wh) => (
-                  <div key={wh.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
-                    <div>
-                      <span className="font-medium text-sm">{wh.name}</span>
-                      {wh.channel_name && (
-                        <span className="ml-2 text-xs text-gray-500">{wh.channel_name}</span>
-                      )}
-                    </div>
-                    <button
-                      onClick={() => handleDeleteWebhook(wh.id)}
-                      className="text-xs text-red-500 hover:text-red-700"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <div className="grid grid-cols-3 gap-3">
-              <input
-                type="text"
-                placeholder="Webhook name"
-                value={newWebhookName}
-                onChange={(e) => setNewWebhookName(e.target.value)}
-                className="px-3 py-2 border rounded text-sm"
-              />
-              <input
-                type="url"
-                placeholder="https://hooks.slack.com/..."
-                value={newWebhookUrl}
-                onChange={(e) => setNewWebhookUrl(e.target.value)}
-                className="px-3 py-2 border rounded text-sm"
-              />
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  placeholder="#channel"
-                  value={newWebhookChannel}
-                  onChange={(e) => setNewWebhookChannel(e.target.value)}
-                  className="flex-1 px-3 py-2 border rounded text-sm"
-                />
-                <button
-                  onClick={handleAddWebhook}
-                  className="px-3 py-2 bg-bioaf-600 text-white rounded text-sm hover:bg-bioaf-700"
-                >
-                  Add
-                </button>
-              </div>
+            <div className="flex items-center gap-3">
+              <div className={`w-3 h-3 rounded-full ${slackStatus?.connected ? "bg-green-500" : "bg-gray-300"}`} />
+              <span className="text-sm text-gray-700">
+                {slackStatus?.connected ? `Connected to ${slackStatus.team_name}` : "Not connected"}
+              </span>
             </div>
-
             <div className="mt-3 flex gap-2">
               <button onClick={() => handleTestNotification("in_app")} className="text-xs text-gray-500 hover:text-gray-700">
                 Test In-App
@@ -307,6 +225,11 @@ export default function SettingsPage() {
               <button onClick={() => handleTestNotification("email")} className="text-xs text-gray-500 hover:text-gray-700">
                 Test Email
               </button>
+              {slackStatus?.connected && (
+                <button onClick={() => handleTestNotification("slack")} className="text-xs text-gray-500 hover:text-gray-700">
+                  Test Slack
+                </button>
+              )}
             </div>
           </div>
 

--- a/frontend/src/app/settings/slack/page.tsx
+++ b/frontend/src/app/settings/slack/page.tsx
@@ -36,6 +36,19 @@ interface SlackManifest {
   settings: { org_deploy_enabled: boolean; socket_mode_enabled: boolean; token_rotation_enabled: boolean };
 }
 
+interface TestWebhookResult {
+  webhook: string;
+  status: string;
+  detail?: string;
+}
+
+interface TestResult {
+  channel: string;
+  status: string;
+  detail?: string;
+  webhooks?: TestWebhookResult[];
+}
+
 const EVENT_CATEGORIES: Record<string, { label: string; events: string[] }> = {
   pipelines: {
     label: "Pipelines & Analysis",
@@ -115,6 +128,10 @@ export default function SettingsSlackPage() {
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
   const [signingSecret, setSigningSecret] = useState("");
+  const [editingMappingId, setEditingMappingId] = useState<number | null>(null);
+  const [editEvents, setEditEvents] = useState<string[]>([]);
+  const [testResults, setTestResults] = useState<TestResult | null>(null);
+  const [testing, setTesting] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const manifestRef = useRef<HTMLPreElement>(null);
@@ -320,11 +337,68 @@ export default function SettingsSlackPage() {
   };
 
   const handleTestSlack = async () => {
+    if (mappings.length === 0) {
+      setError("No channel mappings exist yet. Add a channel mapping first, then test.");
+      return;
+    }
+    setTesting(true);
+    setTestResults(null);
+    setError("");
+    setMessage("");
     try {
-      await api.post("/api/notifications/test", { channel: "slack" });
-      setMessage("Test notification sent to all mapped channels");
+      const result = await api.post<TestResult>("/api/notifications/test", { channel: "slack" });
+      setTestResults(result);
+      if (result.status === "sent") {
+        const allSent = result.webhooks?.every((w) => w.status === "sent");
+        if (allSent) {
+          setMessage("Test notification sent to all mapped channels.");
+        }
+      }
     } catch {
       setError("Failed to send test notification");
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleStartEdit = (mapping: ChannelMapping) => {
+    setEditingMappingId(mapping.id);
+    setEditEvents([...mapping.event_types_json]);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingMappingId(null);
+    setEditEvents([]);
+  };
+
+  const handleSaveEdit = async () => {
+    if (editingMappingId === null) return;
+    try {
+      const updated = await api.put<ChannelMapping>(
+        `/api/notifications/slack/channel-mappings/${editingMappingId}`,
+        { event_types: editEvents }
+      );
+      setMappings(mappings.map((m) => (m.id === editingMappingId ? updated : m)));
+      setEditingMappingId(null);
+      setEditEvents([]);
+      setMessage("Channel mapping updated");
+    } catch {
+      setError("Failed to update channel mapping");
+    }
+  };
+
+  const toggleEditEvent = (event: string) => {
+    setEditEvents((prev) =>
+      prev.includes(event) ? prev.filter((e) => e !== event) : [...prev, event]
+    );
+  };
+
+  const toggleEditCategory = (events: string[]) => {
+    const allSelected = events.every((e) => editEvents.includes(e));
+    if (allSelected) {
+      setEditEvents((prev) => prev.filter((e) => !events.includes(e)));
+    } else {
+      setEditEvents((prev) => [...new Set([...prev, ...events])]);
     }
   };
 
@@ -371,14 +445,7 @@ export default function SettingsSlackPage() {
                   Connect your Slack workspace to receive bioAF notifications in channels you choose.
                 </p>
               </div>
-              {status?.connected && (
-                <button
-                  onClick={handleTestSlack}
-                  className="text-sm text-bioaf-600 hover:text-bioaf-700"
-                >
-                  Send Test Notification
-                </button>
-              )}
+              {/* Test button is in the dedicated section below */}
             </div>
 
             {message && (
@@ -543,6 +610,7 @@ export default function SettingsSlackPage() {
             {/* Phase 3: Connected */}
             {status?.connected && (
               <>
+                {/* Connection status */}
                 <div className="bg-white rounded-lg shadow p-6 mb-6">
                   <h2 className="font-semibold mb-4">Connection</h2>
                   <div className="flex items-center justify-between">
@@ -565,64 +633,22 @@ export default function SettingsSlackPage() {
                   </div>
                 </div>
 
+                {/* Channel mappings */}
                 <div className="bg-white rounded-lg shadow p-6 mb-6">
-                  <h2 className="font-semibold mb-4">Channel Mappings</h2>
+                  <h2 className="font-semibold mb-2">Channel Mappings</h2>
                   <p className="text-sm text-gray-500 mb-4">
-                    Route notifications to specific Slack channels. Leave event types empty to receive all events.
+                    Choose which Slack channels receive bioAF notifications and what types of events each channel gets.
                   </p>
 
-                  {mappings.length > 0 && (
-                    <div className="space-y-2 mb-6">
-                      {mappings.map((mapping) => (
-                        <div
-                          key={mapping.id}
-                          className="flex items-center justify-between p-3 bg-gray-50 rounded"
-                        >
-                          <div className="flex items-center gap-3">
-                            <button
-                              onClick={() => handleToggleMapping(mapping)}
-                              className={`w-8 h-5 rounded-full relative transition-colors ${
-                                mapping.enabled ? "bg-bioaf-600" : "bg-gray-300"
-                              }`}
-                            >
-                              <span
-                                className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-                                  mapping.enabled ? "left-3.5" : "left-0.5"
-                                }`}
-                              />
-                            </button>
-                            <div>
-                              <span className="font-medium text-sm">{mapping.channel_name}</span>
-                              {mapping.event_types_json.length > 0 ? (
-                                <span className="ml-2 text-xs text-gray-500">
-                                  {mapping.event_types_json.length} event type{mapping.event_types_json.length !== 1 ? "s" : ""}
-                                </span>
-                              ) : (
-                                <span className="ml-2 text-xs text-gray-500">All events</span>
-                              )}
-                            </div>
-                          </div>
-                          <button
-                            onClick={() => handleDeleteMapping(mapping.id)}
-                            className="text-xs text-red-500 hover:text-red-700"
-                          >
-                            Remove
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-
                   {/* Add new mapping */}
-                  <div className="border-t pt-4">
-                    <h3 className="font-medium text-sm mb-3">Add Channel</h3>
-                    <div className="flex gap-3 mb-4">
+                  <div className="mb-6">
+                    <div className="flex gap-3 mb-3">
                       <select
                         value={selectedChannel}
                         onChange={(e) => setSelectedChannel(e.target.value)}
                         className="flex-1 px-3 py-2 border rounded text-sm"
                       >
-                        <option value="">Select a channel...</option>
+                        <option value="">Select a channel to add...</option>
                         {channels
                           .filter((ch) => !mappings.some((m) => m.channel_id === ch.id))
                           .map((ch) => (
@@ -631,38 +657,27 @@ export default function SettingsSlackPage() {
                             </option>
                           ))}
                       </select>
-                      <button
-                        onClick={handleAddMapping}
-                        disabled={!selectedChannel}
-                        className="px-4 py-2 bg-bioaf-600 text-white rounded text-sm hover:bg-bioaf-700 disabled:opacity-50"
-                      >
-                        Add
-                      </button>
                     </div>
 
-                    {/* Event type filter */}
                     {selectedChannel && (
-                      <div className="bg-gray-50 rounded p-4">
-                        <p className="text-xs text-gray-500 mb-3">
-                          Select event types for this channel (leave all unchecked for all events):
+                      <div className="bg-gray-50 rounded p-4 mb-3">
+                        <p className="text-sm font-medium mb-2">
+                          Select which events to send to this channel
                         </p>
-                        <div className="space-y-4">
+                        <p className="text-xs text-gray-500 mb-3">
+                          Leave all unchecked to receive every event type.
+                        </p>
+                        <div className="space-y-4 mb-4">
                           {Object.entries(EVENT_CATEGORIES).map(([key, category]) => {
-                            const allSelected = category.events.every((e) =>
-                              selectedEvents.includes(e)
-                            );
-                            const someSelected = category.events.some((e) =>
-                              selectedEvents.includes(e)
-                            );
+                            const allSelected = category.events.every((e) => selectedEvents.includes(e));
+                            const someSelected = category.events.some((e) => selectedEvents.includes(e));
                             return (
                               <div key={key}>
                                 <label className="flex items-center gap-2 text-sm font-medium mb-1 cursor-pointer">
                                   <input
                                     type="checkbox"
                                     checked={allSelected}
-                                    ref={(el) => {
-                                      if (el) el.indeterminate = someSelected && !allSelected;
-                                    }}
+                                    ref={(el) => { if (el) el.indeterminate = someSelected && !allSelected; }}
                                     onChange={() => toggleCategory(category.events)}
                                     className="rounded"
                                   />
@@ -670,10 +685,7 @@ export default function SettingsSlackPage() {
                                 </label>
                                 <div className="ml-6 flex flex-wrap gap-x-4 gap-y-1">
                                   {category.events.map((event) => (
-                                    <label
-                                      key={event}
-                                      className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer"
-                                    >
+                                    <label key={event} className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer">
                                       <input
                                         type="checkbox"
                                         checked={selectedEvents.includes(event)}
@@ -688,9 +700,160 @@ export default function SettingsSlackPage() {
                             );
                           })}
                         </div>
+                        <button
+                          onClick={handleAddMapping}
+                          className="px-4 py-2 bg-bioaf-600 text-white rounded text-sm hover:bg-bioaf-700"
+                        >
+                          Save Channel Mapping
+                        </button>
                       </div>
                     )}
                   </div>
+
+                  {/* Existing mappings list */}
+                  {mappings.length === 0 && !selectedChannel && (
+                    <div className="text-center py-6 text-gray-400 text-sm border rounded border-dashed">
+                      No channel mappings yet. Select a channel above to get started.
+                    </div>
+                  )}
+
+                  {mappings.length > 0 && (
+                    <div className="space-y-3">
+                      {mappings.map((mapping) => (
+                        <div key={mapping.id} className="border rounded">
+                          <div className="flex items-center justify-between p-3">
+                            <div className="flex items-center gap-3">
+                              <button
+                                onClick={() => handleToggleMapping(mapping)}
+                                className={`w-8 h-5 rounded-full relative transition-colors ${
+                                  mapping.enabled ? "bg-bioaf-600" : "bg-gray-300"
+                                }`}
+                              >
+                                <span
+                                  className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                                    mapping.enabled ? "left-3.5" : "left-0.5"
+                                  }`}
+                                />
+                              </button>
+                              <div>
+                                <span className="font-medium text-sm">{mapping.channel_name}</span>
+                                <span className="ml-2 text-xs text-gray-500">
+                                  {mapping.event_types_json.length > 0
+                                    ? `${mapping.event_types_json.length} event type${mapping.event_types_json.length !== 1 ? "s" : ""}`
+                                    : "All events"}
+                                </span>
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-3">
+                              <button
+                                onClick={() => editingMappingId === mapping.id ? handleCancelEdit() : handleStartEdit(mapping)}
+                                className="text-xs text-bioaf-600 hover:text-bioaf-700"
+                              >
+                                {editingMappingId === mapping.id ? "Cancel" : "Edit"}
+                              </button>
+                              <button
+                                onClick={() => handleDeleteMapping(mapping.id)}
+                                className="text-xs text-red-500 hover:text-red-700"
+                              >
+                                Remove
+                              </button>
+                            </div>
+                          </div>
+
+                          {/* Expanded edit view */}
+                          {editingMappingId === mapping.id && (
+                            <div className="border-t bg-gray-50 p-4">
+                              <p className="text-sm font-medium mb-2">Event types for {mapping.channel_name}</p>
+                              <p className="text-xs text-gray-500 mb-3">
+                                Leave all unchecked to receive every event type.
+                              </p>
+                              <div className="space-y-4 mb-4">
+                                {Object.entries(EVENT_CATEGORIES).map(([key, category]) => {
+                                  const allSelected = category.events.every((e) => editEvents.includes(e));
+                                  const someSelected = category.events.some((e) => editEvents.includes(e));
+                                  return (
+                                    <div key={key}>
+                                      <label className="flex items-center gap-2 text-sm font-medium mb-1 cursor-pointer">
+                                        <input
+                                          type="checkbox"
+                                          checked={allSelected}
+                                          ref={(el) => { if (el) el.indeterminate = someSelected && !allSelected; }}
+                                          onChange={() => toggleEditCategory(category.events)}
+                                          className="rounded"
+                                        />
+                                        {category.label}
+                                      </label>
+                                      <div className="ml-6 flex flex-wrap gap-x-4 gap-y-1">
+                                        {category.events.map((event) => (
+                                          <label key={event} className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer">
+                                            <input
+                                              type="checkbox"
+                                              checked={editEvents.includes(event)}
+                                              onChange={() => toggleEditEvent(event)}
+                                              className="rounded"
+                                            />
+                                            {event.split(".").pop()?.replace(/_/g, " ")}
+                                          </label>
+                                        ))}
+                                      </div>
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                              <button
+                                onClick={handleSaveEdit}
+                                className="px-4 py-2 bg-bioaf-600 text-white rounded text-sm hover:bg-bioaf-700"
+                              >
+                                Save Changes
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Test channel mappings */}
+                <div className="bg-white rounded-lg shadow p-6 mb-6">
+                  <h2 className="font-semibold mb-2">Test Channel Mappings</h2>
+                  <p className="text-sm text-gray-500 mb-4">
+                    Send a test message to all mapped channels to verify everything is working.
+                  </p>
+                  <button
+                    onClick={handleTestSlack}
+                    disabled={testing}
+                    className="px-4 py-2 bg-bioaf-600 text-white rounded text-sm hover:bg-bioaf-700 disabled:opacity-50"
+                  >
+                    {testing ? "Sending..." : "Test Channel Mappings"}
+                  </button>
+
+                  {testResults && (
+                    <div className="mt-4 space-y-2">
+                      {testResults.detail && (
+                        <div className="p-3 bg-yellow-50 border border-yellow-200 text-yellow-800 rounded text-sm">
+                          {testResults.detail}
+                        </div>
+                      )}
+                      {testResults.webhooks?.map((result, i) => (
+                        <div
+                          key={i}
+                          className={`p-3 rounded text-sm ${
+                            result.status === "sent"
+                              ? "bg-green-50 border border-green-200 text-green-700"
+                              : "bg-red-50 border border-red-200 text-red-700"
+                          }`}
+                        >
+                          <span className="font-medium">{result.webhook}</span>
+                          {result.status === "sent" ? (
+                            <span className="ml-2">-- Sent successfully</span>
+                          ) : (
+                            <span className="ml-2">-- {result.detail || "Failed to deliver"}</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </>
             )}

--- a/frontend/src/app/settings/slack/page.tsx
+++ b/frontend/src/app/settings/slack/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { api } from "@/lib/api";
 
 interface SlackStatus {
+  configured: boolean;
   connected: boolean;
   team_name: string | null;
   team_id: string | null;
@@ -26,6 +27,13 @@ interface ChannelMapping {
   channel_name: string;
   event_types_json: string[];
   enabled: boolean;
+}
+
+interface SlackManifest {
+  display_information: { name: string; description: string };
+  features: { bot_user: { display_name: string; always_online: boolean } };
+  oauth_config: { scopes: { bot: string[] }; redirect_urls: string[] };
+  settings: { org_deploy_enabled: boolean; socket_mode_enabled: boolean; token_rotation_enabled: boolean };
 }
 
 const EVENT_CATEGORIES: Record<string, { label: string; events: string[] }> = {
@@ -97,12 +105,15 @@ export default function SettingsSlackPage() {
   const [status, setStatus] = useState<SlackStatus | null>(null);
   const [channels, setChannels] = useState<SlackChannel[]>([]);
   const [mappings, setMappings] = useState<ChannelMapping[]>([]);
+  const [manifest, setManifest] = useState<SlackManifest | null>(null);
   const [selectedChannel, setSelectedChannel] = useState("");
   const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [connecting, setConnecting] = useState(false);
+  const [copied, setCopied] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
+  const manifestRef = useRef<HTMLPreElement>(null);
 
   const loadStatus = useCallback(async () => {
     try {
@@ -159,6 +170,34 @@ export default function SettingsSlackPage() {
     }
   }, [loadStatus, loadChannels, loadMappings]);
 
+  const handleGenerateManifest = async () => {
+    setError("");
+    try {
+      const data = await api.get<SlackManifest>("/api/notifications/slack/manifest");
+      setManifest(data);
+    } catch {
+      setError("Failed to generate manifest");
+    }
+  };
+
+  const handleCopyManifest = async () => {
+    if (!manifest) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(manifest, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select the text
+      if (manifestRef.current) {
+        const range = document.createRange();
+        range.selectNodeContents(manifestRef.current);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+      }
+    }
+  };
+
   const handleConnect = async () => {
     setConnecting(true);
     setError("");
@@ -166,7 +205,7 @@ export default function SettingsSlackPage() {
       const data = await api.get<{ auth_url: string }>("/api/notifications/slack/auth-url");
       window.location.href = data.auth_url;
     } catch {
-      setError("Failed to start Slack connection. Ensure BIOAF_SLACK_CLIENT_ID is configured.");
+      setError("Failed to start Slack connection. Make sure you have set BIOAF_SLACK_CLIENT_ID and BIOAF_SLACK_CLIENT_SECRET from your Slack App credentials.");
       setConnecting(false);
     }
   };
@@ -175,7 +214,7 @@ export default function SettingsSlackPage() {
     setError("");
     try {
       await api.delete("/api/notifications/slack/disconnect");
-      setStatus({ connected: false, team_name: null, team_id: null, installed_by: null, installed_at: null, enabled: false });
+      setStatus((prev) => prev ? { ...prev, connected: false, team_name: null, team_id: null, installed_by: null, installed_at: null, enabled: false } : prev);
       setChannels([]);
       setMappings([]);
       setMessage("Slack disconnected");
@@ -299,29 +338,87 @@ export default function SettingsSlackPage() {
               </div>
             )}
 
-            {/* Connection Status */}
-            <div className="bg-white rounded-lg shadow p-6 mb-6">
-              <h2 className="font-semibold mb-4">Connection</h2>
-              {status?.connected ? (
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="w-3 h-3 rounded-full bg-green-500" />
-                    <div>
-                      <p className="font-medium">{status.team_name}</p>
-                      <p className="text-xs text-gray-500">
-                        Connected by {status.installed_by}
-                        {status.installed_at && ` on ${new Date(status.installed_at).toLocaleDateString()}`}
-                      </p>
+            {/* Phase 1: Setup wizard (no Slack App configured yet) */}
+            {!status?.configured && !status?.connected && (
+              <div className="bg-white rounded-lg shadow p-6 mb-6">
+                <h2 className="font-semibold mb-2">Set Up Slack App</h2>
+                <p className="text-sm text-gray-600 mb-4">
+                  Before connecting, you need to create a Slack App in your workspace.
+                  Click the button below to generate the configuration, then follow the steps.
+                </p>
+
+                {!manifest ? (
+                  <button
+                    onClick={handleGenerateManifest}
+                    className="px-4 py-2 bg-bioaf-600 text-white rounded hover:bg-bioaf-700 text-sm font-medium"
+                  >
+                    Generate Slack App Manifest
+                  </button>
+                ) : (
+                  <div className="space-y-4">
+                    <div className="bg-gray-50 rounded-lg p-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <span className="text-sm font-medium text-gray-700">App Manifest (JSON)</span>
+                        <button
+                          onClick={handleCopyManifest}
+                          className="text-xs px-3 py-1 bg-white border rounded hover:bg-gray-50 text-gray-700"
+                        >
+                          {copied ? "Copied" : "Copy to Clipboard"}
+                        </button>
+                      </div>
+                      <pre
+                        ref={manifestRef}
+                        className="text-xs bg-white border rounded p-3 overflow-x-auto max-h-64 overflow-y-auto font-mono text-gray-800"
+                      >
+                        {JSON.stringify(manifest, null, 2)}
+                      </pre>
+                    </div>
+
+                    <div className="border-t pt-4">
+                      <h3 className="font-medium text-sm mb-3">Steps to create your Slack App</h3>
+                      <ol className="list-decimal list-inside space-y-2 text-sm text-gray-700">
+                        <li>
+                          Go to{" "}
+                          <a
+                            href="https://api.slack.com/apps"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-bioaf-600 hover:text-bioaf-700 underline"
+                          >
+                            api.slack.com/apps
+                          </a>
+                        </li>
+                        <li>Click <span className="font-semibold">Create New App</span></li>
+                        <li>Select <span className="font-semibold">From a manifest</span></li>
+                        <li>Choose your workspace, then select <span className="font-semibold">JSON</span> as the format</li>
+                        <li>Paste the manifest above and click <span className="font-semibold">Next</span></li>
+                        <li>Review the summary and click <span className="font-semibold">Create</span></li>
+                        <li>
+                          On the app&apos;s <span className="font-semibold">Basic Information</span> page,
+                          copy the <span className="font-semibold">Client ID</span>,{" "}
+                          <span className="font-semibold">Client Secret</span>, and{" "}
+                          <span className="font-semibold">Signing Secret</span>
+                        </li>
+                        <li>
+                          Set them as environment variables on your bioAF deployment:
+                          <div className="mt-1 bg-white border rounded p-2 font-mono text-xs text-gray-600">
+                            BIOAF_SLACK_CLIENT_ID=your_client_id<br />
+                            BIOAF_SLACK_CLIENT_SECRET=your_client_secret<br />
+                            BIOAF_SLACK_SIGNING_SECRET=your_signing_secret
+                          </div>
+                        </li>
+                        <li>Restart bioAF, then return here and click <span className="font-semibold">Add to Slack</span></li>
+                      </ol>
                     </div>
                   </div>
-                  <button
-                    onClick={handleDisconnect}
-                    className="text-sm text-red-500 hover:text-red-700"
-                  >
-                    Disconnect
-                  </button>
-                </div>
-              ) : (
+                )}
+              </div>
+            )}
+
+            {/* Phase 2: Configured but not connected */}
+            {status?.configured && !status?.connected && (
+              <div className="bg-white rounded-lg shadow p-6 mb-6">
+                <h2 className="font-semibold mb-4">Connection</h2>
                 <div className="text-center py-8">
                   <p className="text-gray-500 mb-4">
                     Connect bioAF to your Slack workspace to send notifications to channels.
@@ -340,12 +437,34 @@ export default function SettingsSlackPage() {
                     {connecting ? "Connecting..." : "Add to Slack"}
                   </button>
                 </div>
-              )}
-            </div>
+              </div>
+            )}
 
-            {/* Channel Mappings (only when connected) */}
+            {/* Phase 3: Connected */}
             {status?.connected && (
               <>
+                <div className="bg-white rounded-lg shadow p-6 mb-6">
+                  <h2 className="font-semibold mb-4">Connection</h2>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="w-3 h-3 rounded-full bg-green-500" />
+                      <div>
+                        <p className="font-medium">{status.team_name}</p>
+                        <p className="text-xs text-gray-500">
+                          Connected by {status.installed_by}
+                          {status.installed_at && ` on ${new Date(status.installed_at).toLocaleDateString()}`}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={handleDisconnect}
+                      className="text-sm text-red-500 hover:text-red-700"
+                    >
+                      Disconnect
+                    </button>
+                  </div>
+                </div>
+
                 <div className="bg-white rounded-lg shadow p-6 mb-6">
                   <h2 className="font-semibold mb-4">Channel Mappings</h2>
                   <p className="text-sm text-gray-500 mb-4">

--- a/frontend/src/app/settings/slack/page.tsx
+++ b/frontend/src/app/settings/slack/page.tsx
@@ -111,6 +111,10 @@ export default function SettingsSlackPage() {
   const [loading, setLoading] = useState(true);
   const [connecting, setConnecting] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [savingCreds, setSavingCreds] = useState(false);
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [signingSecret, setSigningSecret] = useState("");
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const manifestRef = useRef<HTMLPreElement>(null);
@@ -177,6 +181,32 @@ export default function SettingsSlackPage() {
       setManifest(data);
     } catch {
       setError("Failed to generate manifest");
+    }
+  };
+
+  const handleSaveCredentials = async () => {
+    if (!clientId.trim() || !clientSecret.trim() || !signingSecret.trim()) {
+      setError("All three fields are required");
+      return;
+    }
+    setSavingCreds(true);
+    setError("");
+    try {
+      await api.post("/api/notifications/slack/credentials", {
+        client_id: clientId.trim(),
+        client_secret: clientSecret.trim(),
+        signing_secret: signingSecret.trim(),
+      });
+      setMessage("Slack credentials saved");
+      setClientId("");
+      setClientSecret("");
+      setSigningSecret("");
+      // Reload status so UI transitions to "configured" state
+      await loadStatus();
+    } catch {
+      setError("Failed to save credentials");
+    } finally {
+      setSavingCreds(false);
     }
   };
 
@@ -355,27 +385,32 @@ export default function SettingsSlackPage() {
                     Generate Slack App Manifest
                   </button>
                 ) : (
-                  <div className="space-y-4">
-                    <div className="bg-gray-50 rounded-lg p-4">
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="text-sm font-medium text-gray-700">App Manifest (JSON)</span>
-                        <button
-                          onClick={handleCopyManifest}
-                          className="text-xs px-3 py-1 bg-white border rounded hover:bg-gray-50 text-gray-700"
+                  <div className="space-y-6">
+                    {/* Step 1: Manifest */}
+                    <div>
+                      <h3 className="font-medium text-sm mb-2">Step 1: Copy the manifest</h3>
+                      <div className="bg-gray-50 rounded-lg p-4">
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="text-sm font-medium text-gray-700">App Manifest (JSON)</span>
+                          <button
+                            onClick={handleCopyManifest}
+                            className="text-xs px-3 py-1 bg-white border rounded hover:bg-gray-50 text-gray-700"
+                          >
+                            {copied ? "Copied" : "Copy to Clipboard"}
+                          </button>
+                        </div>
+                        <pre
+                          ref={manifestRef}
+                          className="text-xs bg-white border rounded p-3 overflow-x-auto max-h-64 overflow-y-auto font-mono text-gray-800"
                         >
-                          {copied ? "Copied" : "Copy to Clipboard"}
-                        </button>
+                          {JSON.stringify(manifest, null, 2)}
+                        </pre>
                       </div>
-                      <pre
-                        ref={manifestRef}
-                        className="text-xs bg-white border rounded p-3 overflow-x-auto max-h-64 overflow-y-auto font-mono text-gray-800"
-                      >
-                        {JSON.stringify(manifest, null, 2)}
-                      </pre>
                     </div>
 
-                    <div className="border-t pt-4">
-                      <h3 className="font-medium text-sm mb-3">Steps to create your Slack App</h3>
+                    {/* Step 2: Create the app in Slack */}
+                    <div>
+                      <h3 className="font-medium text-sm mb-2">Step 2: Create the app in Slack</h3>
                       <ol className="list-decimal list-inside space-y-2 text-sm text-gray-700">
                         <li>
                           Go to{" "}
@@ -393,22 +428,55 @@ export default function SettingsSlackPage() {
                         <li>Choose your workspace, then select <span className="font-semibold">JSON</span> as the format</li>
                         <li>Paste the manifest above and click <span className="font-semibold">Next</span></li>
                         <li>Review the summary and click <span className="font-semibold">Create</span></li>
-                        <li>
-                          On the app&apos;s <span className="font-semibold">Basic Information</span> page,
-                          copy the <span className="font-semibold">Client ID</span>,{" "}
-                          <span className="font-semibold">Client Secret</span>, and{" "}
-                          <span className="font-semibold">Signing Secret</span>
-                        </li>
-                        <li>
-                          Set them as environment variables on your bioAF deployment:
-                          <div className="mt-1 bg-white border rounded p-2 font-mono text-xs text-gray-600">
-                            BIOAF_SLACK_CLIENT_ID=your_client_id<br />
-                            BIOAF_SLACK_CLIENT_SECRET=your_client_secret<br />
-                            BIOAF_SLACK_SIGNING_SECRET=your_signing_secret
-                          </div>
-                        </li>
-                        <li>Restart bioAF, then return here and click <span className="font-semibold">Add to Slack</span></li>
                       </ol>
+                    </div>
+
+                    {/* Step 3: Paste credentials */}
+                    <div>
+                      <h3 className="font-medium text-sm mb-2">Step 3: Enter your app credentials</h3>
+                      <p className="text-sm text-gray-500 mb-3">
+                        After creating the app, you will land on its <span className="font-semibold">Basic Information</span> page.
+                        Copy the three values below from the <span className="font-semibold">App Credentials</span> section.
+                      </p>
+                      <div className="space-y-3">
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Client ID</label>
+                          <input
+                            type="text"
+                            value={clientId}
+                            onChange={(e) => setClientId(e.target.value)}
+                            placeholder="Paste your Client ID"
+                            className="w-full px-3 py-2 border rounded text-sm font-mono"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Client Secret</label>
+                          <input
+                            type="password"
+                            value={clientSecret}
+                            onChange={(e) => setClientSecret(e.target.value)}
+                            placeholder="Paste your Client Secret"
+                            className="w-full px-3 py-2 border rounded text-sm font-mono"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-medium text-gray-600 mb-1">Signing Secret</label>
+                          <input
+                            type="password"
+                            value={signingSecret}
+                            onChange={(e) => setSigningSecret(e.target.value)}
+                            placeholder="Paste your Signing Secret"
+                            className="w-full px-3 py-2 border rounded text-sm font-mono"
+                          />
+                        </div>
+                        <button
+                          onClick={handleSaveCredentials}
+                          disabled={savingCreds || !clientId || !clientSecret || !signingSecret}
+                          className="px-4 py-2 bg-bioaf-600 text-white rounded hover:bg-bioaf-700 text-sm font-medium disabled:opacity-50"
+                        >
+                          {savingCreds ? "Saving..." : "Save Credentials"}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 )}

--- a/frontend/src/app/settings/slack/page.tsx
+++ b/frontend/src/app/settings/slack/page.tsx
@@ -238,6 +238,20 @@ export default function SettingsSlackPage() {
     }
   };
 
+  const handleStartOver = async () => {
+    setError("");
+    try {
+      await api.delete("/api/notifications/slack/credentials");
+      setStatus((prev) => prev ? { ...prev, configured: false, connected: false, team_name: null, team_id: null, installed_by: null, installed_at: null, enabled: false } : prev);
+      setChannels([]);
+      setMappings([]);
+      setManifest(null);
+      setMessage("Slack integration cleared. You can set it up again.");
+    } catch {
+      setError("Failed to clear Slack integration");
+    }
+  };
+
   const handleConnect = async () => {
     setConnecting(true);
     setError("");
@@ -514,6 +528,14 @@ export default function SettingsSlackPage() {
                     </svg>
                     {connecting ? "Connecting..." : "Add to Slack"}
                   </button>
+                  <div className="mt-6">
+                    <button
+                      onClick={handleStartOver}
+                      className="text-sm text-red-500 hover:text-red-700"
+                    >
+                      Start Over
+                    </button>
+                  </div>
                 </div>
               </div>
             )}

--- a/frontend/src/app/settings/slack/page.tsx
+++ b/frontend/src/app/settings/slack/page.tsx
@@ -177,7 +177,8 @@ export default function SettingsSlackPage() {
   const handleGenerateManifest = async () => {
     setError("");
     try {
-      const data = await api.get<SlackManifest>("/api/notifications/slack/manifest");
+      const origin = encodeURIComponent(window.location.origin);
+      const data = await api.get<SlackManifest>(`/api/notifications/slack/manifest?origin=${origin}`);
       setManifest(data);
     } catch {
       setError("Failed to generate manifest");
@@ -212,19 +213,28 @@ export default function SettingsSlackPage() {
 
   const handleCopyManifest = async () => {
     if (!manifest) return;
+    const text = JSON.stringify(manifest, null, 2);
+
+    // navigator.clipboard requires HTTPS; use textarea fallback on HTTP
+    let success = false;
     try {
-      await navigator.clipboard.writeText(JSON.stringify(manifest, null, 2));
+      await navigator.clipboard.writeText(text);
+      success = true;
+    } catch {
+      // Fallback for HTTP contexts
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      success = document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
+
+    if (success) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback: select the text
-      if (manifestRef.current) {
-        const range = document.createRange();
-        range.selectNodeContents(manifestRef.current);
-        const sel = window.getSelection();
-        sel?.removeAllRanges();
-        sel?.addRange(range);
-      }
     }
   };
 

--- a/frontend/src/app/settings/slack/page.tsx
+++ b/frontend/src/app/settings/slack/page.tsx
@@ -1,79 +1,268 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { api } from "@/lib/api";
 
-interface SlackWebhook {
-  id: number;
+interface SlackStatus {
+  connected: boolean;
+  team_name: string | null;
+  team_id: string | null;
+  installed_by: string | null;
+  installed_at: string | null;
+  enabled: boolean;
+}
+
+interface SlackChannel {
+  id: string;
   name: string;
-  webhook_url: string;
-  channel_name: string | null;
+  is_private: boolean;
+}
+
+interface ChannelMapping {
+  id: number;
+  channel_id: string;
+  channel_name: string;
   event_types_json: string[];
   enabled: boolean;
 }
 
+const EVENT_CATEGORIES: Record<string, { label: string; events: string[] }> = {
+  pipelines: {
+    label: "Pipelines & Analysis",
+    events: [
+      "pipeline.completed",
+      "pipeline.failed",
+      "pipeline.stage_error",
+      "pipeline.run_reviewed",
+      "pipeline.run_review_reminder",
+      "qc.results_ready",
+    ],
+  },
+  experiments: {
+    label: "Experiments & Data",
+    events: [
+      "experiment.status_changed",
+      "results.published",
+      "data.uploaded",
+      "reference.deprecated",
+    ],
+  },
+  ingest: {
+    label: "Ingest & Files",
+    events: [
+      "ingest.files_cataloged",
+      "ingest.unclaimed_entity",
+      "ingest.unmatched_file",
+      "ingest.duplicate_file",
+      "ingest.failure",
+      "ingest.batch_complete",
+    ],
+  },
+  infrastructure: {
+    label: "Infrastructure",
+    events: [
+      "compute.node_failure",
+      "component.health_degraded",
+      "component.health_down",
+      "backup.failure",
+      "terraform.apply_failure",
+      "work_node.heartbeat_timeout",
+    ],
+  },
+  budget: {
+    label: "Budget & Storage",
+    events: [
+      "budget.threshold_50",
+      "budget.threshold_80",
+      "budget.threshold_100",
+      "quota.warning",
+      "storage.threshold",
+    ],
+  },
+  automation: {
+    label: "Automation",
+    events: [
+      "trigger.auto_run_submitted",
+      "trigger.run_queued_budget",
+      "trigger.run_queued_exhausted",
+      "trigger.evaluation_failed",
+      "trigger.batch_window_closed",
+    ],
+  },
+};
+
 export default function SettingsSlackPage() {
-  const [webhooks, setWebhooks] = useState<SlackWebhook[]>([]);
-  const [newWebhookName, setNewWebhookName] = useState("");
-  const [newWebhookUrl, setNewWebhookUrl] = useState("");
-  const [newWebhookChannel, setNewWebhookChannel] = useState("");
+  const [status, setStatus] = useState<SlackStatus | null>(null);
+  const [channels, setChannels] = useState<SlackChannel[]>([]);
+  const [mappings, setMappings] = useState<ChannelMapping[]>([]);
+  const [selectedChannel, setSelectedChannel] = useState("");
+  const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [connecting, setConnecting] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
 
-  useEffect(() => {
-    loadWebhooks();
+  const loadStatus = useCallback(async () => {
+    try {
+      const data = await api.get<SlackStatus>("/api/notifications/slack/status");
+      setStatus(data);
+      return data;
+    } catch {
+      return null;
+    }
   }, []);
 
-  const loadWebhooks = async () => {
+  const loadChannels = useCallback(async () => {
     try {
-      const data = await api.get<SlackWebhook[]>("/api/notifications/slack-webhooks");
-      setWebhooks(data);
+      const data = await api.get<SlackChannel[]>("/api/notifications/slack/channels");
+      setChannels(data);
     } catch {
-      // ignore
+      // Not connected or error
     }
-  };
+  }, []);
 
-  const handleAddWebhook = async () => {
-    if (!newWebhookName || !newWebhookUrl) return;
-    setError("");
-    setMessage("");
+  const loadMappings = useCallback(async () => {
     try {
-      const wh = await api.post<SlackWebhook>("/api/notifications/slack-webhooks", {
-        name: newWebhookName,
-        webhook_url: newWebhookUrl,
-        channel_name: newWebhookChannel || null,
-        event_types: [],
+      const data = await api.get<ChannelMapping[]>("/api/notifications/slack/channel-mappings");
+      setMappings(data);
+    } catch {
+      // Not connected
+    }
+  }, []);
+
+  useEffect(() => {
+    const init = async () => {
+      setLoading(true);
+      const st = await loadStatus();
+      if (st?.connected) {
+        await Promise.all([loadChannels(), loadMappings()]);
+      }
+      setLoading(false);
+    };
+    init();
+  }, [loadStatus, loadChannels, loadMappings]);
+
+  // Handle OAuth callback redirect
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("connected") === "true") {
+      setMessage("Slack connected successfully");
+      window.history.replaceState({}, "", "/settings/slack");
+      loadStatus().then((st) => {
+        if (st?.connected) {
+          loadChannels();
+          loadMappings();
+        }
       });
-      setWebhooks([...webhooks, wh]);
-      setNewWebhookName("");
-      setNewWebhookUrl("");
-      setNewWebhookChannel("");
-      setMessage("Webhook added successfully");
+    }
+  }, [loadStatus, loadChannels, loadMappings]);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    setError("");
+    try {
+      const data = await api.get<{ auth_url: string }>("/api/notifications/slack/auth-url");
+      window.location.href = data.auth_url;
     } catch {
-      setError("Failed to add webhook");
+      setError("Failed to start Slack connection. Ensure BIOAF_SLACK_CLIENT_ID is configured.");
+      setConnecting(false);
     }
   };
 
-  const handleDeleteWebhook = async (id: number) => {
+  const handleDisconnect = async () => {
+    setError("");
     try {
-      await api.delete(`/api/notifications/slack-webhooks/${id}`);
-      setWebhooks(webhooks.filter((w) => w.id !== id));
-      setMessage("Webhook removed");
+      await api.delete("/api/notifications/slack/disconnect");
+      setStatus({ connected: false, team_name: null, team_id: null, installed_by: null, installed_at: null, enabled: false });
+      setChannels([]);
+      setMappings([]);
+      setMessage("Slack disconnected");
     } catch {
-      setError("Failed to delete webhook");
+      setError("Failed to disconnect Slack");
+    }
+  };
+
+  const handleAddMapping = async () => {
+    if (!selectedChannel) return;
+    setError("");
+    const channel = channels.find((c) => c.id === selectedChannel);
+    if (!channel) return;
+
+    try {
+      const mapping = await api.post<ChannelMapping>("/api/notifications/slack/channel-mappings", {
+        channel_id: channel.id,
+        channel_name: `#${channel.name}`,
+        event_types: selectedEvents,
+      });
+      setMappings([...mappings, mapping]);
+      setSelectedChannel("");
+      setSelectedEvents([]);
+      setMessage(`Added #${channel.name}`);
+    } catch {
+      setError("Failed to add channel mapping");
+    }
+  };
+
+  const handleDeleteMapping = async (id: number) => {
+    try {
+      await api.delete(`/api/notifications/slack/channel-mappings/${id}`);
+      setMappings(mappings.filter((m) => m.id !== id));
+      setMessage("Channel mapping removed");
+    } catch {
+      setError("Failed to remove channel mapping");
+    }
+  };
+
+  const handleToggleMapping = async (mapping: ChannelMapping) => {
+    try {
+      const updated = await api.put<ChannelMapping>(`/api/notifications/slack/channel-mappings/${mapping.id}`, {
+        enabled: !mapping.enabled,
+      });
+      setMappings(mappings.map((m) => (m.id === mapping.id ? updated : m)));
+    } catch {
+      setError("Failed to update channel mapping");
     }
   };
 
   const handleTestSlack = async () => {
     try {
       await api.post("/api/notifications/test", { channel: "slack" });
-      setMessage("Test notification sent via Slack");
+      setMessage("Test notification sent to all mapped channels");
     } catch {
-      setError("Failed to send test notification via Slack");
+      setError("Failed to send test notification");
     }
   };
+
+  const toggleEvent = (event: string) => {
+    setSelectedEvents((prev) =>
+      prev.includes(event) ? prev.filter((e) => e !== event) : [...prev, event]
+    );
+  };
+
+  const toggleCategory = (events: string[]) => {
+    const allSelected = events.every((e) => selectedEvents.includes(e));
+    if (allSelected) {
+      setSelectedEvents((prev) => prev.filter((e) => !events.includes(e)));
+    } else {
+      setSelectedEvents((prev) => [...new Set([...prev, ...events])]);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-screen">
+        <Sidebar />
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <Header />
+          <main className="flex-1 flex items-center justify-center">
+            <p className="text-gray-500">Loading Slack settings...</p>
+          </main>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen">
@@ -81,73 +270,211 @@ export default function SettingsSlackPage() {
       <div className="flex-1 flex flex-col overflow-hidden">
         <Header />
         <main className="flex-1 overflow-y-auto p-6">
-          <div className="flex items-center justify-between mb-6">
-            <h1 className="text-2xl font-bold">Slack Webhooks</h1>
-            <button
-              onClick={handleTestSlack}
-              className="text-sm text-bioaf-600 hover:text-bioaf-700"
-            >
-              Send Test Notification
-            </button>
-          </div>
+          <div className="max-w-4xl">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h1 className="text-2xl font-bold">Slack Integration</h1>
+                <p className="text-sm text-gray-500 mt-1">
+                  Connect your Slack workspace to receive bioAF notifications in channels you choose.
+                </p>
+              </div>
+              {status?.connected && (
+                <button
+                  onClick={handleTestSlack}
+                  className="text-sm text-bioaf-600 hover:text-bioaf-700"
+                >
+                  Send Test Notification
+                </button>
+              )}
+            </div>
 
-          {message && <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-700 rounded text-sm">{message}</div>}
-          {error && <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded text-sm">{error}</div>}
-
-          <div className="bg-white rounded-lg shadow p-6">
-            {webhooks.length > 0 && (
-              <div className="mb-6 space-y-2">
-                {webhooks.map((wh) => (
-                  <div key={wh.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
-                    <div>
-                      <span className="font-medium text-sm">{wh.name}</span>
-                      {wh.channel_name && (
-                        <span className="ml-2 text-xs text-gray-500">{wh.channel_name}</span>
-                      )}
-                    </div>
-                    <button
-                      onClick={() => handleDeleteWebhook(wh.id)}
-                      className="text-xs text-red-500 hover:text-red-700"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                ))}
+            {message && (
+              <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-700 rounded text-sm">
+                {message}
+              </div>
+            )}
+            {error && (
+              <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded text-sm">
+                {error}
               </div>
             )}
 
-            <h3 className="font-medium mb-3">Add Webhook</h3>
-            <div className="grid grid-cols-3 gap-3">
-              <input
-                type="text"
-                placeholder="Webhook name"
-                value={newWebhookName}
-                onChange={(e) => setNewWebhookName(e.target.value)}
-                className="px-3 py-2 border rounded text-sm"
-              />
-              <input
-                type="url"
-                placeholder="https://hooks.slack.com/..."
-                value={newWebhookUrl}
-                onChange={(e) => setNewWebhookUrl(e.target.value)}
-                className="px-3 py-2 border rounded text-sm"
-              />
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  placeholder="#channel"
-                  value={newWebhookChannel}
-                  onChange={(e) => setNewWebhookChannel(e.target.value)}
-                  className="flex-1 px-3 py-2 border rounded text-sm"
-                />
-                <button
-                  onClick={handleAddWebhook}
-                  className="px-3 py-2 bg-bioaf-600 text-white rounded text-sm hover:bg-bioaf-700"
-                >
-                  Add
-                </button>
-              </div>
+            {/* Connection Status */}
+            <div className="bg-white rounded-lg shadow p-6 mb-6">
+              <h2 className="font-semibold mb-4">Connection</h2>
+              {status?.connected ? (
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-3 h-3 rounded-full bg-green-500" />
+                    <div>
+                      <p className="font-medium">{status.team_name}</p>
+                      <p className="text-xs text-gray-500">
+                        Connected by {status.installed_by}
+                        {status.installed_at && ` on ${new Date(status.installed_at).toLocaleDateString()}`}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={handleDisconnect}
+                    className="text-sm text-red-500 hover:text-red-700"
+                  >
+                    Disconnect
+                  </button>
+                </div>
+              ) : (
+                <div className="text-center py-8">
+                  <p className="text-gray-500 mb-4">
+                    Connect bioAF to your Slack workspace to send notifications to channels.
+                  </p>
+                  <button
+                    onClick={handleConnect}
+                    disabled={connecting}
+                    className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#4A154B] text-white rounded-lg hover:bg-[#3a1039] disabled:opacity-50 font-medium"
+                  >
+                    <svg width="20" height="20" viewBox="0 0 54 54" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M19.712.133a5.381 5.381 0 0 0-5.376 5.387 5.381 5.381 0 0 0 5.376 5.386h5.376V5.52A5.381 5.381 0 0 0 19.712.133m0 14.365H5.376A5.381 5.381 0 0 0 0 19.884a5.381 5.381 0 0 0 5.376 5.387h14.336a5.381 5.381 0 0 0 5.376-5.387 5.381 5.381 0 0 0-5.376-5.386" fill="#36C5F0"/>
+                      <path d="M53.76 19.884a5.381 5.381 0 0 0-5.376-5.386 5.381 5.381 0 0 0-5.376 5.386v5.387h5.376a5.381 5.381 0 0 0 5.376-5.387m-14.336 0V5.52A5.381 5.381 0 0 0 34.048.133a5.381 5.381 0 0 0-5.376 5.387v14.364a5.381 5.381 0 0 0 5.376 5.387 5.381 5.381 0 0 0 5.376-5.387" fill="#2EB67D"/>
+                      <path d="M34.048 54a5.381 5.381 0 0 0 5.376-5.387 5.381 5.381 0 0 0-5.376-5.386h-5.376v5.386A5.381 5.381 0 0 0 34.048 54m0-14.365h14.336a5.381 5.381 0 0 0 5.376-5.386 5.381 5.381 0 0 0-5.376-5.387H34.048a5.381 5.381 0 0 0-5.376 5.387 5.381 5.381 0 0 0 5.376 5.386" fill="#ECB22E"/>
+                      <path d="M0 34.249a5.381 5.381 0 0 0 5.376 5.386 5.381 5.381 0 0 0 5.376-5.386v-5.387H5.376A5.381 5.381 0 0 0 0 34.25m14.336-.001v14.364A5.381 5.381 0 0 0 19.712 54a5.381 5.381 0 0 0 5.376-5.387V34.249a5.381 5.381 0 0 0-5.376-5.387 5.381 5.381 0 0 0-5.376 5.387" fill="#E01E5A"/>
+                    </svg>
+                    {connecting ? "Connecting..." : "Add to Slack"}
+                  </button>
+                </div>
+              )}
             </div>
+
+            {/* Channel Mappings (only when connected) */}
+            {status?.connected && (
+              <>
+                <div className="bg-white rounded-lg shadow p-6 mb-6">
+                  <h2 className="font-semibold mb-4">Channel Mappings</h2>
+                  <p className="text-sm text-gray-500 mb-4">
+                    Route notifications to specific Slack channels. Leave event types empty to receive all events.
+                  </p>
+
+                  {mappings.length > 0 && (
+                    <div className="space-y-2 mb-6">
+                      {mappings.map((mapping) => (
+                        <div
+                          key={mapping.id}
+                          className="flex items-center justify-between p-3 bg-gray-50 rounded"
+                        >
+                          <div className="flex items-center gap-3">
+                            <button
+                              onClick={() => handleToggleMapping(mapping)}
+                              className={`w-8 h-5 rounded-full relative transition-colors ${
+                                mapping.enabled ? "bg-bioaf-600" : "bg-gray-300"
+                              }`}
+                            >
+                              <span
+                                className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                                  mapping.enabled ? "left-3.5" : "left-0.5"
+                                }`}
+                              />
+                            </button>
+                            <div>
+                              <span className="font-medium text-sm">{mapping.channel_name}</span>
+                              {mapping.event_types_json.length > 0 ? (
+                                <span className="ml-2 text-xs text-gray-500">
+                                  {mapping.event_types_json.length} event type{mapping.event_types_json.length !== 1 ? "s" : ""}
+                                </span>
+                              ) : (
+                                <span className="ml-2 text-xs text-gray-500">All events</span>
+                              )}
+                            </div>
+                          </div>
+                          <button
+                            onClick={() => handleDeleteMapping(mapping.id)}
+                            className="text-xs text-red-500 hover:text-red-700"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Add new mapping */}
+                  <div className="border-t pt-4">
+                    <h3 className="font-medium text-sm mb-3">Add Channel</h3>
+                    <div className="flex gap-3 mb-4">
+                      <select
+                        value={selectedChannel}
+                        onChange={(e) => setSelectedChannel(e.target.value)}
+                        className="flex-1 px-3 py-2 border rounded text-sm"
+                      >
+                        <option value="">Select a channel...</option>
+                        {channels
+                          .filter((ch) => !mappings.some((m) => m.channel_id === ch.id))
+                          .map((ch) => (
+                            <option key={ch.id} value={ch.id}>
+                              {ch.is_private ? "🔒 " : "#"}{ch.name}
+                            </option>
+                          ))}
+                      </select>
+                      <button
+                        onClick={handleAddMapping}
+                        disabled={!selectedChannel}
+                        className="px-4 py-2 bg-bioaf-600 text-white rounded text-sm hover:bg-bioaf-700 disabled:opacity-50"
+                      >
+                        Add
+                      </button>
+                    </div>
+
+                    {/* Event type filter */}
+                    {selectedChannel && (
+                      <div className="bg-gray-50 rounded p-4">
+                        <p className="text-xs text-gray-500 mb-3">
+                          Select event types for this channel (leave all unchecked for all events):
+                        </p>
+                        <div className="space-y-4">
+                          {Object.entries(EVENT_CATEGORIES).map(([key, category]) => {
+                            const allSelected = category.events.every((e) =>
+                              selectedEvents.includes(e)
+                            );
+                            const someSelected = category.events.some((e) =>
+                              selectedEvents.includes(e)
+                            );
+                            return (
+                              <div key={key}>
+                                <label className="flex items-center gap-2 text-sm font-medium mb-1 cursor-pointer">
+                                  <input
+                                    type="checkbox"
+                                    checked={allSelected}
+                                    ref={(el) => {
+                                      if (el) el.indeterminate = someSelected && !allSelected;
+                                    }}
+                                    onChange={() => toggleCategory(category.events)}
+                                    className="rounded"
+                                  />
+                                  {category.label}
+                                </label>
+                                <div className="ml-6 flex flex-wrap gap-x-4 gap-y-1">
+                                  {category.events.map((event) => (
+                                    <label
+                                      key={event}
+                                      className="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer"
+                                    >
+                                      <input
+                                        type="checkbox"
+                                        checked={selectedEvents.includes(event)}
+                                        onChange={() => toggleEvent(event)}
+                                        className="rounded"
+                                      />
+                                      {event.split(".").pop()?.replace(/_/g, " ")}
+                                    </label>
+                                  ))}
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </main>
       </div>


### PR DESCRIPTION
## Summary

- Replace manual Slack webhook configuration with an OAuth "Add to Slack" flow
- Admin setup is fully UI-driven: generate a manifest, create the app in Slack, paste credentials into a form, click "Add to Slack"
- Channel mappings let admins route specific event types to specific Slack channels
- Slack delivery works via bot token (`chat.postMessage`) with legacy webhook fallback
- Test button sends a test message to all mapped channels with actionable error messages (e.g., "app not in channel -- type @bioAF to invite it")

## Test plan

- [x] Backend: 17 new tests for OAuth flow, channel mappings, adapter, permissions (1453 total pass)
- [x] Frontend: 371 tests pass, `tsc --noEmit` clean
- [x] Linting: `ruff format`, `ruff check`, `mypy`, `markdownlint` all clean
- [x] Manual: end-to-end tested -- connected Slack workspace, created channel mapping, uploaded file, received notification in Slack channel
- [ ] Verify migration 051 + 052 apply cleanly on fresh database
- [ ] Verify legacy webhook path still works for orgs that have not migrated