### PR TITLE
Auto-ingest infrastructure, CSV bulk upload, and pipeline triggers (beta)

### DIFF
--- a/backend/app/api/auto_ingest.py
+++ b/backend/app/api/auto_ingest.py
@@ -27,11 +27,13 @@ router = APIRouter(tags=["auto_ingest"])
 class AutoIngestConfig(BaseModel):
     enabled: bool
     cleanup_policy: str = "delete_after_copy"
+    default_delay_minutes: int | None = None
 
 
 class AutoIngestStatus(BaseModel):
     enabled: bool
     cleanup_policy: str
+    default_delay_minutes: int
     listener_running: bool
     pubsub_topic: str | None
     pubsub_subscription: str | None
@@ -68,10 +70,14 @@ async def configure_auto_ingest(
 
     # Update platform_config
     enabled_value = "true" if body.enabled else "false"
-    updates = {
+    updates: dict[str, str] = {
         "auto_ingest_enabled": enabled_value,
         "ingest_cleanup_policy": body.cleanup_policy,
     }
+    if body.default_delay_minutes is not None:
+        if body.default_delay_minutes < 0:
+            raise HTTPException(status_code=400, detail="default_delay_minutes must be non-negative.")
+        updates["ingest_default_delay_minutes"] = str(body.default_delay_minutes)
     for key, value in updates.items():
         await session.execute(
             text(
@@ -103,6 +109,7 @@ async def get_auto_ingest_status(
     keys = [
         "auto_ingest_enabled",
         "ingest_cleanup_policy",
+        "ingest_default_delay_minutes",
         "pubsub_topic_name",
         "pubsub_subscription_name",
     ]
@@ -115,6 +122,8 @@ async def get_auto_ingest_status(
 
     enabled = config.get("auto_ingest_enabled", "false") == "true"
     cleanup_policy = config.get("ingest_cleanup_policy", "delete_after_copy")
+    delay_str = config.get("ingest_default_delay_minutes", "15")
+    default_delay_minutes = int(delay_str) if delay_str and delay_str != "null" else 15
     topic = config.get("pubsub_topic_name")
     subscription = config.get("pubsub_subscription_name")
     if topic == "null":
@@ -149,6 +158,7 @@ async def get_auto_ingest_status(
     return AutoIngestStatus(
         enabled=enabled,
         cleanup_policy=cleanup_policy,
+        default_delay_minutes=default_delay_minutes,
         listener_running=listener_running,
         pubsub_topic=topic,
         pubsub_subscription=subscription,

--- a/backend/app/api/experiments.py
+++ b/backend/app/api/experiments.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile, File
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
@@ -23,7 +23,7 @@ from app.schemas.batch import BatchCreate, BatchResponse
 from app.services.experiment_service import ExperimentService
 from app.services.sample_service import SampleService
 from app.services.batch_service import BatchService
-from app.services.csv_service import parse_sample_csv
+from app.services.csv_service import generate_sample_template, parse_sample_csv, preview_sample_csv
 
 router = APIRouter(prefix="/api/experiments", tags=["experiments"])
 
@@ -315,6 +315,93 @@ async def bulk_create_samples(
     return {"created": len(samples)}
 
 
+@router.get("/{experiment_id}/samples/csv-template")
+async def download_csv_template(
+    experiment_id: int,
+    request: Request,
+):
+    from fastapi.responses import Response
+
+    content = generate_sample_template()
+    return Response(
+        content=content,
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=sample_template.csv"},
+    )
+
+
+@router.post("/{experiment_id}/samples/upload/preview")
+async def preview_samples_csv(
+    experiment_id: int,
+    file: UploadFile = File(...),
+    current_user: dict = require_permission("experiments", "upload"),
+    session: AsyncSession = Depends(get_session),
+):
+    content = await file.read()
+    return preview_sample_csv(content)
+
+
+@router.post("/{experiment_id}/samples/upload/confirm")
+async def confirm_samples_csv(
+    experiment_id: int,
+    file: UploadFile = File(...),
+    column_mappings: str = Form(""),
+    current_user: dict = require_permission("experiments", "upload"),
+    session: AsyncSession = Depends(get_session),
+):
+    import json as json_mod
+
+    user_id = int(current_user["sub"])
+    content = await file.read()
+
+    mappings: dict[str, str] = {}
+    if column_mappings:
+        try:
+            mappings = json_mod.loads(column_mappings)
+        except (json_mod.JSONDecodeError, TypeError):
+            raise HTTPException(400, detail="Invalid column_mappings JSON")
+
+    parsed_samples, parse_errors, custom_field_rows = parse_sample_csv(content, experiment_id, column_mappings=mappings)
+
+    if not parsed_samples and parse_errors:
+        raise HTTPException(400, detail={"errors": parse_errors})
+
+    # Collect unique custom field names from mappings
+    custom_field_names: list[str] = sorted({name for row in custom_field_rows for name in row})
+
+    created = []
+    create_errors = []
+    for i, sample_data in enumerate(parsed_samples):
+        try:
+            sample = await SampleService.create_sample(session, experiment_id, user_id, sample_data)
+            created.append(sample)
+
+            # Store custom fields on the experiment if any
+            if i < len(custom_field_rows) and custom_field_rows[i]:
+                from app.models.experiment_custom_field import ExperimentCustomField
+
+                for field_name, field_value in custom_field_rows[i].items():
+                    cf = ExperimentCustomField(
+                        experiment_id=experiment_id,
+                        field_name=f"sample:{sample.id}:{field_name}",
+                        field_value=str(field_value),
+                        field_type="text",
+                    )
+                    session.add(cf)
+        except HTTPException as e:
+            create_errors.append(f"Sample {i + 1}: {e.detail}")
+
+    if created:
+        await session.commit()
+
+    return {
+        "created_count": len(created),
+        "error_count": len(parse_errors) + len(create_errors),
+        "errors": parse_errors + create_errors,
+        "custom_fields_created": custom_field_names,
+    }
+
+
 @router.post("/{experiment_id}/samples/upload")
 async def upload_samples_csv(
     experiment_id: int,
@@ -324,7 +411,7 @@ async def upload_samples_csv(
 ):
     user_id = int(current_user["sub"])
     content = await file.read()
-    parsed_samples, parse_errors = parse_sample_csv(content, experiment_id)
+    parsed_samples, parse_errors, _ = parse_sample_csv(content, experiment_id)
 
     if not parsed_samples and parse_errors:
         raise HTTPException(400, detail={"errors": parse_errors})

--- a/backend/app/api/storage_deploy.py
+++ b/backend/app/api/storage_deploy.py
@@ -22,6 +22,39 @@ from app.services.gcs_storage import BucketMetrics, GcsStorageService
 
 logger = logging.getLogger("bioaf.storage_deploy_api")
 
+_STORAGE_OUTPUT_KEYS = [
+    "ingest_bucket_name",
+    "raw_bucket_name",
+    "working_bucket_name",
+    "results_bucket_name",
+    "config_backups_bucket_name",
+    "pubsub_topic_name",
+    "pubsub_subscription_name",
+]
+
+
+async def _store_storage_outputs(session: AsyncSession) -> None:
+    """Read Terraform outputs for the storage module and store them in platform_config."""
+    from app.services.terraform_executor import TerraformExecutor
+
+    try:
+        outputs = await TerraformExecutor.read_module_outputs(session, "storage")
+    except Exception:
+        logger.warning("Could not read storage module outputs after apply", exc_info=True)
+        return
+
+    for config_key in _STORAGE_OUTPUT_KEYS:
+        val = outputs.get(config_key, {}).get("value", "")
+        if val:
+            await session.execute(
+                text(
+                    "INSERT INTO platform_config (key, value) VALUES (:k, :v) "
+                    "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+                ).bindparams(k=config_key, v=val)
+            )
+    await session.commit()
+
+
 router = APIRouter(tags=["storage_deploy"])
 
 
@@ -109,6 +142,48 @@ async def deploy_storage(
         )
 
     result = await deploy_storage_module(session, user_id)
+    return StorageDeployResponse(**result)
+
+
+@router.post(
+    "/api/v1/infrastructure/storage/update",
+    response_model=StorageDeployResponse,
+)
+async def update_storage(
+    current_user: dict = require_permission("infrastructure", "view"),
+    session: AsyncSession = Depends(get_session),
+) -> StorageDeployResponse:
+    """Re-apply the storage module to update infrastructure (e.g. add Pub/Sub).
+
+    Unlike /deploy, this endpoint works when storage is already deployed.
+    Terraform will only create or modify resources that have changed.
+    """
+    user_id = int(current_user["sub"])
+
+    rows = (
+        await session.execute(
+            text("SELECT key, value FROM platform_config WHERE key IN ('terraform_initialized', 'storage_deployed')")
+        )
+    ).fetchall()
+    config = {r[0]: r[1] for r in rows}
+
+    if config.get("terraform_initialized", "false") != "true":
+        raise HTTPException(
+            status_code=400,
+            detail="Terraform has not been initialized. Run bootstrap first.",
+        )
+    if config.get("storage_deployed", "false") != "true":
+        raise HTTPException(
+            status_code=400,
+            detail="Storage has not been deployed yet. Use /deploy instead.",
+        )
+
+    result = await deploy_storage_module(session, user_id)
+
+    # Store outputs since this apply may have added new resources (Pub/Sub).
+    if result.get("status") == "completed":
+        await _store_storage_outputs(session)
+
     return StorageDeployResponse(**result)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -146,6 +146,7 @@ async def lifespan(app: FastAPI):
     background_tasks.append(asyncio.create_task(_review_reminder_loop()))
     background_tasks.append(asyncio.create_task(_trigger_batch_expiry_loop()))
     background_tasks.append(asyncio.create_task(_budget_queue_processing_loop()))
+    background_tasks.append(asyncio.create_task(_scheduled_trigger_loop()))
     background_tasks.append(asyncio.create_task(_pubsub_listener_loop()))
     background_tasks.append(asyncio.create_task(_session_monitor_loop()))
     background_tasks.append(asyncio.create_task(_notebook_image_build_loop()))
@@ -440,6 +441,27 @@ async def _budget_queue_processing_loop():
             break
         except Exception as e:
             logger.error("Budget queue processing error: %s", e)
+
+
+async def _scheduled_trigger_loop():
+    """Evaluate scheduled triggers every 60 seconds."""
+    from app.database import async_session_factory
+    from app.services.trigger_service import TriggerService
+
+    while True:
+        try:
+            await asyncio.sleep(60)
+            async with async_session_factory() as session:
+                evaluations = await TriggerService.evaluate_scheduled_triggers(session)
+                if evaluations:
+                    await session.commit()
+                    submitted = sum(1 for e in evaluations if e.result == "submitted")
+                    if submitted:
+                        logger.info("Scheduled triggers: submitted %d runs", submitted)
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error("Scheduled trigger evaluation error: %s", e)
 
 
 async def _pubsub_listener_loop():

--- a/backend/app/services/csv_service.py
+++ b/backend/app/services/csv_service.py
@@ -1,8 +1,31 @@
 import csv
 import io
+from datetime import datetime
+from typing import Any
 
 from app.schemas.sample import SampleCreate
 
+# All user-facing sample fields (excludes internal fields like id, status, experiment_id)
+SAMPLE_FIELDS = [
+    "sample_id_external",
+    "organism",
+    "tissue_type",
+    "donor_source",
+    "treatment_condition",
+    "chemistry_version",
+    "viability_pct",
+    "cell_count",
+    "prep_notes",
+    "molecule_type",
+    "library_prep_method",
+    "library_layout",
+    "qc_status",
+    "qc_notes",
+    "collection_timestamp",
+    "collection_method",
+]
+
+# Maps common CSV header names to sample model field names
 COLUMN_MAP = {
     "sample_id": "sample_id_external",
     "external_id": "sample_id_external",
@@ -23,9 +46,35 @@ COLUMN_MAP = {
     "notes": "prep_notes",
     "qc_status": "qc_status",
     "qc_notes": "qc_notes",
+    "molecule_type": "molecule_type",
+    "library_prep_method": "library_prep_method",
+    "library_layout": "library_layout",
+    "collection_timestamp": "collection_timestamp",
+    "collection_method": "collection_method",
 }
 
 NUMERIC_FIELDS = {"viability_pct", "cell_count"}
+DATETIME_FIELDS = {"collection_timestamp"}
+
+# Example values for the template CSV
+_EXAMPLE_VALUES = {
+    "sample_id_external": "SAMPLE-001",
+    "organism": "Homo sapiens",
+    "tissue_type": "PBMC",
+    "donor_source": "Donor-A",
+    "treatment_condition": "Control",
+    "chemistry_version": "v3.1",
+    "viability_pct": "92.5",
+    "cell_count": "10000",
+    "prep_notes": "Standard protocol",
+    "molecule_type": "total RNA",
+    "library_prep_method": "10x Chromium 3' v3",
+    "library_layout": "paired",
+    "qc_status": "pass",
+    "qc_notes": "",
+    "collection_timestamp": "2024-01-15T10:30:00",
+    "collection_method": "venipuncture",
+}
 
 
 def _detect_encoding(content: bytes) -> str:
@@ -44,56 +93,216 @@ def _detect_delimiter(first_line: str) -> str:
     return ","
 
 
-def parse_sample_csv(file_content: bytes, experiment_id: int) -> tuple[list[SampleCreate], list[str]]:
+def _normalize_header(raw: str) -> str:
+    return raw.strip().lower().replace(" ", "_")
+
+
+def _build_header_map(
+    fieldnames: list[str],
+    column_mappings: dict[str, str] | None = None,
+) -> tuple[dict[str, str], list[str]]:
+    """Build header-to-field mapping. Returns (header_map, unknown_columns)."""
+    header_map: dict[str, str] = {}
+    unknown_columns: list[str] = []
+
+    for raw_header in fieldnames:
+        clean = _normalize_header(raw_header)
+
+        # Check user-provided mappings first
+        if column_mappings and clean in column_mappings:
+            target = column_mappings[clean]
+            if target.startswith("custom:"):
+                # Custom field -- store as-is, handled by caller
+                header_map[raw_header] = target
+            else:
+                header_map[raw_header] = target
+            continue
+
+        if clean in COLUMN_MAP:
+            header_map[raw_header] = COLUMN_MAP[clean]
+        else:
+            unknown_columns.append(clean)
+
+    return header_map, unknown_columns
+
+
+def _convert_value(field_name: str, raw_val: str) -> tuple[Any, str | None]:
+    """Convert a raw string value to the appropriate type for the field.
+
+    Returns (converted_value, error_message_or_none).
+    """
+    if field_name in NUMERIC_FIELDS:
+        try:
+            if field_name == "cell_count":
+                return int(raw_val), None
+            return float(raw_val), None
+        except ValueError:
+            return None, f"Invalid numeric value '{raw_val}' for {field_name}"
+
+    if field_name in DATETIME_FIELDS:
+        try:
+            return datetime.fromisoformat(raw_val), None
+        except ValueError:
+            return None, f"Invalid datetime value '{raw_val}' for {field_name}"
+
+    return raw_val, None
+
+
+def _parse_rows(
+    text: str,
+    delimiter: str,
+    header_map: dict[str, str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], int]:
+    """Parse CSV rows using the header map.
+
+    Returns (sample_dicts, custom_field_rows, errors, total_rows).
+    Each sample_dict maps field_name -> value (for SampleCreate).
+    Each custom_field_row maps custom_field_name -> value (keyed by row index).
+    """
+    reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+    sample_dicts: list[dict[str, Any]] = []
+    custom_field_rows: list[dict[str, Any]] = []
+    errors: list[str] = []
+    total_rows = 0
+
+    for row_num, row in enumerate(reader, start=2):
+        if all(not v or not v.strip() for v in row.values()):
+            continue
+
+        total_rows += 1
+        sample_data: dict[str, Any] = {}
+        custom_fields: dict[str, Any] = {}
+
+        for raw_header, field_name in header_map.items():
+            val = row.get(raw_header, "").strip()
+            if not val:
+                continue
+
+            if field_name.startswith("custom:"):
+                custom_fields[field_name.removeprefix("custom:")] = val
+                continue
+
+            converted, error = _convert_value(field_name, val)
+            if error:
+                errors.append(f"Row {row_num}: {error}")
+                continue
+            sample_data[field_name] = converted
+
+        sample_dicts.append(sample_data)
+        custom_field_rows.append(custom_fields)
+
+    return sample_dicts, custom_field_rows, errors, total_rows
+
+
+def generate_sample_template() -> bytes:
+    """Generate a CSV template with all sample fields and an example row."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(SAMPLE_FIELDS)
+    writer.writerow([_EXAMPLE_VALUES.get(f, "") for f in SAMPLE_FIELDS])
+    return output.getvalue().encode("utf-8")
+
+
+def preview_sample_csv(file_content: bytes) -> dict[str, Any]:
+    """Parse a CSV file and return a preview without creating any samples.
+
+    Returns a dict with:
+        recognized_columns: list of {csv_header, mapped_to}
+        unknown_columns: list of unrecognized header names
+        preview_rows: first 5 rows of parsed data
+        total_rows: total data row count
+        errors: list of parse error messages
+    """
     encoding = _detect_encoding(file_content)
     text = file_content.decode(encoding)
 
     lines = text.strip().splitlines()
     if not lines:
-        return [], ["File is empty"]
+        return {
+            "recognized_columns": [],
+            "unknown_columns": [],
+            "preview_rows": [],
+            "total_rows": 0,
+            "errors": ["File is empty"],
+        }
 
     delimiter = _detect_delimiter(lines[0])
     reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
 
     if not reader.fieldnames:
-        return [], ["No header row found"]
+        return {
+            "recognized_columns": [],
+            "unknown_columns": [],
+            "preview_rows": [],
+            "total_rows": 0,
+            "errors": ["No header row found"],
+        }
 
-    # Map headers
-    header_map = {}
-    for raw_header in reader.fieldnames:
-        clean = raw_header.strip().lower().replace(" ", "_")
-        if clean in COLUMN_MAP:
-            header_map[raw_header] = COLUMN_MAP[clean]
+    header_map, unknown_columns = _build_header_map(list(reader.fieldnames))
+
+    recognized_columns = [{"csv_header": raw, "mapped_to": field} for raw, field in header_map.items()]
+
+    sample_dicts, _, errors, total_rows = _parse_rows(text, delimiter, header_map)
+
+    # Build preview rows (first 5) using mapped field names
+    preview_rows = []
+    for sample_data in sample_dicts[:5]:
+        preview_rows.append(sample_data)
+
+    return {
+        "recognized_columns": recognized_columns,
+        "unknown_columns": unknown_columns,
+        "preview_rows": preview_rows,
+        "total_rows": total_rows,
+        "errors": errors,
+    }
+
+
+def parse_sample_csv(
+    file_content: bytes,
+    experiment_id: int,
+    column_mappings: dict[str, str] | None = None,
+) -> tuple[list[SampleCreate], list[str], list[dict[str, Any]]]:
+    """Parse a CSV file into SampleCreate objects.
+
+    Args:
+        file_content: Raw CSV bytes.
+        experiment_id: The experiment to associate samples with.
+        column_mappings: Optional user-provided mappings for unknown columns.
+            Keys are normalized header names, values are either a sample field
+            name (e.g. "prep_notes") or "custom:field_name" for custom fields.
+
+    Returns:
+        (samples, errors, custom_field_rows) where custom_field_rows is a list
+        of dicts parallel to samples, mapping custom field names to values.
+    """
+    encoding = _detect_encoding(file_content)
+    text = file_content.decode(encoding)
+
+    lines = text.strip().splitlines()
+    if not lines:
+        return [], ["File is empty"], []
+
+    delimiter = _detect_delimiter(lines[0])
+    reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+
+    if not reader.fieldnames:
+        return [], ["No header row found"], []
+
+    header_map, _ = _build_header_map(list(reader.fieldnames), column_mappings)
+
+    sample_dicts, custom_field_rows, errors, _ = _parse_rows(text, delimiter, header_map)
 
     samples = []
-    errors = []
-
-    for row_num, row in enumerate(reader, start=2):
-        # Skip empty rows
-        if all(not v or not v.strip() for v in row.values()):
-            continue
-
-        sample_data = {}
-        for raw_header, field_name in header_map.items():
-            val = row.get(raw_header, "").strip()
-            if not val:
-                continue
-            if field_name in NUMERIC_FIELDS:
-                try:
-                    if field_name == "cell_count":
-                        sample_data[field_name] = int(val)
-                    else:
-                        sample_data[field_name] = float(val)
-                except ValueError:
-                    errors.append(f"Row {row_num}: Invalid numeric value '{val}' for {field_name}")
-                    continue
-            else:
-                sample_data[field_name] = val
-
+    for i, sample_data in enumerate(sample_dicts):
         try:
             sample = SampleCreate(**sample_data)
             samples.append(sample)
         except Exception as e:
+            row_num = i + 2  # CSV row numbers start at 2 (after header)
             errors.append(f"Row {row_num}: {str(e)}")
+            # Remove corresponding custom fields row so indexes stay aligned
+            if i < len(custom_field_rows):
+                custom_field_rows[i] = {}
 
-    return samples, errors
+    return samples, errors, custom_field_rows

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -150,6 +150,7 @@ class ProjectService:
                 {
                     "id": project.id,
                     "name": project.name,
+                    "code": project.code,
                     "description": project.description,
                     "hypothesis": project.hypothesis,
                     "status": project.status,

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -61,6 +61,7 @@ class StackStatus(BaseModel):
     compute_stack: str | None
     compute_deployed: bool
     storage_deployed: bool
+    pubsub_configured: bool = False
     cluster: ClusterInfo | None = None
 
 
@@ -114,16 +115,19 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
     compute_deployed = await _read_config(session, "compute_deployed")
     compute_stack_val = await _read_config(session, "compute_stack")
     storage_deployed = await _read_config(session, "storage_deployed")
+    pubsub_topic = await _read_config(session, "pubsub_topic_name")
 
     is_deployed = compute_deployed == "true"
     stack = compute_stack_val if compute_stack_val != "null" else None
     storage = storage_deployed == "true"
+    pubsub = pubsub_topic not in ("null", "")
 
     if not is_deployed:
         return StackStatus(
             compute_stack=stack,
             compute_deployed=False,
             storage_deployed=storage,
+            pubsub_configured=pubsub,
             cluster=None,
         )
 
@@ -190,6 +194,7 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
             compute_stack=stack,
             compute_deployed=True,
             storage_deployed=storage,
+            pubsub_configured=pubsub,
             cluster=cluster_info,
         )
 
@@ -199,6 +204,7 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
             compute_stack=stack,
             compute_deployed=True,
             storage_deployed=storage,
+            pubsub_configured=pubsub,
             cluster=None,
         )
 

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -338,10 +338,12 @@ async def deploy_stack(
                     "working_bucket_name",
                     "results_bucket_name",
                     "config_backups_bucket_name",
+                    "pubsub_topic_name",
+                    "pubsub_subscription_name",
                 ]:
-                    bucket_name = outputs.get(config_key, {}).get("value", "")
-                    if bucket_name:
-                        await _set_config(session, config_key, bucket_name)
+                    output_val = outputs.get(config_key, {}).get("value", "")
+                    if output_val:
+                        await _set_config(session, config_key, output_val)
                 await _set_config(session, "storage_deployed", "true")
                 await log_action(
                     session,
@@ -626,6 +628,8 @@ async def destroy_storage(
         "working_bucket_name",
         "results_bucket_name",
         "config_backups_bucket_name",
+        "pubsub_topic_name",
+        "pubsub_subscription_name",
         "stack_uid",
     ]:
         await _set_config(session, key, "null")

--- a/backend/app/services/trigger_service.py
+++ b/backend/app/services/trigger_service.py
@@ -27,8 +27,9 @@ from app.services.event_types import (
 )
 
 
-# In-memory batching windows: trigger_id -> {file_ids, expiry_time}
-_active_batches: dict[int, dict] = {}
+# In-memory batching windows: (trigger_id, experiment_id) -> {file_ids, expiry_time}
+# experiment_id may be None for files not associated with an experiment.
+_active_batches: dict[tuple[int, int | None], dict] = {}
 _batch_lock = asyncio.Lock()
 
 
@@ -144,9 +145,11 @@ class TriggerService:
             action="disable",
         )
 
-        # Remove any active batch for this trigger
+        # Remove all active batches for this trigger
         async with _batch_lock:
-            _active_batches.pop(trigger_id, None)
+            keys_to_remove = [k for k in _active_batches if k[0] == trigger_id]
+            for k in keys_to_remove:
+                del _active_batches[k]
 
         return trigger
 
@@ -178,12 +181,14 @@ class TriggerService:
             window_minutes = event_config.get("batching_window_minutes", 15)
 
             if window_minutes > 0:
-                # Add to batching window
+                # Add to per-experiment batching window
+                experiment_id = ingest_event.resolved_experiment_id
+                batch_key = (trigger.id, experiment_id)
                 async with _batch_lock:
-                    batch = _active_batches.get(trigger.id)
+                    batch = _active_batches.get(batch_key)
                     if batch is None:
                         batch = {"file_ids": [], "expiry_time": 0}
-                        _active_batches[trigger.id] = batch
+                        _active_batches[batch_key] = batch
                     batch["file_ids"].append(file_id)
                     batch["expiry_time"] = time.time() + window_minutes * 60
 
@@ -206,21 +211,23 @@ class TriggerService:
 
     @staticmethod
     async def process_expired_batches(db: AsyncSession) -> list[TriggerEvaluation]:
-        """Check for expired batches and submit pipeline runs."""
+        """Check for expired per-experiment batches and submit pipeline runs."""
         evaluations = []
         now = time.time()
-        expired_triggers: list[tuple[int, list[int]]] = []
+        expired: list[tuple[int, int | None, list[int]]] = []
 
         async with _batch_lock:
-            for trigger_id, batch in list(_active_batches.items()):
+            for batch_key, batch in list(_active_batches.items()):
                 if batch["expiry_time"] <= now and batch["file_ids"]:
-                    expired_triggers.append((trigger_id, list(batch["file_ids"])))
-                    del _active_batches[trigger_id]
+                    trigger_id, experiment_id = batch_key
+                    expired.append((trigger_id, experiment_id, list(batch["file_ids"])))
+                    del _active_batches[batch_key]
 
-        for trigger_id, file_ids in expired_triggers:
+        for trigger_id, experiment_id, file_ids in expired:
             result = await db.execute(select(PipelineTrigger).where(PipelineTrigger.id == trigger_id))
             trigger = result.scalar_one_or_none()
             if trigger and trigger.enabled:
+                exp_label = f" (experiment {experiment_id})" if experiment_id else ""
                 asyncio.create_task(
                     event_bus.emit(
                         BATCH_WINDOW_CLOSED,
@@ -229,7 +236,7 @@ class TriggerService:
                             "org_id": trigger.organization_id,
                             "entity_type": "pipeline_trigger",
                             "entity_id": trigger.id,
-                            "title": f"Batch window closed for trigger #{trigger.id}",
+                            "title": f"Batch window closed for trigger #{trigger.id}{exp_label}",
                             "message": f"Submitting {len(file_ids)} file(s) for evaluation",
                             "severity": "info",
                         },
@@ -512,7 +519,7 @@ class TriggerService:
         }
 
     @staticmethod
-    def get_active_batches() -> dict[int, dict]:
+    def get_active_batches() -> dict[tuple[int, int | None], dict]:
         """Expose active batches for testing."""
         return dict(_active_batches)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.1"
+version = "0.3.2"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -41,7 +41,13 @@ async def db_engine(worker_id):
 
     schema = _worker_schema(worker_id)
 
-    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        echo=False,
+        pool_pre_ping=True,
+        pool_size=5,
+        max_overflow=5,
+    )
 
     if schema != "public":
         async with engine.begin() as conn:

--- a/backend/tests/test_csv_preview.py
+++ b/backend/tests/test_csv_preview.py
@@ -1,0 +1,325 @@
+import io
+import csv
+
+import pytest
+
+from app.services.csv_service import (
+    generate_sample_template,
+    preview_sample_csv,
+    parse_sample_csv,
+    SAMPLE_FIELDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Template generation
+# ---------------------------------------------------------------------------
+
+
+def test_generate_template_returns_csv_bytes():
+    content = generate_sample_template()
+    assert isinstance(content, bytes)
+
+
+def test_generate_template_has_all_sample_fields():
+    content = generate_sample_template()
+    text = content.decode("utf-8")
+    reader = csv.reader(io.StringIO(text))
+    headers = next(reader)
+    for field in SAMPLE_FIELDS:
+        assert field in headers, f"Missing field '{field}' in template headers"
+
+
+def test_generate_template_has_example_row():
+    content = generate_sample_template()
+    text = content.decode("utf-8")
+    reader = csv.reader(io.StringIO(text))
+    next(reader)  # headers
+    example_row = next(reader)
+    # Example row should have values for at least some columns
+    assert any(val.strip() for val in example_row)
+
+
+# ---------------------------------------------------------------------------
+# Preview parsing
+# ---------------------------------------------------------------------------
+
+
+def test_preview_recognized_columns():
+    content = b"sample_id,organism,tissue_type\nS001,Human,Brain\nS002,Mouse,Liver\n"
+    result = preview_sample_csv(content)
+    assert result["total_rows"] == 2
+    assert len(result["errors"]) == 0
+    # All columns should be recognized
+    mapped_names = [c["mapped_to"] for c in result["recognized_columns"]]
+    assert "sample_id_external" in mapped_names
+    assert "organism" in mapped_names
+    assert "tissue_type" in mapped_names
+    assert len(result["unknown_columns"]) == 0
+
+
+def test_preview_detects_unknown_columns():
+    content = b"sample_id,batch_label,organism,mystery_field\nS001,B1,Human,foo\n"
+    result = preview_sample_csv(content)
+    unknown = result["unknown_columns"]
+    assert "batch_label" in unknown
+    assert "mystery_field" in unknown
+    # Known columns should still be recognized
+    mapped_names = [c["mapped_to"] for c in result["recognized_columns"]]
+    assert "sample_id_external" in mapped_names
+    assert "organism" in mapped_names
+
+
+def test_preview_returns_preview_rows():
+    rows = "\n".join([f"S{i:03d},Human" for i in range(1, 21)])
+    content = f"sample_id,organism\n{rows}\n".encode()
+    result = preview_sample_csv(content)
+    assert result["total_rows"] == 20
+    # Preview should return at most 5 rows
+    assert len(result["preview_rows"]) == 5
+    assert result["preview_rows"][0]["sample_id_external"] == "S001"
+
+
+def test_preview_empty_file():
+    result = preview_sample_csv(b"")
+    assert result["total_rows"] == 0
+    assert len(result["errors"]) >= 1
+
+
+def test_preview_includes_parse_errors():
+    content = b"sample_id,viability_pct\nS001,not_a_number\nS002,95.5\n"
+    result = preview_sample_csv(content)
+    assert len(result["errors"]) >= 1
+    assert "Invalid numeric" in result["errors"][0]
+    # Valid row should still be in preview
+    assert result["total_rows"] == 2
+
+
+def test_preview_alternative_headers():
+    content = b"external_id,tissue,donor\nEX1,Brain,Donor1\n"
+    result = preview_sample_csv(content)
+    mapped = {c["csv_header"]: c["mapped_to"] for c in result["recognized_columns"]}
+    assert mapped["external_id"] == "sample_id_external"
+    assert mapped["tissue"] == "tissue_type"
+    assert mapped["donor"] == "donor_source"
+
+
+# ---------------------------------------------------------------------------
+# Column mapping in parse_sample_csv
+# ---------------------------------------------------------------------------
+
+
+def test_parse_with_custom_column_mappings():
+    content = b"sample_id,batch_label,organism\nS001,B1,Human\nS002,B2,Mouse\n"
+    # User maps "batch_label" to prep_notes
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1, column_mappings={"batch_label": "prep_notes"})
+    assert len(samples) == 2
+    assert samples[0].prep_notes == "B1"
+    assert samples[1].prep_notes == "B2"
+
+
+def test_parse_with_custom_field_mapping():
+    content = b"sample_id,cell_line,organism\nS001,HEK293,Human\n"
+    # User says "cell_line" is a custom field
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1, column_mappings={"cell_line": "custom:cell_line"})
+    assert len(samples) == 1
+    assert samples[0].sample_id_external == "S001"
+    # Custom fields should be collected separately
+    assert len(errors) == 0
+
+
+def test_parse_mapping_overrides_ignored_column():
+    """If a column was unknown and user maps it, it should be used."""
+    content = b"sample_id,batch_label\nS001,my notes\n"
+    # Without mapping, batch_label is ignored
+    samples_no_map, _, _ = parse_sample_csv(content, experiment_id=1)
+    assert samples_no_map[0].prep_notes is None
+
+    # With mapping, batch_label goes to prep_notes
+    samples_mapped, _, _ = parse_sample_csv(content, experiment_id=1, column_mappings={"batch_label": "prep_notes"})
+    assert samples_mapped[0].prep_notes == "my notes"
+
+
+# ---------------------------------------------------------------------------
+# New columns in COLUMN_MAP
+# ---------------------------------------------------------------------------
+
+
+def test_molecule_type_column():
+    content = b"sample_id,molecule_type\nS001,mRNA\n"
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
+    assert len(samples) == 1
+    assert samples[0].molecule_type == "mRNA"
+
+
+def test_library_prep_method_column():
+    content = b"sample_id,library_prep_method\nS001,10x Chromium\n"
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
+    assert len(samples) == 1
+    assert samples[0].library_prep_method == "10x Chromium"
+
+
+def test_library_layout_column():
+    content = b"sample_id,library_layout\nS001,paired\n"
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
+    assert len(samples) == 1
+    assert samples[0].library_layout == "paired"
+
+
+def test_collection_method_column():
+    content = b"sample_id,collection_method\nS001,biopsy\n"
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
+    assert len(samples) == 1
+    assert samples[0].collection_method == "biopsy"
+
+
+def test_collection_timestamp_column():
+    content = b"sample_id,collection_timestamp\nS001,2024-01-15T10:30:00\n"
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
+    assert len(samples) == 1
+    assert samples[0].collection_timestamp is not None
+    assert samples[0].collection_timestamp.year == 2024
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_template_download_endpoint(client, admin_token):
+    response = await client.get(
+        "/api/experiments/1/samples/csv-template",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    # Template doesn't require an existing experiment
+    assert response.status_code == 200
+    assert "text/csv" in response.headers["content-type"]
+    # Should be parseable CSV
+    reader = csv.reader(io.StringIO(response.text))
+    headers = next(reader)
+    assert "sample_id_external" in headers
+    assert "organism" in headers
+
+
+@pytest.mark.asyncio
+async def test_preview_endpoint_all_recognized(client, admin_token):
+    resp = await client.post(
+        "/api/experiments",
+        json={"name": "Preview Test"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = resp.json()["id"]
+
+    csv_content = b"sample_id,organism,tissue_type\nS001,Human,Brain\nS002,Mouse,Liver\n"
+    response = await client.post(
+        f"/api/experiments/{exp_id}/samples/upload/preview",
+        files={"file": ("samples.csv", io.BytesIO(csv_content), "text/csv")},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_rows"] == 2
+    assert len(data["unknown_columns"]) == 0
+    assert len(data["recognized_columns"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_preview_endpoint_with_unknown_columns(client, admin_token):
+    resp = await client.post(
+        "/api/experiments",
+        json={"name": "Preview Unknown Test"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = resp.json()["id"]
+
+    csv_content = b"sample_id,organism,cell_line,passage_number\nS001,Human,HEK293,5\n"
+    response = await client.post(
+        f"/api/experiments/{exp_id}/samples/upload/preview",
+        files={"file": ("samples.csv", io.BytesIO(csv_content), "text/csv")},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "cell_line" in data["unknown_columns"]
+    assert "passage_number" in data["unknown_columns"]
+    assert data["total_rows"] == 1
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_creates_samples(client, admin_token):
+    resp = await client.post(
+        "/api/experiments",
+        json={"name": "Confirm Test"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = resp.json()["id"]
+
+    csv_content = b"sample_id,organism,tissue_type\nS001,Human,Brain\nS002,Mouse,Liver\n"
+    response = await client.post(
+        f"/api/experiments/{exp_id}/samples/upload/confirm",
+        files={"file": ("samples.csv", io.BytesIO(csv_content), "text/csv")},
+        data={"column_mappings": "{}"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created_count"] == 2
+    assert data["error_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_with_column_remapping(client, admin_token):
+    resp = await client.post(
+        "/api/experiments",
+        json={"name": "Remap Test"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = resp.json()["id"]
+
+    csv_content = b"sample_id,batch_label,organism\nS001,my notes,Human\n"
+    import json
+
+    response = await client.post(
+        f"/api/experiments/{exp_id}/samples/upload/confirm",
+        files={"file": ("samples.csv", io.BytesIO(csv_content), "text/csv")},
+        data={"column_mappings": json.dumps({"batch_label": "prep_notes"})},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created_count"] == 1
+
+    # Verify the mapping took effect
+    samples_resp = await client.get(
+        f"/api/experiments/{exp_id}/samples",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    samples = samples_resp.json()
+    assert samples[0]["prep_notes"] == "my notes"
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_with_custom_fields(client, admin_token):
+    resp = await client.post(
+        "/api/experiments",
+        json={"name": "Custom Field Test"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = resp.json()["id"]
+
+    csv_content = b"sample_id,organism,cell_line\nS001,Human,HEK293\n"
+    import json
+
+    response = await client.post(
+        f"/api/experiments/{exp_id}/samples/upload/confirm",
+        files={"file": ("samples.csv", io.BytesIO(csv_content), "text/csv")},
+        data={"column_mappings": json.dumps({"cell_line": "custom:cell_line"})},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created_count"] == 1
+    # Custom fields should be reported in response
+    assert "custom_fields_created" in data
+    assert data["custom_fields_created"] == ["cell_line"]

--- a/backend/tests/test_csv_upload.py
+++ b/backend/tests/test_csv_upload.py
@@ -6,7 +6,7 @@ from app.services.csv_service import parse_sample_csv
 
 def test_parse_valid_csv():
     content = b"sample_id,organism,tissue_type\nS001,Human,Brain\nS002,Mouse,Liver\n"
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 2
     assert len(errors) == 0
     assert samples[0].sample_id_external == "S001"
@@ -16,14 +16,14 @@ def test_parse_valid_csv():
 
 def test_parse_tsv():
     content = b"sample_id\torganism\ttissue\nS001\tHuman\tBrain\n"
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 1
     assert samples[0].tissue_type == "Brain"
 
 
 def test_parse_alternative_headers():
     content = b"external_id,tissue,donor,treatment,chemistry\nEX1,Brain,Donor1,Drug A,v3\n"
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 1
     assert samples[0].sample_id_external == "EX1"
     assert samples[0].tissue_type == "Brain"
@@ -34,7 +34,7 @@ def test_parse_alternative_headers():
 
 def test_parse_with_numeric_fields():
     content = b"sample_id,viability_pct,cell_count\nS001,95.5,10000\n"
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 1
     assert samples[0].viability_pct == 95.5
     assert samples[0].cell_count == 10000
@@ -42,33 +42,33 @@ def test_parse_with_numeric_fields():
 
 def test_parse_invalid_numeric():
     content = b"sample_id,viability_pct\nS001,not_a_number\n"
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(errors) >= 1
     assert "Invalid numeric" in errors[0]
 
 
 def test_parse_empty_rows_skipped():
     content = b"sample_id,organism\nS001,Human\n\n\nS002,Mouse\n"
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 2
 
 
 def test_parse_empty_file():
     content = b""
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 0
     assert len(errors) >= 1
 
 
 def test_parse_latin1_encoding():
     content = "sample_id,organism\nS001,Mus musculus\n".encode("latin-1")
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 1
 
 
 def test_parse_unknown_columns():
     content = b"sample_id,unknown_col,organism\nS001,mystery,Human\n"
-    samples, errors = parse_sample_csv(content, experiment_id=1)
+    samples, errors, _ = parse_sample_csv(content, experiment_id=1)
     assert len(samples) == 1
     assert samples[0].organism == "Human"
 

--- a/backend/tests/test_stack_deployment.py
+++ b/backend/tests/test_stack_deployment.py
@@ -704,6 +704,61 @@ async def test_deploy_stack_stores_bucket_names_after_storage(session):
     assert await _get_config(session, "config_backups_bucket_name") == "bioaf-abc123-config-backups"
 
 
+@pytest.mark.asyncio
+async def test_deploy_stack_stores_pubsub_names_after_storage(session):
+    """Storage apply_complete event writes Pub/Sub topic and subscription to platform_config."""
+    from app.services.stack_deployment import deploy_stack
+
+    _, user_id = await _seed_org_and_user(session)
+
+    await _set_config(session, "gcp_credentials_configured", "true")
+    await _set_config(session, "terraform_initialized", "true")
+    await _set_config(session, "compute_deployed", "false")
+    await _set_config(session, "storage_deployed", "false")
+    await _set_config(session, "pubsub_topic_name", "null")
+    await _set_config(session, "pubsub_subscription_name", "null")
+    await session.commit()
+
+    storage_outputs = {
+        "ingest_bucket_name": {"value": "bioaf-abc123-ingest"},
+        "raw_bucket_name": {"value": "bioaf-abc123-raw"},
+        "working_bucket_name": {"value": "bioaf-abc123-working"},
+        "results_bucket_name": {"value": "bioaf-abc123-results"},
+        "config_backups_bucket_name": {"value": "bioaf-abc123-config-backups"},
+        "pubsub_topic_name": {"value": "bioaf-ingest-events-abc123"},
+        "pubsub_subscription_name": {"value": "bioaf-ingest-worker-abc123"},
+    }
+
+    async def mock_run_module(sess, uid, module_name):
+        if module_name == "storage":
+            yield _make_progress_event(
+                "apply_complete",
+                "storage done",
+                extra={"outputs": storage_outputs},
+            )
+        else:
+            yield _make_progress_event(
+                "apply_complete",
+                "compute done",
+                extra={
+                    "outputs": {
+                        "cluster_name": {"value": "bioaf-test"},
+                        "cluster_endpoint": {"value": "https://1.2.3.4"},
+                        "cluster_ca_cert": {"value": "Y2VydA=="},
+                    }
+                },
+            )
+
+    with patch("app.services.stack_deployment._run_module", side_effect=mock_run_module):
+        async for _ in deploy_stack(session, "kubernetes", user_id=user_id):
+            pass
+
+    await session.commit()
+
+    assert await _get_config(session, "pubsub_topic_name") == "bioaf-ingest-events-abc123"
+    assert await _get_config(session, "pubsub_subscription_name") == "bioaf-ingest-worker-abc123"
+
+
 # -----------------------------------------------------------------------
 # destroy_storage tests
 # -----------------------------------------------------------------------
@@ -752,6 +807,8 @@ async def test_destroy_storage_clears_config_and_resets_stack_uid(session):
     await _set_config(session, "working_bucket_name", "bioaf-working-abc123")
     await _set_config(session, "results_bucket_name", "bioaf-results-abc123")
     await _set_config(session, "config_backups_bucket_name", "bioaf-config-backups-abc123")
+    await _set_config(session, "pubsub_topic_name", "bioaf-ingest-events-abc123")
+    await _set_config(session, "pubsub_subscription_name", "bioaf-ingest-worker-abc123")
     await session.commit()
 
     async def mock_run_destroy(sess, uid, module_name):
@@ -771,6 +828,8 @@ async def test_destroy_storage_clears_config_and_resets_stack_uid(session):
     assert await _get_config(session, "working_bucket_name") == "null"
     assert await _get_config(session, "results_bucket_name") == "null"
     assert await _get_config(session, "config_backups_bucket_name") == "null"
+    assert await _get_config(session, "pubsub_topic_name") == "null"
+    assert await _get_config(session, "pubsub_subscription_name") == "null"
 
     event_types = [e.event_type for e in events]
     assert "stack_complete" in event_types

--- a/backend/tests/test_trigger_per_experiment.py
+++ b/backend/tests/test_trigger_per_experiment.py
@@ -1,0 +1,426 @@
+"""Tests for per-experiment batching and scheduled trigger execution."""
+
+import time
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.models.file import File
+from app.models.ingest_event import IngestEvent
+from app.models.pipeline_catalog_entry import PipelineCatalogEntry
+from app.models.project import Project
+from app.schemas.pipeline_trigger import (
+    EventTriggerConfig,
+    PipelineTriggerCreate,
+    ScheduleTriggerConfig,
+)
+from app.services.trigger_service import TriggerService
+
+
+@pytest_asyncio.fixture
+async def org_user(client, admin_token, session):
+    result = await session.execute(text("SELECT id FROM organizations LIMIT 1"))
+    org = result.fetchone()
+    result = await session.execute(text("SELECT id FROM users LIMIT 1"))
+    user = result.fetchone()
+    return org.id, user.id
+
+
+@pytest_asyncio.fixture
+async def pipeline(session, org_user):
+    org_id, _ = org_user
+    p = PipelineCatalogEntry(
+        organization_id=org_id,
+        pipeline_key="per-exp-test-pipeline",
+        name="Per-Experiment Test Pipeline",
+        source_type="github",
+        source_url="https://example.com",
+        version="1.0",
+    )
+    session.add(p)
+    await session.flush()
+    await session.commit()
+    return p
+
+
+@pytest_asyncio.fixture
+async def experiments(session, org_user):
+    """Create two experiments under a project."""
+    from app.models.experiment import Experiment
+
+    org_id, _ = org_user
+    project = Project(organization_id=org_id, name="BatchTestProject")
+    session.add(project)
+    await session.flush()
+
+    exp_a = Experiment(name="Experiment A", project_id=project.id, organization_id=org_id)
+    exp_b = Experiment(name="Experiment B", project_id=project.id, organization_id=org_id)
+    session.add_all([exp_a, exp_b])
+    await session.flush()
+    await session.commit()
+    return exp_a, exp_b
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clear_batches():
+    TriggerService.clear_batches()
+    yield
+    TriggerService.clear_batches()
+
+
+def _make_file_and_event(session, org_id, filename, experiment_id=None, project_id=None):
+    """Helper to create a file + ingest event. Must be awaited for flush."""
+    f = File(
+        organization_id=org_id,
+        gcs_uri=f"gs://bucket/{filename}",
+        filename=filename,
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add(f)
+    return f, experiment_id, project_id
+
+
+# ---------------------------------------------------------------------------
+# Per-experiment batching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batching_separates_experiments(
+    client, admin_token, session, org_user, pipeline, experiments, monkeypatch
+):
+    """Files from different experiments get separate batch windows."""
+    monkeypatch.setenv("BIOAF_MOCK_MONTHLY_SPEND", "0")
+    monkeypatch.setenv("BIOAF_MONTHLY_BUDGET", "500.0")
+    org_id, user_id = org_user
+    exp_a, exp_b = experiments
+
+    data = PipelineTriggerCreate(
+        pipeline_id=pipeline.id,
+        trigger_mode="event_driven",
+        event_config=EventTriggerConfig(file_types=["fastq"], batching_window_minutes=15),
+    )
+    trigger = await TriggerService.create_trigger(session, org_id, user_id, data)
+    await session.commit()
+
+    # File 1 for experiment A
+    f1 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/a1.fastq",
+        filename="a1.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    # File 2 for experiment B
+    f2 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/b1.fastq",
+        filename="b1.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add_all([f1, f2])
+    await session.flush()
+
+    ev1 = IngestEvent(
+        file_id=f1.id,
+        source_bucket="b",
+        source_path="a1.fastq",
+        ingest_status="cataloged",
+        resolved_experiment_id=exp_a.id,
+    )
+    ev2 = IngestEvent(
+        file_id=f2.id,
+        source_bucket="b",
+        source_path="b1.fastq",
+        ingest_status="cataloged",
+        resolved_experiment_id=exp_b.id,
+    )
+    session.add_all([ev1, ev2])
+    await session.flush()
+
+    await TriggerService.evaluate_event_triggers(ev1, session)
+    await TriggerService.evaluate_event_triggers(ev2, session)
+    await session.commit()
+
+    batches = TriggerService.get_active_batches()
+    # Should have two separate batch keys, not one
+    batch_keys = [k for k in batches if k[0] == trigger.id] if isinstance(list(batches.keys())[0], tuple) else []
+    assert len(batch_keys) == 2, f"Expected 2 per-experiment batches, got {len(batch_keys)}: {batches}"
+
+
+@pytest.mark.asyncio
+async def test_batch_expiry_per_experiment(client, admin_token, session, org_user, pipeline, experiments, monkeypatch):
+    """Expired batch for one experiment doesn't affect another's window."""
+    monkeypatch.setenv("BIOAF_MOCK_MONTHLY_SPEND", "0")
+    monkeypatch.setenv("BIOAF_MONTHLY_BUDGET", "500.0")
+    org_id, user_id = org_user
+    exp_a, exp_b = experiments
+
+    data = PipelineTriggerCreate(
+        pipeline_id=pipeline.id,
+        trigger_mode="event_driven",
+        event_config=EventTriggerConfig(file_types=["fastq"], batching_window_minutes=1),
+    )
+    await TriggerService.create_trigger(session, org_id, user_id, data)
+    await session.commit()
+
+    f1 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/ea1.fastq",
+        filename="ea1.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    f2 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/eb1.fastq",
+        filename="eb1.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add_all([f1, f2])
+    await session.flush()
+
+    # Experiment A file arrives first
+    ev1 = IngestEvent(
+        file_id=f1.id,
+        source_bucket="b",
+        source_path="ea1.fastq",
+        ingest_status="cataloged",
+        resolved_experiment_id=exp_a.id,
+    )
+    session.add(ev1)
+    await session.flush()
+    await TriggerService.evaluate_event_triggers(ev1, session)
+
+    # Force expire experiment A's batch
+    batches = TriggerService.get_active_batches()
+    for key in batches:
+        if isinstance(key, tuple) and key[1] == exp_a.id:
+            batches[key]["expiry_time"] = time.time() - 1
+
+    # Experiment B file arrives (should get its own window)
+    ev2 = IngestEvent(
+        file_id=f2.id,
+        source_bucket="b",
+        source_path="eb1.fastq",
+        ingest_status="cataloged",
+        resolved_experiment_id=exp_b.id,
+    )
+    session.add(ev2)
+    await session.flush()
+    await TriggerService.evaluate_event_triggers(ev2, session)
+
+    # Process expired batches -- only exp A should fire
+    evaluations = await TriggerService.process_expired_batches(session)
+    await session.commit()
+
+    assert len(evaluations) == 1, f"Expected 1 expired batch (exp A), got {len(evaluations)}"
+    # Experiment B should still have an active batch
+    remaining = TriggerService.get_active_batches()
+    assert len(remaining) == 1, "Experiment B batch should still be active"
+
+
+@pytest.mark.asyncio
+async def test_files_without_experiment_batch_separately(client, admin_token, session, org_user, pipeline, monkeypatch):
+    """Files with no resolved experiment get their own batch (experiment_id=None)."""
+    monkeypatch.setenv("BIOAF_MOCK_MONTHLY_SPEND", "0")
+    monkeypatch.setenv("BIOAF_MONTHLY_BUDGET", "500.0")
+    org_id, user_id = org_user
+
+    data = PipelineTriggerCreate(
+        pipeline_id=pipeline.id,
+        trigger_mode="event_driven",
+        event_config=EventTriggerConfig(file_types=["fastq"], batching_window_minutes=15),
+    )
+    await TriggerService.create_trigger(session, org_id, user_id, data)
+    await session.commit()
+
+    f1 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/unmatched.fastq",
+        filename="unmatched.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add(f1)
+    await session.flush()
+
+    ev = IngestEvent(
+        file_id=f1.id,
+        source_bucket="b",
+        source_path="unmatched.fastq",
+        ingest_status="cataloged",
+        resolved_experiment_id=None,
+    )
+    session.add(ev)
+    await session.flush()
+
+    await TriggerService.evaluate_event_triggers(ev, session)
+    await session.commit()
+
+    batches = TriggerService.get_active_batches()
+    assert len(batches) == 1
+    key = list(batches.keys())[0]
+    # Key should be (trigger_id, None) for unresolved experiment
+    assert isinstance(key, tuple)
+    assert key[1] is None
+
+
+@pytest.mark.asyncio
+async def test_new_file_resets_experiment_timer(
+    client, admin_token, session, org_user, pipeline, experiments, monkeypatch
+):
+    """A new file for the same experiment resets the batch expiry timer."""
+    monkeypatch.setenv("BIOAF_MOCK_MONTHLY_SPEND", "0")
+    monkeypatch.setenv("BIOAF_MONTHLY_BUDGET", "500.0")
+    org_id, user_id = org_user
+    exp_a, _ = experiments
+
+    data = PipelineTriggerCreate(
+        pipeline_id=pipeline.id,
+        trigger_mode="event_driven",
+        event_config=EventTriggerConfig(file_types=["fastq"], batching_window_minutes=15),
+    )
+    trigger = await TriggerService.create_trigger(session, org_id, user_id, data)
+    await session.commit()
+
+    f1 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/r1.fastq",
+        filename="r1.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add(f1)
+    await session.flush()
+
+    ev1 = IngestEvent(
+        file_id=f1.id,
+        source_bucket="b",
+        source_path="r1.fastq",
+        ingest_status="cataloged",
+        resolved_experiment_id=exp_a.id,
+    )
+    session.add(ev1)
+    await session.flush()
+
+    await TriggerService.evaluate_event_triggers(ev1, session)
+    batches = TriggerService.get_active_batches()
+    first_key = (trigger.id, exp_a.id)
+    first_expiry = batches[first_key]["expiry_time"]
+
+    # Second file arrives -- timer should reset to later
+    f2 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/r2.fastq",
+        filename="r2.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add(f2)
+    await session.flush()
+
+    ev2 = IngestEvent(
+        file_id=f2.id,
+        source_bucket="b",
+        source_path="r2.fastq",
+        ingest_status="cataloged",
+        resolved_experiment_id=exp_a.id,
+    )
+    session.add(ev2)
+    await session.flush()
+
+    await TriggerService.evaluate_event_triggers(ev2, session)
+    await session.commit()
+
+    batches = TriggerService.get_active_batches()
+    second_expiry = batches[first_key]["expiry_time"]
+    assert second_expiry >= first_expiry
+    assert len(batches[first_key]["file_ids"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Scheduled trigger execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduled_trigger_evaluates(client, admin_token, session, org_user, pipeline, monkeypatch):
+    """Scheduled trigger finds unprocessed files and submits a run."""
+    monkeypatch.setenv("BIOAF_MOCK_MONTHLY_SPEND", "0")
+    monkeypatch.setenv("BIOAF_MONTHLY_BUDGET", "500.0")
+    org_id, user_id = org_user
+
+    data = PipelineTriggerCreate(
+        pipeline_id=pipeline.id,
+        trigger_mode="scheduled",
+        schedule_config=ScheduleTriggerConfig(
+            cron_expression="0 0 * * *",
+            file_types=["fastq"],
+            min_files_to_trigger=1,
+        ),
+    )
+    trigger = await TriggerService.create_trigger(session, org_id, user_id, data)
+    await session.commit()
+
+    f1 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/sched.fastq",
+        filename="sched.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add(f1)
+    await session.flush()
+    await session.commit()
+
+    evaluations = await TriggerService.evaluate_scheduled_triggers(session)
+    await session.commit()
+
+    assert len(evaluations) >= 1
+    submitted = [e for e in evaluations if e.trigger_id == trigger.id]
+    assert len(submitted) == 1
+    assert submitted[0].result == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_trigger_skips_below_minimum(client, admin_token, session, org_user, pipeline, monkeypatch):
+    """Scheduled trigger does not fire when file count is below minimum."""
+    monkeypatch.setenv("BIOAF_MOCK_MONTHLY_SPEND", "0")
+    monkeypatch.setenv("BIOAF_MONTHLY_BUDGET", "500.0")
+    org_id, user_id = org_user
+
+    data = PipelineTriggerCreate(
+        pipeline_id=pipeline.id,
+        trigger_mode="scheduled",
+        schedule_config=ScheduleTriggerConfig(
+            cron_expression="0 0 * * *",
+            file_types=["fastq"],
+            min_files_to_trigger=5,
+        ),
+    )
+    trigger = await TriggerService.create_trigger(session, org_id, user_id, data)
+    await session.commit()
+
+    # Only one file, minimum is 5
+    f1 = File(
+        organization_id=org_id,
+        gcs_uri="gs://b/min.fastq",
+        filename="min.fastq",
+        file_type="fastq",
+        ingest_source="auto_ingest",
+    )
+    session.add(f1)
+    await session.flush()
+    await session.commit()
+
+    evaluations = await TriggerService.evaluate_scheduled_triggers(session)
+    await session.commit()
+
+    our_evals = [e for e in evaluations if e.trigger_id == trigger.id]
+    assert len(our_evals) == 1
+    assert our_evals[0].result == "no_files"

--- a/backend/tests/test_trigger_service.py
+++ b/backend/tests/test_trigger_service.py
@@ -231,10 +231,12 @@ async def test_batching_window(client, admin_token, session, org_user, pipeline,
     await TriggerService.evaluate_event_triggers(ev2, session)
     await session.commit()
 
-    # Check that both files are in the batch
+    # Check that both files are in the batch (keyed by (trigger_id, experiment_id))
     batches = TriggerService.get_active_batches()
-    assert trigger.id in batches
-    assert len(batches[trigger.id]["file_ids"]) == 2
+    # Both events have no experiment, so key is (trigger.id, None)
+    batch_key = (trigger.id, None)
+    assert batch_key in batches
+    assert len(batches[batch_key]["file_ids"]) == 2
 
 
 @pytest.mark.asyncio

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,8 @@ Welcome to the bioAF documentation. bioAF is a turnkey computational biology pla
 ## Architecture
 
 - [ADR Index](adr-index.md) - All Architecture Decision Records
-- [Architecture Spec](../documentation/bioAF-architecture-spec-v0_2.md) - System architecture
-- [Product Spec](../documentation/bioAF-product-spec-v0_4.md) - Full product specification
+- [Architecture Spec](../documentation/bioAF-architecture-spec-v0_3.md) - System architecture
+- [Product Spec](../documentation/bioAF-product-spec-v0_5.md) - Full product specification
 
 ## API Reference
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/naming-profiles/page.tsx
+++ b/frontend/src/app/admin/naming-profiles/page.tsx
@@ -178,7 +178,7 @@ export default function NamingProfilesPage() {
         <main className="flex-1 overflow-y-auto p-6">
           <div className="max-w-6xl mx-auto">
             <div className="flex justify-between items-center mb-6">
-              <h1 className="text-2xl font-bold text-gray-900">Naming Profiles</h1>
+              <h1 className="text-2xl font-bold text-gray-900">Naming Profiles <span className="ml-2 text-xs font-medium bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full align-middle">Beta</span></h1>
               <div className="flex gap-2">
                 <button
                   onClick={() => { setShowTest(!showTest); setShowCreate(false); setShowWizard(false); }}

--- a/frontend/src/app/admin/naming-profiles/page.tsx
+++ b/frontend/src/app/admin/naming-profiles/page.tsx
@@ -8,6 +8,7 @@ import { isAuthenticated } from "@/lib/auth";
 import { usePermissions } from "@/hooks/usePermissions";
 import { api } from "@/lib/api";
 import type { NamingProfile, NamingProfileTestResult, SegmentDefinition } from "@/lib/types";
+import { NamingProfileWizard } from "@/components/naming/NamingProfileWizard";
 
 const FIELD_OPTIONS = [
   "date", "project_code", "experiment_code", "sample_id",
@@ -21,6 +22,7 @@ export default function NamingProfilesPage() {
   const [profiles, setProfiles] = useState<NamingProfile[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
+  const [showWizard, setShowWizard] = useState(false);
   const [showTest, setShowTest] = useState(false);
   const [editingProfile, setEditingProfile] = useState<NamingProfile | null>(null);
 
@@ -179,22 +181,36 @@ export default function NamingProfilesPage() {
               <h1 className="text-2xl font-bold text-gray-900">Naming Profiles</h1>
               <div className="flex gap-2">
                 <button
-                  onClick={() => { setShowTest(!showTest); setShowCreate(false); }}
+                  onClick={() => { setShowTest(!showTest); setShowCreate(false); setShowWizard(false); }}
                   className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
                 >
                   Test Filenames
                 </button>
                 <button
-                  onClick={() => { resetForm(); setShowCreate(!showCreate); setShowTest(false); }}
+                  onClick={() => { setShowWizard(!showWizard); setShowCreate(false); setShowTest(false); }}
                   className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700"
                 >
                   New Profile
+                </button>
+                <button
+                  onClick={() => { resetForm(); setShowCreate(!showCreate); setShowTest(false); setShowWizard(false); }}
+                  className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
+                >
+                  Advanced
                 </button>
               </div>
             </div>
 
             {error && <div className="mb-4 p-3 bg-red-50 text-red-700 rounded-lg">{error}</div>}
             {message && <div className="mb-4 p-3 bg-green-50 text-green-700 rounded-lg">{message}</div>}
+
+            {/* Wizard */}
+            {showWizard && (
+              <NamingProfileWizard
+                onSave={() => { setShowWizard(false); loadProfiles(); setMessage("Profile created"); }}
+                onCancel={() => setShowWizard(false)}
+              />
+            )}
 
             {/* Test Panel */}
             {showTest && (

--- a/frontend/src/app/experiments/[id]/page.tsx
+++ b/frontend/src/app/experiments/[id]/page.tsx
@@ -16,6 +16,7 @@ import { ProvenanceExportMenu } from "@/components/shared/ProvenanceExportMenu";
 import { ProvenanceReportPanel } from "@/components/provenance/ProvenanceReportPanel";
 import { FileBrowser } from "@/components/files/FileBrowser";
 import { VocabularySelect } from "@/components/shared/VocabularySelect";
+import { CsvUploadModal } from "@/components/experiments/CsvUploadModal";
 import { ExtensibleVocabularySelect } from "@/components/shared/ExtensibleVocabularySelect";
 import { isAuthenticated, getCurrentUser } from "@/lib/auth";
 import { api, fileContentUrl } from "@/lib/api";
@@ -69,6 +70,7 @@ export default function ExperimentDetailPage() {
   const [overviewForm, setOverviewForm] = useState<ExperimentUpdateRequest>({});
   const [overviewError, setOverviewError] = useState("");
   const [showSampleForm, setShowSampleForm] = useState(false);
+  const [showCsvUpload, setShowCsvUpload] = useState(false);
   const [showBatchForm, setShowBatchForm] = useState(false);
   const [sampleForm, setSampleForm] = useState<SampleCreateRequest>({});
   const [sampleFormError, setSampleFormError] = useState("");
@@ -253,12 +255,9 @@ export default function ExperimentDetailPage() {
     } catch {}
   }
 
-  async function handleCsvUpload(file: File) {
-    try {
-      await api.upload(`/api/experiments/${id}/samples/upload`, file);
-      loadSamples();
-      loadExperiment();
-    } catch {}
+  function handleCsvUploadSuccess() {
+    loadSamples();
+    loadExperiment();
   }
 
   function startEditSample(sample: Sample) {
@@ -615,15 +614,12 @@ export default function ExperimentDetailPage() {
                 >
                   Add Sample
                 </button>
-                <label className="bg-white border border-gray-300 px-4 py-2 rounded-md text-sm cursor-pointer hover:bg-gray-50">
+                <button
+                  onClick={() => setShowCsvUpload(true)}
+                  className="bg-white border border-gray-300 px-4 py-2 rounded-md text-sm hover:bg-gray-50"
+                >
                   Upload CSV
-                  <input
-                    type="file"
-                    accept=".csv,.tsv,.txt"
-                    className="hidden"
-                    onChange={(e) => { if (e.target.files?.[0]) handleCsvUpload(e.target.files[0]); }}
-                  />
-                </label>
+                </button>
                 {selectedSampleIds.size > 0 && (
                   <button
                     onClick={() => { setShowBulkEdit(true); setBulkEditForm({}); setBulkEditError(""); }}
@@ -1088,6 +1084,13 @@ export default function ExperimentDetailPage() {
                 </table>
               </div>
             </div>
+          )}
+          {showCsvUpload && (
+            <CsvUploadModal
+              experimentId={Number(id)}
+              onClose={() => setShowCsvUpload(false)}
+              onSuccess={handleCsvUploadSuccess}
+            />
           )}
           <DataExportModal
             experimentId={Number(id)}

--- a/frontend/src/app/experiments/[id]/page.tsx
+++ b/frontend/src/app/experiments/[id]/page.tsx
@@ -391,6 +391,9 @@ export default function ExperimentDetailPage() {
               ← Back
             </button>
             <h1 className="text-2xl font-bold">{experiment.name}</h1>
+            {experiment.code && (
+              <span className="text-sm font-mono bg-gray-100 text-gray-600 px-2 py-0.5 rounded">{experiment.code}</span>
+            )}
             <ExperimentStatusBadge status={experiment.status} />
             <div className="ml-auto flex items-center gap-2">
               <ProvenanceExportMenu entityType="experiments" entityId={Number(id)} />

--- a/frontend/src/app/experiments/page.tsx
+++ b/frontend/src/app/experiments/page.tsx
@@ -128,6 +128,7 @@ export default function ExperimentsPage() {
                   <thead className="bg-gray-50">
                     <tr>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Code</th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Project</th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Owner</th>
@@ -143,6 +144,7 @@ export default function ExperimentsPage() {
                         className="hover:bg-gray-50 cursor-pointer"
                       >
                         <td className="px-6 py-4 text-sm font-medium text-gray-900">{exp.name}</td>
+                        <td className="px-6 py-4 text-sm text-gray-500 font-mono">{exp.code || "—"}</td>
                         <td className="px-6 py-4 text-sm text-gray-500">{exp.project?.name || "—"}</td>
                         <td className="px-6 py-4">
                           <ExperimentStatusBadge status={exp.status} />

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -57,6 +57,7 @@ interface StackStatus {
   compute_stack: string | null;
   compute_deployed: boolean;
   storage_deployed: boolean;
+  pubsub_configured: boolean;
   cluster: ClusterInfo | null;
 }
 
@@ -847,7 +848,9 @@ export default function InfraComponentsPage() {
                 <StorageSection
                   storageDeployed={stackStatus?.storage_deployed ?? false}
                   terraformInitialized={tfInitialized}
-                  onDeploy={() => {}}
+                  pubsubConfigured={stackStatus?.pubsub_configured ?? false}
+                  onDeploy={() => setShowDeployModal(true)}
+                  onUpdateStorage={() => setRefreshKey((k) => k + 1)}
                 />
               </div>
             </>

--- a/frontend/src/app/pipelines/triggers/page.tsx
+++ b/frontend/src/app/pipelines/triggers/page.tsx
@@ -130,7 +130,7 @@ export default function PipelineTriggersPage() {
         <main className="flex-1 overflow-y-auto p-6">
           <div className="max-w-6xl mx-auto">
             <div className="flex justify-between items-center mb-6">
-              <h1 className="text-2xl font-bold text-gray-900">Pipeline Triggers</h1>
+              <h1 className="text-2xl font-bold text-gray-900">Pipeline Triggers <span className="ml-2 text-xs font-medium bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full align-middle">Beta</span></h1>
               <button
                 onClick={() => setShowCreate(!showCreate)}
                 className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700"

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -203,6 +203,9 @@ export default function ProjectDetailPage() {
           <div className="mb-6">
             <div className="flex items-center gap-3 mb-2">
               <h1 className="text-2xl font-bold">{project.name}</h1>
+              {project.code && (
+                <span className="text-sm font-mono bg-gray-100 text-gray-600 px-2 py-0.5 rounded">{project.code}</span>
+              )}
               <StatusBadge status={project.status || "active"} />
               <div className="ml-auto">
                 {canModify && (

--- a/frontend/src/app/projects/page.tsx
+++ b/frontend/src/app/projects/page.tsx
@@ -129,6 +129,7 @@ export default function ProjectsPage() {
                 <thead className="bg-gray-50">
                   <tr>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Code</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Owner</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Samples</th>
@@ -145,6 +146,7 @@ export default function ProjectsPage() {
                       className="hover:bg-gray-50 cursor-pointer"
                     >
                       <td className="px-6 py-4 text-sm font-medium text-gray-900">{p.name}</td>
+                      <td className="px-6 py-4 text-sm text-gray-500 font-mono">{p.code || "—"}</td>
                       <td className="px-6 py-4">
                         <StatusBadge status={p.status || "active"} />
                       </td>

--- a/frontend/src/components/components/AutoIngestControls.tsx
+++ b/frontend/src/components/components/AutoIngestControls.tsx
@@ -153,6 +153,7 @@ export function AutoIngestControls({
           <span className="text-xs font-medium text-gray-700 uppercase tracking-wide">
             Auto-Ingest
           </span>
+          <span className="text-xs font-medium bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded-full">Beta</span>
           <span
             data-testid="status-dot"
             className={`inline-block w-2 h-2 rounded-full ${dotColor}`}

--- a/frontend/src/components/components/AutoIngestControls.tsx
+++ b/frontend/src/components/components/AutoIngestControls.tsx
@@ -26,6 +26,8 @@ export function AutoIngestControls({
 }: AutoIngestControlsProps) {
   const [status, setStatus] = useState<AutoIngestStatus | null>(null);
   const [loading, setLoading] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const [updateError, setUpdateError] = useState("");
 
   useEffect(() => {
     if (!storageDeployed || !pubsubConfigured) return;
@@ -37,18 +39,39 @@ export function AutoIngestControls({
 
   if (!storageDeployed) return null;
 
+  const handleUpdateStorage = async () => {
+    setUpdating(true);
+    setUpdateError("");
+    try {
+      await api.post("/api/v1/infrastructure/storage/update");
+      // Trigger parent refresh so pubsubConfigured updates
+      if (onUpdateStorage) onUpdateStorage();
+    } catch (err) {
+      setUpdateError(
+        err instanceof Error ? err.message : "Storage update failed",
+      );
+    } finally {
+      setUpdating(false);
+    }
+  };
+
   if (!pubsubConfigured) {
     return (
       <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded text-sm">
         <p className="text-amber-800 font-medium text-xs">
-          Auto-ingest requires an infrastructure update. Click to deploy the
-          notification system.
+          Auto-ingest requires Pub/Sub notification infrastructure. This runs a
+          Terraform apply to add the notification resources to your existing
+          storage deployment.
         </p>
+        {updateError && (
+          <p className="text-xs text-red-600 mt-1">{updateError}</p>
+        )}
         <button
-          onClick={onUpdateStorage}
-          className="mt-2 px-3 py-1.5 bg-amber-600 text-white rounded text-xs hover:bg-amber-700"
+          onClick={handleUpdateStorage}
+          disabled={updating}
+          className="mt-2 px-3 py-1.5 bg-amber-600 text-white rounded text-xs hover:bg-amber-700 disabled:opacity-50"
         >
-          Update Storage Infrastructure
+          {updating ? "Updating infrastructure..." : "Update Storage Infrastructure"}
         </button>
       </div>
     );

--- a/frontend/src/components/components/AutoIngestControls.tsx
+++ b/frontend/src/components/components/AutoIngestControls.tsx
@@ -6,6 +6,7 @@ import { api } from "@/lib/api";
 interface AutoIngestStatus {
   enabled: boolean;
   cleanup_policy: string;
+  default_delay_minutes: number;
   listener_running: boolean;
   pubsub_topic: string | null;
   pubsub_subscription: string | null;
@@ -84,6 +85,25 @@ export function AutoIngestControls({
       await api.post("/api/v1/settings/auto-ingest", {
         enabled: newEnabled,
         cleanup_policy: status?.cleanup_policy || "delete_after_copy",
+      });
+      const updated = await api.get<AutoIngestStatus>(
+        "/api/v1/settings/auto-ingest",
+      );
+      setStatus(updated);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelayChange = async (minutes: number) => {
+    setLoading(true);
+    try {
+      await api.post("/api/v1/settings/auto-ingest", {
+        enabled: status?.enabled ?? false,
+        cleanup_policy: status?.cleanup_policy || "delete_after_copy",
+        default_delay_minutes: minutes,
       });
       const updated = await api.get<AutoIngestStatus>(
         "/api/v1/settings/auto-ingest",
@@ -179,6 +199,36 @@ export function AutoIngestControls({
               <option value="retain_7d">Retain for 7 days</option>
               <option value="retain_30d">Retain for 30 days</option>
             </select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="delay-minutes"
+              className="text-xs text-gray-600 block mb-1"
+            >
+              Pipeline delay after last file upload
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                id="delay-minutes"
+                type="number"
+                min="0"
+                max="1440"
+                value={status.default_delay_minutes}
+                onChange={(e) => {
+                  const val = parseInt(e.target.value, 10);
+                  if (!isNaN(val) && val >= 0) handleDelayChange(val);
+                }}
+                disabled={loading}
+                className="text-xs border border-gray-300 rounded px-2 py-1 w-20"
+              />
+              <span className="text-xs text-gray-500">minutes</span>
+            </div>
+            <p className="text-xs text-gray-400 mt-0.5">
+              How long to wait after the last file arrives for an experiment
+              before triggering pipelines. Increase if pipelines run with
+              incomplete datasets.
+            </p>
           </div>
 
           <div className="flex gap-4 text-xs text-gray-500">

--- a/frontend/src/components/experiments/CsvUploadModal.tsx
+++ b/frontend/src/components/experiments/CsvUploadModal.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+
+interface RecognizedColumn {
+  csv_header: string;
+  mapped_to: string;
+}
+
+interface PreviewResponse {
+  recognized_columns: RecognizedColumn[];
+  unknown_columns: string[];
+  preview_rows: Record<string, unknown>[];
+  total_rows: number;
+  errors: string[];
+}
+
+interface ConfirmResponse {
+  created_count: number;
+  error_count: number;
+  errors: string[];
+  custom_fields_created: string[];
+}
+
+// All sample fields that an unknown column can be mapped to
+const SAMPLE_FIELDS = [
+  { value: "sample_id_external", label: "Sample ID (External)" },
+  { value: "organism", label: "Organism" },
+  { value: "tissue_type", label: "Tissue Type" },
+  { value: "donor_source", label: "Donor Source" },
+  { value: "treatment_condition", label: "Treatment Condition" },
+  { value: "chemistry_version", label: "Chemistry Version" },
+  { value: "viability_pct", label: "Viability %" },
+  { value: "cell_count", label: "Cell Count" },
+  { value: "prep_notes", label: "Prep Notes" },
+  { value: "molecule_type", label: "Molecule Type" },
+  { value: "library_prep_method", label: "Library Prep Method" },
+  { value: "library_layout", label: "Library Layout" },
+  { value: "qc_status", label: "QC Status" },
+  { value: "qc_notes", label: "QC Notes" },
+  { value: "collection_timestamp", label: "Collection Timestamp" },
+  { value: "collection_method", label: "Collection Method" },
+];
+
+interface Props {
+  experimentId: number;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+type Step = "select" | "preview" | "confirm" | "done";
+
+export function CsvUploadModal({ experimentId, onClose, onSuccess }: Props) {
+  const [step, setStep] = useState<Step>("select");
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<PreviewResponse | null>(null);
+  const [columnMappings, setColumnMappings] = useState<Record<string, string>>({});
+  const [result, setResult] = useState<ConfirmResponse | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleFileSelect(selectedFile: File) {
+    setFile(selectedFile);
+    setError("");
+    setLoading(true);
+
+    try {
+      const data = await api.upload<PreviewResponse>(
+        `/api/experiments/${experimentId}/samples/upload/preview`,
+        selectedFile,
+      );
+      setPreview(data);
+
+      if (data.unknown_columns.length > 0) {
+        // Initialize mappings: default to "skip" for unknown columns
+        const initial: Record<string, string> = {};
+        for (const col of data.unknown_columns) {
+          initial[col] = "skip";
+        }
+        setColumnMappings(initial);
+        setStep("preview");
+      } else if (data.errors.length > 0 && data.total_rows === 0) {
+        setError(data.errors.join("; "));
+      } else {
+        // No unknowns, go straight to confirm
+        await submitConfirm(selectedFile, {});
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to parse CSV");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitConfirm(confirmFile: File, mappings: Record<string, string>) {
+    setLoading(true);
+    setError("");
+
+    // Filter out "skip" mappings
+    const activeMappings: Record<string, string> = {};
+    for (const [col, target] of Object.entries(mappings)) {
+      if (target !== "skip") {
+        activeMappings[col] = target;
+      }
+    }
+
+    try {
+      const data = await api.upload<ConfirmResponse>(
+        `/api/experiments/${experimentId}/samples/upload/confirm`,
+        confirmFile,
+        { column_mappings: JSON.stringify(activeMappings) },
+      );
+      setResult(data);
+      setStep("done");
+      if (data.created_count > 0) {
+        onSuccess();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create samples");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleMappingChange(column: string, value: string) {
+    setColumnMappings((prev) => ({ ...prev, [column]: value }));
+  }
+
+  // Fields already claimed by recognized columns or other mappings
+  const usedFields = new Set<string>([
+    ...(preview?.recognized_columns.map((c) => c.mapped_to) ?? []),
+    ...Object.values(columnMappings).filter((v) => v !== "skip" && !v.startsWith("custom:")),
+  ]);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[80vh] overflow-hidden flex flex-col">
+        <div className="px-6 py-4 border-b flex justify-between items-center">
+          <h2 className="text-lg font-semibold">
+            {step === "select" && "Upload Sample CSV"}
+            {step === "preview" && "Map Unknown Columns"}
+            {step === "done" && "Upload Complete"}
+          </h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl">
+            &times;
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {/* Step 1: File selection */}
+          {step === "select" && (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                Upload a CSV or TSV file to bulk-create samples. Need a template?{" "}
+                <a
+                  href={`/api/experiments/${experimentId}/samples/csv-template`}
+                  className="text-bioaf-600 hover:underline"
+                  download
+                >
+                  Download sample template
+                </a>
+              </p>
+
+              <label className="flex items-center justify-center w-full h-32 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-bioaf-400 hover:bg-gray-50 transition-colors">
+                <div className="text-center">
+                  {loading ? (
+                    <p className="text-sm text-gray-500">Analyzing file...</p>
+                  ) : (
+                    <>
+                      <p className="text-sm font-medium text-gray-700">
+                        Click to select a CSV file
+                      </p>
+                      <p className="text-xs text-gray-500 mt-1">
+                        Supports .csv, .tsv, and .txt
+                      </p>
+                    </>
+                  )}
+                </div>
+                <input
+                  type="file"
+                  accept=".csv,.tsv,.txt"
+                  className="hidden"
+                  onChange={(e) => {
+                    if (e.target.files?.[0]) handleFileSelect(e.target.files[0]);
+                  }}
+                  disabled={loading}
+                />
+              </label>
+
+              {error && (
+                <div className="bg-red-50 border border-red-200 rounded-md p-3">
+                  <p className="text-sm text-red-700">{error}</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 2: Map unknown columns */}
+          {step === "preview" && preview && (
+            <div className="space-y-6">
+              <div>
+                <p className="text-sm text-gray-600 mb-2">
+                  Found {preview.total_rows} row{preview.total_rows !== 1 ? "s" : ""}.{" "}
+                  {preview.recognized_columns.length} column{preview.recognized_columns.length !== 1 ? "s" : ""} recognized,{" "}
+                  {preview.unknown_columns.length} need mapping.
+                </p>
+              </div>
+
+              {preview.recognized_columns.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">Recognized Columns</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {preview.recognized_columns.map((col) => (
+                      <span
+                        key={col.csv_header}
+                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
+                      >
+                        {col.csv_header} &rarr; {col.mapped_to}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <h3 className="text-sm font-medium text-gray-700 mb-3">Unknown Columns</h3>
+                <p className="text-xs text-gray-500 mb-3">
+                  For each unknown column, choose to map it to an existing sample field,
+                  accept it as a custom field, or skip it.
+                </p>
+                <div className="space-y-3">
+                  {preview.unknown_columns.map((col) => (
+                    <div key={col} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
+                      <span className="text-sm font-mono font-medium text-gray-800 min-w-[140px]">
+                        {col}
+                      </span>
+                      <span className="text-gray-400">&rarr;</span>
+                      <select
+                        value={columnMappings[col] ?? "skip"}
+                        onChange={(e) => handleMappingChange(col, e.target.value)}
+                        className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
+                      >
+                        <option value="skip">Skip this column</option>
+                        <option value={`custom:${col}`}>Accept as custom field &quot;{col}&quot;</option>
+                        <optgroup label="Map to sample field">
+                          {SAMPLE_FIELDS.filter(
+                            (f) => !usedFields.has(f.value) || columnMappings[col] === f.value
+                          ).map((f) => (
+                            <option key={f.value} value={f.value}>
+                              {f.label}
+                            </option>
+                          ))}
+                        </optgroup>
+                      </select>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {preview.preview_rows.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">
+                    Preview (first {preview.preview_rows.length} rows)
+                  </h3>
+                  <div className="overflow-x-auto border rounded-md">
+                    <table className="min-w-full text-xs">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          {Object.keys(preview.preview_rows[0]).map((key) => (
+                            <th key={key} className="px-3 py-2 text-left font-medium text-gray-600">
+                              {key}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {preview.preview_rows.map((row, i) => (
+                          <tr key={i} className="border-t">
+                            {Object.values(row).map((val, j) => (
+                              <td key={j} className="px-3 py-1.5 text-gray-700">
+                                {val != null ? String(val) : ""}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {preview.errors.length > 0 && (
+                <div className="bg-amber-50 border border-amber-200 rounded-md p-3">
+                  <p className="text-sm font-medium text-amber-800 mb-1">Parse Warnings</p>
+                  <ul className="text-xs text-amber-700 list-disc list-inside">
+                    {preview.errors.map((err, i) => (
+                      <li key={i}>{err}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {error && (
+                <div className="bg-red-50 border border-red-200 rounded-md p-3">
+                  <p className="text-sm text-red-700">{error}</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 3: Results */}
+          {step === "done" && result && (
+            <div className="space-y-4">
+              <div className={`rounded-md p-4 ${result.error_count > 0 ? "bg-amber-50 border border-amber-200" : "bg-green-50 border border-green-200"}`}>
+                <p className={`text-sm font-medium ${result.error_count > 0 ? "text-amber-800" : "text-green-800"}`}>
+                  Created {result.created_count} sample{result.created_count !== 1 ? "s" : ""}
+                  {result.error_count > 0 && ` with ${result.error_count} error${result.error_count !== 1 ? "s" : ""}`}
+                </p>
+              </div>
+
+              {result.custom_fields_created.length > 0 && (
+                <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+                  <p className="text-sm text-blue-800">
+                    Custom fields created: {result.custom_fields_created.join(", ")}
+                  </p>
+                </div>
+              )}
+
+              {result.errors.length > 0 && (
+                <div>
+                  <p className="text-sm font-medium text-gray-700 mb-1">Errors</p>
+                  <ul className="text-xs text-red-700 list-disc list-inside bg-red-50 rounded-md p-3">
+                    {result.errors.map((err, i) => (
+                      <li key={i}>{err}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="px-6 py-4 border-t bg-gray-50 flex justify-end gap-3">
+          {step === "preview" && (
+            <>
+              <button
+                onClick={() => { setStep("select"); setPreview(null); setFile(null); setError(""); }}
+                className="px-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                disabled={loading}
+              >
+                Back
+              </button>
+              <button
+                onClick={() => file && submitConfirm(file, columnMappings)}
+                className="px-4 py-2 text-sm text-white bg-bioaf-600 rounded-md hover:bg-bioaf-700 disabled:opacity-50"
+                disabled={loading}
+              >
+                {loading ? "Creating samples..." : `Create ${preview?.total_rows ?? 0} Samples`}
+              </button>
+            </>
+          )}
+          {step === "done" && (
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-white bg-bioaf-600 rounded-md hover:bg-bioaf-700"
+            >
+              Done
+            </button>
+          )}
+          {step === "select" && (
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/experiments/CsvUploadModal.tsx
+++ b/frontend/src/components/experiments/CsvUploadModal.tsx
@@ -43,6 +43,25 @@ const SAMPLE_FIELDS = [
   { value: "collection_method", label: "Collection Method" },
 ];
 
+const EXAMPLE_VALUES: Record<string, string> = {
+  sample_id_external: "SAMPLE-001",
+  organism: "Homo sapiens",
+  tissue_type: "PBMC",
+  donor_source: "Donor-A",
+  treatment_condition: "Control",
+  chemistry_version: "v3.1",
+  viability_pct: "92.5",
+  cell_count: "10000",
+  prep_notes: "Standard protocol",
+  molecule_type: "total RNA",
+  library_prep_method: "10x Chromium 3' v3",
+  library_layout: "paired",
+  qc_status: "pass",
+  qc_notes: "",
+  collection_timestamp: "2024-01-15T10:30:00",
+  collection_method: "venipuncture",
+};
+
 interface Props {
   experimentId: number;
   onClose: () => void;
@@ -152,17 +171,48 @@ export function CsvUploadModal({ experimentId, onClose, onSuccess }: Props) {
           {step === "select" && (
             <div className="space-y-4">
               <p className="text-sm text-gray-600">
-                Upload a CSV or TSV file to bulk-create samples. Need a template?{" "}
-                <a
-                  href={`/api/experiments/${experimentId}/samples/csv-template`}
-                  className="text-bioaf-600 hover:underline"
-                  download
-                >
-                  Download sample template
-                </a>
+                Upload a CSV or TSV file to bulk-create samples. Your CSV should include a
+                header row with column names matching the fields below.
               </p>
 
-              <label className="flex items-center justify-center w-full h-32 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-bioaf-400 hover:bg-gray-50 transition-colors">
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-sm font-medium text-gray-700">Expected CSV Format</h3>
+                  <button
+                    onClick={() => api.download(`/api/experiments/${experimentId}/samples/csv-template`)}
+                    className="text-xs text-bioaf-600 hover:underline"
+                  >
+                    Download template CSV
+                  </button>
+                </div>
+                <div className="overflow-x-auto border rounded-md">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        {SAMPLE_FIELDS.map((f) => (
+                          <th key={f.value} className="px-2 py-1.5 text-left font-medium text-gray-600 whitespace-nowrap">
+                            {f.value}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr className="text-gray-400 italic">
+                        {SAMPLE_FIELDS.map((f) => (
+                          <td key={f.value} className="px-2 py-1 whitespace-nowrap">
+                            {EXAMPLE_VALUES[f.value] ?? ""}
+                          </td>
+                        ))}
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <p className="text-xs text-gray-500 mt-1">
+                  All columns are optional. Unrecognized columns will prompt you to map or skip them.
+                </p>
+              </div>
+
+              <label className="flex items-center justify-center w-full h-24 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-bioaf-400 hover:bg-gray-50 transition-colors">
                 <div className="text-center">
                   {loading ? (
                     <p className="text-sm text-gray-500">Analyzing file...</p>

--- a/frontend/src/components/naming/NamingProfileWizard.tsx
+++ b/frontend/src/components/naming/NamingProfileWizard.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+interface ProjectOption {
+  id: number;
+  name: string;
+  code: string | null;
+}
+
+interface ExperimentOption {
+  id: number;
+  name: string;
+  code: string | null;
+}
+
+interface SegmentAssignment {
+  value: string;
+  field: string;
+  mappedEntityId?: number;
+}
+
+const FIELD_OPTIONS = [
+  { value: "project_code", label: "Project Code" },
+  { value: "experiment_code", label: "Experiment Code" },
+  { value: "sample_id", label: "Sample ID" },
+  { value: "data_type", label: "Data Type" },
+  { value: "date", label: "Date" },
+  { value: "version", label: "Version" },
+  { value: "organism", label: "Organism" },
+  { value: "researcher_initials", label: "Researcher Initials" },
+  { value: "analysis_type", label: "Analysis Type" },
+  { value: "batch_id", label: "Batch ID" },
+  { value: "ignore", label: "Ignore" },
+];
+
+type Step = "filename" | "assign" | "map" | "verify" | "save";
+
+interface Props {
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export function NamingProfileWizard({ onSave, onCancel }: Props) {
+  const [step, setStep] = useState<Step>("filename");
+  const [filename, setFilename] = useState("");
+  const [delimiter, setDelimiter] = useState("_");
+  const [segments, setSegments] = useState<string[]>([]);
+  const [assignments, setAssignments] = useState<SegmentAssignment[]>([]);
+  const [profileName, setProfileName] = useState("");
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  const [experiments, setExperiments] = useState<ExperimentOption[]>([]);
+  const [verifyFilename, setVerifyFilename] = useState("");
+  const [verifyResult, setVerifyResult] = useState<Record<string, string> | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    api.get<ProjectOption[]>("/api/projects?page_size=100").then((data) => {
+      // API returns {projects: [...], total: ...}
+      const items = Array.isArray(data) ? data : (data as unknown as { projects: ProjectOption[] }).projects ?? [];
+      setProjects(items);
+    }).catch(() => {});
+    api.get<ExperimentOption[]>("/api/experiments?page_size=100").then((data) => {
+      const items = Array.isArray(data) ? data : (data as unknown as { experiments: ExperimentOption[] }).experiments ?? [];
+      setExperiments(items);
+    }).catch(() => {});
+  }, []);
+
+  function splitFilename() {
+    let name = filename.trim();
+    // Strip extensions (.fastq.gz, .bam, etc.)
+    name = name.replace(/\.(fastq|fq)(\.gz|\.bz2)?$/i, "");
+    name = name.replace(/\.(bam|sam|h5ad|h5|csv|tsv|txt|bed|vcf|gtf|gff)(\.gz)?$/i, "");
+    const parts = name.split(delimiter);
+    setSegments(parts);
+    setAssignments(parts.map((value) => ({ value, field: "ignore" })));
+    // Auto-detect common patterns
+    const autoAssigned = parts.map((value, i) => {
+      const lower = value.toLowerCase();
+      if (lower.startsWith("s") && /^s\d+$/i.test(lower)) return { value, field: "sample_id" };
+      if (lower.startsWith("l") && /^l\d+$/i.test(lower)) return { value, field: "ignore" };
+      if (lower.startsWith("r") && /^r[12]$/i.test(lower)) return { value, field: "data_type" };
+      if (lower.startsWith("i") && /^i[12]$/i.test(lower)) return { value, field: "data_type" };
+      if (/^\d{4}-?\d{2}-?\d{2}$/.test(value)) return { value, field: "date" };
+      if (/^v\d+$/i.test(value)) return { value, field: "version" };
+      if (i === 0) return { value, field: "project_code" };
+      return { value, field: "ignore" };
+    });
+    setAssignments(autoAssigned);
+    setStep("assign");
+  }
+
+  function updateAssignment(idx: number, field: string) {
+    setAssignments((prev) =>
+      prev.map((a, i) => (i === idx ? { ...a, field } : a))
+    );
+  }
+
+  function updateMapping(idx: number, entityId: number) {
+    setAssignments((prev) =>
+      prev.map((a, i) => (i === idx ? { ...a, mappedEntityId: entityId } : a))
+    );
+  }
+
+  const needsMapping = assignments.some(
+    (a) => a.field === "project_code" || a.field === "experiment_code"
+  );
+
+  function handleVerify() {
+    if (!verifyFilename.trim()) return;
+    let name = verifyFilename.trim();
+    name = name.replace(/\.(fastq|fq)(\.gz|\.bz2)?$/i, "");
+    name = name.replace(/\.(bam|sam|h5ad|h5|csv|tsv|txt|bed|vcf|gtf|gff)(\.gz)?$/i, "");
+    const parts = name.split(delimiter);
+    const result: Record<string, string> = {};
+    parts.forEach((val, i) => {
+      if (i < assignments.length && assignments[i].field !== "ignore") {
+        const field = assignments[i].field;
+        result[field] = val;
+        // Show mapped entity name
+        if (field === "project_code" && assignments[i].mappedEntityId) {
+          const proj = projects.find((p) => p.id === assignments[i].mappedEntityId);
+          if (proj) result[`${field}_resolved`] = proj.name;
+        }
+        if (field === "experiment_code" && assignments[i].mappedEntityId) {
+          const exp = experiments.find((e) => e.id === assignments[i].mappedEntityId);
+          if (exp) result[`${field}_resolved`] = exp.name;
+        }
+      }
+    });
+    setVerifyResult(result);
+  }
+
+  async function handleSave() {
+    setError("");
+    setSaving(true);
+
+    const segmentDefs = assignments.map((a, i) => ({
+      position: i,
+      field: a.field,
+      required: a.field !== "ignore",
+    }));
+
+    const projectMappings: Record<string, string> = {};
+    const experimentMappings: Record<string, string> = {};
+    for (const a of assignments) {
+      if (a.field === "project_code" && a.mappedEntityId) {
+        projectMappings[a.value] = String(a.mappedEntityId);
+      }
+      if (a.field === "experiment_code" && a.mappedEntityId) {
+        experimentMappings[a.value] = String(a.mappedEntityId);
+      }
+    }
+
+    try {
+      await api.post("/api/naming-profiles", {
+        name: profileName || `Profile for ${filename}`,
+        delimiter,
+        strip_extension: true,
+        segments: segmentDefs,
+        project_code_mappings: projectMappings,
+        experiment_code_mappings: experimentMappings,
+      });
+      onSave();
+    } catch {
+      setError("Failed to save profile");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="bg-white border rounded-lg p-6 mb-6">
+      <h2 className="text-lg font-semibold mb-4">Create Naming Profile</h2>
+
+      {/* Step 1: Enter filename and delimiter */}
+      {step === "filename" && (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Paste a real filename from your data. The wizard will split it into segments and
+            help you assign each one.
+          </p>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Sample filename</label>
+            <input
+              value={filename}
+              onChange={(e) => setFilename(e.target.value)}
+              placeholder="e.g. pbmc01_s001_l001_r2_i2.fastq.gz"
+              className="w-full border rounded-lg px-3 py-2 font-mono text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Delimiter</label>
+            <div className="flex gap-3">
+              {[
+                { value: "_", label: "Underscore (_)" },
+                { value: "-", label: "Hyphen (-)" },
+                { value: ".", label: "Dot (.)" },
+              ].map((d) => (
+                <label key={d.value} className="flex items-center gap-1.5 text-sm cursor-pointer">
+                  <input
+                    type="radio"
+                    name="delimiter"
+                    value={d.value}
+                    checked={delimiter === d.value}
+                    onChange={() => setDelimiter(d.value)}
+                  />
+                  {d.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          {filename && (
+            <div className="bg-gray-50 rounded-md p-3">
+              <p className="text-xs text-gray-500 mb-1">Preview</p>
+              <div className="flex flex-wrap gap-1">
+                {filename.replace(/\.(fastq|fq)(\.gz|\.bz2)?$/i, "")
+                  .replace(/\.(bam|sam|h5ad|h5|csv|tsv|txt|bed|vcf|gtf|gff)(\.gz)?$/i, "")
+                  .split(delimiter)
+                  .map((part, i) => (
+                    <span
+                      key={i}
+                      className="bg-white border rounded px-2 py-1 font-mono text-sm"
+                    >
+                      {part}
+                    </span>
+                  ))}
+              </div>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <button
+              onClick={splitFilename}
+              disabled={!filename.trim()}
+              className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700 disabled:opacity-50"
+            >
+              Next
+            </button>
+            <button onClick={onCancel} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 2: Assign segments */}
+      {step === "assign" && (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Assign a role to each segment of the filename. The system auto-detected some
+            common patterns. Adjust as needed.
+          </p>
+          <div className="space-y-2">
+            {segments.map((seg, i) => (
+              <div key={i} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
+                <span className="font-mono text-sm font-medium text-gray-800 min-w-[120px] bg-white border rounded px-2 py-1">
+                  {seg}
+                </span>
+                <span className="text-gray-400">&rarr;</span>
+                <select
+                  value={assignments[i]?.field || "ignore"}
+                  onChange={(e) => updateAssignment(i, e.target.value)}
+                  className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
+                >
+                  {FIELD_OPTIONS.map((f) => (
+                    <option key={f.value} value={f.value}>{f.label}</option>
+                  ))}
+                </select>
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setStep(needsMapping ? "map" : "verify")}
+              className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700"
+            >
+              Next
+            </button>
+            <button onClick={() => setStep("filename")} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
+              Back
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 3: Map codes to entities */}
+      {step === "map" && (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Map the extracted codes to your existing projects and experiments. This tells the
+            system which project/experiment a file belongs to based on its filename.
+          </p>
+          <div className="space-y-3">
+            {assignments.map((a, i) => {
+              if (a.field === "project_code") {
+                return (
+                  <div key={i} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
+                    <span className="text-sm text-gray-600 min-w-[100px]">Project code</span>
+                    <span className="font-mono text-sm font-medium bg-white border rounded px-2 py-1">
+                      {a.value}
+                    </span>
+                    <span className="text-gray-400">&rarr;</span>
+                    <select
+                      value={a.mappedEntityId || ""}
+                      onChange={(e) => updateMapping(i, parseInt(e.target.value, 10))}
+                      className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
+                    >
+                      <option value="">Select a project...</option>
+                      {projects.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name} {p.code ? `(${p.code})` : ""}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                );
+              }
+              if (a.field === "experiment_code") {
+                return (
+                  <div key={i} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
+                    <span className="text-sm text-gray-600 min-w-[100px]">Experiment code</span>
+                    <span className="font-mono text-sm font-medium bg-white border rounded px-2 py-1">
+                      {a.value}
+                    </span>
+                    <span className="text-gray-400">&rarr;</span>
+                    <select
+                      value={a.mappedEntityId || ""}
+                      onChange={(e) => updateMapping(i, parseInt(e.target.value, 10))}
+                      className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
+                    >
+                      <option value="">Select an experiment...</option>
+                      {experiments.map((exp) => (
+                        <option key={exp.id} value={exp.id}>
+                          {exp.name} {exp.code ? `(${exp.code})` : ""}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                );
+              }
+              return null;
+            })}
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setStep("verify")}
+              className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700"
+            >
+              Next
+            </button>
+            <button onClick={() => setStep("assign")} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
+              Back
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 4: Verify with another file */}
+      {step === "verify" && (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Test the profile against another filename to make sure it parses correctly.
+          </p>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Profile name</label>
+            <input
+              value={profileName}
+              onChange={(e) => setProfileName(e.target.value)}
+              placeholder={`Profile for ${filename}`}
+              className="w-full border rounded-lg px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="bg-gray-50 rounded-md p-4">
+            <p className="text-sm font-medium text-gray-700 mb-2">Profile summary</p>
+            <div className="text-xs text-gray-600 space-y-1">
+              <p>Delimiter: <span className="font-mono font-medium">{delimiter === "_" ? "underscore" : delimiter === "-" ? "hyphen" : "dot"}</span></p>
+              <p>Segments: {assignments.filter((a) => a.field !== "ignore").map((a) => a.field).join(", ")}</p>
+              {assignments.filter((a) => a.mappedEntityId).map((a, i) => (
+                <p key={i}>
+                  {a.field === "project_code" ? "Project" : "Experiment"} mapping:{" "}
+                  <span className="font-mono">{a.value}</span> &rarr;{" "}
+                  {a.field === "project_code"
+                    ? projects.find((p) => p.id === a.mappedEntityId)?.name
+                    : experiments.find((e) => e.id === a.mappedEntityId)?.name}
+                </p>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Verify with another filename (optional)
+            </label>
+            <div className="flex gap-2">
+              <input
+                value={verifyFilename}
+                onChange={(e) => { setVerifyFilename(e.target.value); setVerifyResult(null); }}
+                placeholder="Paste another filename to test..."
+                className="flex-1 border rounded-lg px-3 py-2 font-mono text-sm"
+              />
+              <button
+                onClick={handleVerify}
+                disabled={!verifyFilename.trim()}
+                className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                Test
+              </button>
+            </div>
+          </div>
+
+          {verifyResult && (
+            <div className="bg-green-50 border border-green-200 rounded-md p-3">
+              <p className="text-sm font-medium text-green-800 mb-2">Parsed result</p>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                {Object.entries(verifyResult).filter(([k]) => !k.endsWith("_resolved")).map(([key, val]) => (
+                  <div key={key} className="flex gap-2">
+                    <span className="text-gray-600">{key}:</span>
+                    <span className="font-mono font-medium">{val}</span>
+                    {verifyResult[`${key}_resolved`] && (
+                      <span className="text-green-700">({verifyResult[`${key}_resolved`]})</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-md p-3">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700 disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Save Profile"}
+            </button>
+            <button
+              onClick={() => setStep(needsMapping ? "map" : "assign")}
+              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
+            >
+              Back
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/naming/NamingProfileWizard.tsx
+++ b/frontend/src/components/naming/NamingProfileWizard.tsx
@@ -1,41 +1,30 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 
-interface ProjectOption {
+interface EntityOption {
   id: number;
   name: string;
   code: string | null;
 }
 
-interface ExperimentOption {
-  id: number;
-  name: string;
-  code: string | null;
-}
-
-interface SegmentAssignment {
+interface SegmentMapping {
   value: string;
-  field: string;
-  mappedEntityId?: number;
+  role: string;
+  entityId?: number;
+  entityName?: string;
 }
 
-const FIELD_OPTIONS = [
-  { value: "project_code", label: "Project Code" },
-  { value: "experiment_code", label: "Experiment Code" },
-  { value: "sample_id", label: "Sample ID" },
-  { value: "data_type", label: "Data Type" },
+const SEGMENT_ROLES = [
+  { value: "project_code", label: "Project" },
+  { value: "experiment_code", label: "Experiment" },
+  { value: "sample_id", label: "Sample" },
+  { value: "data_type", label: "Data type (e.g. R1, R2, I1)" },
   { value: "date", label: "Date" },
   { value: "version", label: "Version" },
-  { value: "organism", label: "Organism" },
-  { value: "researcher_initials", label: "Researcher Initials" },
-  { value: "analysis_type", label: "Analysis Type" },
-  { value: "batch_id", label: "Batch ID" },
-  { value: "ignore", label: "Ignore" },
+  { value: "ignore", label: "Not important / skip" },
 ];
-
-type Step = "filename" | "assign" | "map" | "verify" | "save";
 
 interface Props {
   onSave: () => void;
@@ -43,114 +32,109 @@ interface Props {
 }
 
 export function NamingProfileWizard({ onSave, onCancel }: Props) {
-  const [step, setStep] = useState<Step>("filename");
+  // Phase: pick-file -> pick-delimiter -> walk-segments -> name-and-save
+  const [phase, setPhase] = useState<"pick-file" | "pick-delimiter" | "walk-segments" | "name-and-save">("pick-file");
   const [filename, setFilename] = useState("");
   const [delimiter, setDelimiter] = useState("_");
   const [segments, setSegments] = useState<string[]>([]);
-  const [assignments, setAssignments] = useState<SegmentAssignment[]>([]);
+  const [mappings, setMappings] = useState<SegmentMapping[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
   const [profileName, setProfileName] = useState("");
-  const [projects, setProjects] = useState<ProjectOption[]>([]);
-  const [experiments, setExperiments] = useState<ExperimentOption[]>([]);
-  const [verifyFilename, setVerifyFilename] = useState("");
-  const [verifyResult, setVerifyResult] = useState<Record<string, string> | null>(null);
+  const [projects, setProjects] = useState<EntityOption[]>([]);
+  const [experiments, setExperiments] = useState<EntityOption[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    api.get<ProjectOption[]>("/api/projects?page_size=100").then((data) => {
-      // API returns {projects: [...], total: ...}
-      const items = Array.isArray(data) ? data : (data as unknown as { projects: ProjectOption[] }).projects ?? [];
-      setProjects(items);
+    api.get<{ projects: EntityOption[] }>("/api/projects?page_size=200").then((data) => {
+      setProjects(data.projects ?? []);
     }).catch(() => {});
-    api.get<ExperimentOption[]>("/api/experiments?page_size=100").then((data) => {
-      const items = Array.isArray(data) ? data : (data as unknown as { experiments: ExperimentOption[] }).experiments ?? [];
-      setExperiments(items);
+    api.get<{ experiments: EntityOption[] }>("/api/experiments?page_size=200").then((data) => {
+      setExperiments(data.experiments ?? []);
     }).catch(() => {});
   }, []);
 
-  function splitFilename() {
-    let name = filename.trim();
-    // Strip extensions (.fastq.gz, .bam, etc.)
-    name = name.replace(/\.(fastq|fq)(\.gz|\.bz2)?$/i, "");
-    name = name.replace(/\.(bam|sam|h5ad|h5|csv|tsv|txt|bed|vcf|gtf|gff)(\.gz)?$/i, "");
-    const parts = name.split(delimiter);
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      setFilename(file.name);
+      setPhase("pick-delimiter");
+    }
+  }
+
+  function handleFilenameSubmit() {
+    if (filename.trim()) setPhase("pick-delimiter");
+  }
+
+  function stripExtension(name: string): string {
+    return name
+      .replace(/\.(fastq|fq)(\.gz|\.bz2)?$/i, "")
+      .replace(/\.(bam|sam|h5ad|h5|csv|tsv|txt|bed|vcf|gtf|gff|cram)(\.gz)?$/i, "");
+  }
+
+  function startWalk() {
+    const stripped = stripExtension(filename.trim());
+    const parts = stripped.split(delimiter);
     setSegments(parts);
-    setAssignments(parts.map((value) => ({ value, field: "ignore" })));
-    // Auto-detect common patterns
-    const autoAssigned = parts.map((value, i) => {
-      const lower = value.toLowerCase();
-      if (lower.startsWith("s") && /^s\d+$/i.test(lower)) return { value, field: "sample_id" };
-      if (lower.startsWith("l") && /^l\d+$/i.test(lower)) return { value, field: "ignore" };
-      if (lower.startsWith("r") && /^r[12]$/i.test(lower)) return { value, field: "data_type" };
-      if (lower.startsWith("i") && /^i[12]$/i.test(lower)) return { value, field: "data_type" };
-      if (/^\d{4}-?\d{2}-?\d{2}$/.test(value)) return { value, field: "date" };
-      if (/^v\d+$/i.test(value)) return { value, field: "version" };
-      if (i === 0) return { value, field: "project_code" };
-      return { value, field: "ignore" };
-    });
-    setAssignments(autoAssigned);
-    setStep("assign");
+    setMappings(parts.map((value) => ({ value, role: "" })));
+    setActiveIndex(0);
+    setPhase("walk-segments");
   }
 
-  function updateAssignment(idx: number, field: string) {
-    setAssignments((prev) =>
-      prev.map((a, i) => (i === idx ? { ...a, field } : a))
+  function assignRole(role: string) {
+    setMappings((prev) =>
+      prev.map((m, i) => (i === activeIndex ? { ...m, role, entityId: undefined, entityName: undefined } : m))
     );
+    // If this role needs entity selection, stay on this segment. Otherwise advance.
+    if (role !== "project_code" && role !== "experiment_code" && role !== "sample_id") {
+      advanceSegment();
+    }
   }
 
-  function updateMapping(idx: number, entityId: number) {
-    setAssignments((prev) =>
-      prev.map((a, i) => (i === idx ? { ...a, mappedEntityId: entityId } : a))
+  function assignEntity(entityId: number, entityName: string) {
+    setMappings((prev) =>
+      prev.map((m, i) => (i === activeIndex ? { ...m, entityId, entityName } : m))
     );
+    advanceSegment();
   }
 
-  const needsMapping = assignments.some(
-    (a) => a.field === "project_code" || a.field === "experiment_code"
-  );
+  function advanceSegment() {
+    if (activeIndex < segments.length - 1) {
+      setActiveIndex((prev) => prev + 1);
+    } else {
+      setPhase("name-and-save");
+    }
+  }
 
-  function handleVerify() {
-    if (!verifyFilename.trim()) return;
-    let name = verifyFilename.trim();
-    name = name.replace(/\.(fastq|fq)(\.gz|\.bz2)?$/i, "");
-    name = name.replace(/\.(bam|sam|h5ad|h5|csv|tsv|txt|bed|vcf|gtf|gff)(\.gz)?$/i, "");
-    const parts = name.split(delimiter);
-    const result: Record<string, string> = {};
-    parts.forEach((val, i) => {
-      if (i < assignments.length && assignments[i].field !== "ignore") {
-        const field = assignments[i].field;
-        result[field] = val;
-        // Show mapped entity name
-        if (field === "project_code" && assignments[i].mappedEntityId) {
-          const proj = projects.find((p) => p.id === assignments[i].mappedEntityId);
-          if (proj) result[`${field}_resolved`] = proj.name;
-        }
-        if (field === "experiment_code" && assignments[i].mappedEntityId) {
-          const exp = experiments.find((e) => e.id === assignments[i].mappedEntityId);
-          if (exp) result[`${field}_resolved`] = exp.name;
-        }
-      }
-    });
-    setVerifyResult(result);
+  function goBackSegment() {
+    if (activeIndex > 0) {
+      setActiveIndex((prev) => prev - 1);
+      // Clear the current assignment so they can redo it
+      setMappings((prev) =>
+        prev.map((m, i) => (i === activeIndex - 1 ? { ...m, role: "", entityId: undefined, entityName: undefined } : m))
+      );
+    }
   }
 
   async function handleSave() {
     setError("");
     setSaving(true);
 
-    const segmentDefs = assignments.map((a, i) => ({
+    const segmentDefs = mappings.map((m, i) => ({
       position: i,
-      field: a.field,
-      required: a.field !== "ignore",
+      field: m.role || "ignore",
+      required: m.role !== "ignore" && m.role !== "",
     }));
 
     const projectMappings: Record<string, string> = {};
     const experimentMappings: Record<string, string> = {};
-    for (const a of assignments) {
-      if (a.field === "project_code" && a.mappedEntityId) {
-        projectMappings[a.value] = String(a.mappedEntityId);
+    for (const m of mappings) {
+      if (m.role === "project_code" && m.entityId) {
+        projectMappings[m.value] = String(m.entityId);
       }
-      if (a.field === "experiment_code" && a.mappedEntityId) {
-        experimentMappings[a.value] = String(a.mappedEntityId);
+      if (m.role === "experiment_code" && m.entityId) {
+        experimentMappings[m.value] = String(m.entityId);
       }
     }
 
@@ -171,68 +155,76 @@ export function NamingProfileWizard({ onSave, onCancel }: Props) {
     }
   }
 
+  // Render the filename with the active segment highlighted
+  function renderSegmentHighlight() {
+    return (
+      <div className="flex flex-wrap items-center gap-0.5 font-mono text-lg my-4">
+        {segments.map((seg, i) => (
+          <span key={i} className="flex items-center">
+            {i > 0 && <span className="text-gray-300 mx-0.5">{delimiter}</span>}
+            <span
+              className={`px-2 py-1 rounded transition-all ${
+                i === activeIndex
+                  ? "bg-bioaf-100 border-2 border-bioaf-500 text-bioaf-900 font-bold"
+                  : i < activeIndex && mappings[i]?.role
+                    ? "bg-green-50 border border-green-300 text-green-800"
+                    : "bg-gray-100 border border-gray-200 text-gray-400"
+              }`}
+            >
+              {seg}
+              {i < activeIndex && mappings[i]?.role && mappings[i].role !== "ignore" && (
+                <span className="ml-1 text-xs font-normal text-green-600">
+                  ({SEGMENT_ROLES.find((r) => r.value === mappings[i].role)?.label})
+                </span>
+              )}
+            </span>
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  const currentMapping = mappings[activeIndex];
+  const needsEntity = currentMapping?.role === "project_code" || currentMapping?.role === "experiment_code" || currentMapping?.role === "sample_id";
+
   return (
     <div className="bg-white border rounded-lg p-6 mb-6">
-      <h2 className="text-lg font-semibold mb-4">Create Naming Profile</h2>
-
-      {/* Step 1: Enter filename and delimiter */}
-      {step === "filename" && (
+      {/* Phase 1: Pick a file */}
+      {phase === "pick-file" && (
         <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Create Naming Profile</h2>
           <p className="text-sm text-gray-600">
-            Paste a real filename from your data. The wizard will split it into segments and
-            help you assign each one.
+            Select a real file or type a filename. The wizard will walk you through
+            each part of the name so you can tell bioAF what it means.
           </p>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Sample filename</label>
+          <div className="flex gap-3 items-end">
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">Filename</label>
+              <input
+                value={filename}
+                onChange={(e) => setFilename(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") handleFilenameSubmit(); }}
+                placeholder="Type or paste a filename..."
+                className="w-full border rounded-lg px-3 py-2 font-mono text-sm"
+              />
+            </div>
+            <span className="text-sm text-gray-400 pb-2">or</span>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
+            >
+              Choose file
+            </button>
             <input
-              value={filename}
-              onChange={(e) => setFilename(e.target.value)}
-              placeholder="e.g. pbmc01_s001_l001_r2_i2.fastq.gz"
-              className="w-full border rounded-lg px-3 py-2 font-mono text-sm"
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={handleFileSelect}
             />
           </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Delimiter</label>
-            <div className="flex gap-3">
-              {[
-                { value: "_", label: "Underscore (_)" },
-                { value: "-", label: "Hyphen (-)" },
-                { value: ".", label: "Dot (.)" },
-              ].map((d) => (
-                <label key={d.value} className="flex items-center gap-1.5 text-sm cursor-pointer">
-                  <input
-                    type="radio"
-                    name="delimiter"
-                    value={d.value}
-                    checked={delimiter === d.value}
-                    onChange={() => setDelimiter(d.value)}
-                  />
-                  {d.label}
-                </label>
-              ))}
-            </div>
-          </div>
-          {filename && (
-            <div className="bg-gray-50 rounded-md p-3">
-              <p className="text-xs text-gray-500 mb-1">Preview</p>
-              <div className="flex flex-wrap gap-1">
-                {filename.replace(/\.(fastq|fq)(\.gz|\.bz2)?$/i, "")
-                  .replace(/\.(bam|sam|h5ad|h5|csv|tsv|txt|bed|vcf|gtf|gff)(\.gz)?$/i, "")
-                  .split(delimiter)
-                  .map((part, i) => (
-                    <span
-                      key={i}
-                      className="bg-white border rounded px-2 py-1 font-mono text-sm"
-                    >
-                      {part}
-                    </span>
-                  ))}
-              </div>
-            </div>
-          )}
-          <div className="flex gap-2">
+          <div className="flex gap-2 pt-2">
             <button
-              onClick={splitFilename}
+              onClick={handleFilenameSubmit}
               disabled={!filename.trim()}
               className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700 disabled:opacity-50"
             >
@@ -245,188 +237,191 @@ export function NamingProfileWizard({ onSave, onCancel }: Props) {
         </div>
       )}
 
-      {/* Step 2: Assign segments */}
-      {step === "assign" && (
+      {/* Phase 2: Pick delimiter */}
+      {phase === "pick-delimiter" && (
         <div className="space-y-4">
-          <p className="text-sm text-gray-600">
-            Assign a role to each segment of the filename. The system auto-detected some
-            common patterns. Adjust as needed.
-          </p>
-          <div className="space-y-2">
-            {segments.map((seg, i) => (
-              <div key={i} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
-                <span className="font-mono text-sm font-medium text-gray-800 min-w-[120px] bg-white border rounded px-2 py-1">
-                  {seg}
-                </span>
-                <span className="text-gray-400">&rarr;</span>
-                <select
-                  value={assignments[i]?.field || "ignore"}
-                  onChange={(e) => updateAssignment(i, e.target.value)}
-                  className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
-                >
-                  {FIELD_OPTIONS.map((f) => (
-                    <option key={f.value} value={f.value}>{f.label}</option>
-                  ))}
-                </select>
-              </div>
-            ))}
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setStep(needsMapping ? "map" : "verify")}
-              className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700"
-            >
-              Next
-            </button>
-            <button onClick={() => setStep("filename")} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
-              Back
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Step 3: Map codes to entities */}
-      {step === "map" && (
-        <div className="space-y-4">
-          <p className="text-sm text-gray-600">
-            Map the extracted codes to your existing projects and experiments. This tells the
-            system which project/experiment a file belongs to based on its filename.
-          </p>
+          <h2 className="text-lg font-semibold">How is the filename separated?</h2>
+          <p className="font-mono text-sm bg-gray-50 rounded-lg p-3 break-all">{filename}</p>
           <div className="space-y-3">
-            {assignments.map((a, i) => {
-              if (a.field === "project_code") {
-                return (
-                  <div key={i} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
-                    <span className="text-sm text-gray-600 min-w-[100px]">Project code</span>
-                    <span className="font-mono text-sm font-medium bg-white border rounded px-2 py-1">
-                      {a.value}
-                    </span>
-                    <span className="text-gray-400">&rarr;</span>
-                    <select
-                      value={a.mappedEntityId || ""}
-                      onChange={(e) => updateMapping(i, parseInt(e.target.value, 10))}
-                      className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
-                    >
-                      <option value="">Select a project...</option>
-                      {projects.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name} {p.code ? `(${p.code})` : ""}
-                        </option>
-                      ))}
-                    </select>
+            {[
+              { value: "_", label: "Underscores", example: "part1_part2_part3" },
+              { value: "-", label: "Hyphens", example: "part1-part2-part3" },
+              { value: ".", label: "Periods", example: "part1.part2.part3" },
+            ].map((d) => {
+              const stripped = stripExtension(filename.trim());
+              const parts = stripped.split(d.value);
+              const isSelected = delimiter === d.value;
+              return (
+                <button
+                  key={d.value}
+                  onClick={() => setDelimiter(d.value)}
+                  className={`w-full text-left p-3 rounded-lg border-2 transition-colors ${
+                    isSelected ? "border-bioaf-500 bg-bioaf-50" : "border-gray-200 hover:border-gray-300"
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-sm">{d.label}</span>
+                    <span className="text-xs text-gray-500">{parts.length} segments</span>
                   </div>
-                );
-              }
-              if (a.field === "experiment_code") {
-                return (
-                  <div key={i} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
-                    <span className="text-sm text-gray-600 min-w-[100px]">Experiment code</span>
-                    <span className="font-mono text-sm font-medium bg-white border rounded px-2 py-1">
-                      {a.value}
-                    </span>
-                    <span className="text-gray-400">&rarr;</span>
-                    <select
-                      value={a.mappedEntityId || ""}
-                      onChange={(e) => updateMapping(i, parseInt(e.target.value, 10))}
-                      className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
-                    >
-                      <option value="">Select an experiment...</option>
-                      {experiments.map((exp) => (
-                        <option key={exp.id} value={exp.id}>
-                          {exp.name} {exp.code ? `(${exp.code})` : ""}
-                        </option>
-                      ))}
-                    </select>
+                  <div className="flex flex-wrap gap-1 mt-2">
+                    {parts.map((part, i) => (
+                      <span key={i} className="bg-white border rounded px-2 py-0.5 font-mono text-xs">
+                        {part}
+                      </span>
+                    ))}
                   </div>
-                );
-              }
-              return null;
+                </button>
+              );
             })}
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 pt-2">
             <button
-              onClick={() => setStep("verify")}
+              onClick={startWalk}
               className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700"
             >
               Next
             </button>
-            <button onClick={() => setStep("assign")} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
+            <button onClick={() => setPhase("pick-file")} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
               Back
             </button>
           </div>
         </div>
       )}
 
-      {/* Step 4: Verify with another file */}
-      {step === "verify" && (
+      {/* Phase 3: Walk through segments one at a time */}
+      {phase === "walk-segments" && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="text-lg font-semibold">
+              What is &ldquo;<span className="font-mono text-bioaf-700">{segments[activeIndex]}</span>&rdquo;?
+            </h2>
+            <span className="text-xs text-gray-400">
+              Segment {activeIndex + 1} of {segments.length}
+            </span>
+          </div>
+
+          {renderSegmentHighlight()}
+
+          {/* Role selection (if not yet picked for this segment) */}
+          {!needsEntity && (
+            <div className="grid grid-cols-2 gap-2">
+              {SEGMENT_ROLES.map((role) => (
+                <button
+                  key={role.value}
+                  onClick={() => assignRole(role.value)}
+                  className="text-left p-3 rounded-lg border border-gray-200 hover:border-bioaf-400 hover:bg-bioaf-50 transition-colors"
+                >
+                  <span className="text-sm font-medium">{role.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Entity selection (after picking project/experiment/sample) */}
+          {needsEntity && !currentMapping.entityId && (
+            <div>
+              <p className="text-sm text-gray-600 mb-3">
+                Which {currentMapping.role === "project_code" ? "project" : currentMapping.role === "experiment_code" ? "experiment" : "sample"} does
+                &ldquo;<span className="font-mono font-bold">{segments[activeIndex]}</span>&rdquo; represent?
+              </p>
+              {currentMapping.role === "project_code" && (
+                <div className="space-y-1 max-h-60 overflow-y-auto">
+                  {projects.map((p) => (
+                    <button
+                      key={p.id}
+                      onClick={() => assignEntity(p.id, p.name)}
+                      className="w-full text-left px-3 py-2 rounded-lg border border-gray-200 hover:border-bioaf-400 hover:bg-bioaf-50 transition-colors text-sm"
+                    >
+                      <span className="font-medium">{p.name}</span>
+                      {p.code && <span className="ml-2 text-gray-400 font-mono text-xs">{p.code}</span>}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {currentMapping.role === "experiment_code" && (
+                <div className="space-y-1 max-h-60 overflow-y-auto">
+                  {experiments.map((exp) => (
+                    <button
+                      key={exp.id}
+                      onClick={() => assignEntity(exp.id, exp.name)}
+                      className="w-full text-left px-3 py-2 rounded-lg border border-gray-200 hover:border-bioaf-400 hover:bg-bioaf-50 transition-colors text-sm"
+                    >
+                      <span className="font-medium">{exp.name}</span>
+                      {exp.code && <span className="ml-2 text-gray-400 font-mono text-xs">{exp.code}</span>}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {currentMapping.role === "sample_id" && (
+                <div>
+                  <p className="text-xs text-gray-500 mb-2">
+                    Sample IDs are matched automatically during ingest. No selection needed.
+                  </p>
+                  <button
+                    onClick={advanceSegment}
+                    className="px-4 py-2 bg-bioaf-600 text-white rounded-lg hover:bg-bioaf-700 text-sm"
+                  >
+                    Continue
+                  </button>
+                </div>
+              )}
+              <button
+                onClick={() => {
+                  setMappings((prev) => prev.map((m, i) => (i === activeIndex ? { ...m, role: "" } : m)));
+                }}
+                className="mt-3 text-sm text-gray-500 hover:text-gray-700"
+              >
+                &larr; Pick a different role
+              </button>
+            </div>
+          )}
+
+          <div className="flex gap-2 mt-4 pt-4 border-t">
+            {activeIndex > 0 && (
+              <button onClick={goBackSegment} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 text-sm">
+                Back
+              </button>
+            )}
+            <button onClick={onCancel} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 text-sm">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Phase 4: Name and save */}
+      {phase === "name-and-save" && (
         <div className="space-y-4">
-          <p className="text-sm text-gray-600">
-            Test the profile against another filename to make sure it parses correctly.
-          </p>
+          <h2 className="text-lg font-semibold">Profile Summary</h2>
+
+          <div className="flex flex-wrap items-center gap-0.5 font-mono text-sm bg-gray-50 rounded-lg p-4">
+            {mappings.map((m, i) => (
+              <span key={i} className="flex items-center">
+                {i > 0 && <span className="text-gray-300 mx-0.5">{delimiter}</span>}
+                <span className={`px-2 py-1 rounded border ${
+                  m.role === "ignore" || !m.role ? "bg-gray-100 border-gray-200 text-gray-400" : "bg-green-50 border-green-300 text-green-800"
+                }`}>
+                  {m.value}
+                  {m.role && m.role !== "ignore" && (
+                    <span className="ml-1 text-xs font-sans">
+                      ({SEGMENT_ROLES.find((r) => r.value === m.role)?.label}
+                      {m.entityName && `: ${m.entityName}`})
+                    </span>
+                  )}
+                </span>
+              </span>
+            ))}
+          </div>
+
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Profile name</label>
             <input
               value={profileName}
               onChange={(e) => setProfileName(e.target.value)}
-              placeholder={`Profile for ${filename}`}
+              placeholder={`Profile for ${stripExtension(filename)}`}
               className="w-full border rounded-lg px-3 py-2 text-sm"
             />
           </div>
-
-          <div className="bg-gray-50 rounded-md p-4">
-            <p className="text-sm font-medium text-gray-700 mb-2">Profile summary</p>
-            <div className="text-xs text-gray-600 space-y-1">
-              <p>Delimiter: <span className="font-mono font-medium">{delimiter === "_" ? "underscore" : delimiter === "-" ? "hyphen" : "dot"}</span></p>
-              <p>Segments: {assignments.filter((a) => a.field !== "ignore").map((a) => a.field).join(", ")}</p>
-              {assignments.filter((a) => a.mappedEntityId).map((a, i) => (
-                <p key={i}>
-                  {a.field === "project_code" ? "Project" : "Experiment"} mapping:{" "}
-                  <span className="font-mono">{a.value}</span> &rarr;{" "}
-                  {a.field === "project_code"
-                    ? projects.find((p) => p.id === a.mappedEntityId)?.name
-                    : experiments.find((e) => e.id === a.mappedEntityId)?.name}
-                </p>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Verify with another filename (optional)
-            </label>
-            <div className="flex gap-2">
-              <input
-                value={verifyFilename}
-                onChange={(e) => { setVerifyFilename(e.target.value); setVerifyResult(null); }}
-                placeholder="Paste another filename to test..."
-                className="flex-1 border rounded-lg px-3 py-2 font-mono text-sm"
-              />
-              <button
-                onClick={handleVerify}
-                disabled={!verifyFilename.trim()}
-                className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-              >
-                Test
-              </button>
-            </div>
-          </div>
-
-          {verifyResult && (
-            <div className="bg-green-50 border border-green-200 rounded-md p-3">
-              <p className="text-sm font-medium text-green-800 mb-2">Parsed result</p>
-              <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-                {Object.entries(verifyResult).filter(([k]) => !k.endsWith("_resolved")).map(([key, val]) => (
-                  <div key={key} className="flex gap-2">
-                    <span className="text-gray-600">{key}:</span>
-                    <span className="font-mono font-medium">{val}</span>
-                    {verifyResult[`${key}_resolved`] && (
-                      <span className="text-green-700">({verifyResult[`${key}_resolved`]})</span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
 
           {error && (
             <div className="bg-red-50 border border-red-200 rounded-md p-3">
@@ -443,10 +438,13 @@ export function NamingProfileWizard({ onSave, onCancel }: Props) {
               {saving ? "Saving..." : "Save Profile"}
             </button>
             <button
-              onClick={() => setStep(needsMapping ? "map" : "assign")}
+              onClick={() => { setActiveIndex(0); setPhase("walk-segments"); }}
               className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
             >
-              Back
+              Re-do mapping
+            </button>
+            <button onClick={onCancel} className="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50">
+              Cancel
             </button>
           </div>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -57,10 +57,15 @@ async function fetchApi<T>(
   return response.json();
 }
 
-async function uploadFile<T>(path: string, file: File): Promise<T> {
+async function uploadFile<T>(path: string, file: File, extraFields?: Record<string, string>): Promise<T> {
   const token = getToken();
   const formData = new FormData();
   formData.append("file", file);
+  if (extraFields) {
+    for (const [key, value] of Object.entries(extraFields)) {
+      formData.append(key, value);
+    }
+  }
 
   const headers: Record<string, string> = {};
   if (token) {
@@ -253,7 +258,8 @@ export const api = {
     }),
   delete: <T>(path: string) =>
     fetchApi<T>(path, { method: "DELETE" }),
-  upload: <T>(path: string, file: File) => uploadFile<T>(path, file),
+  upload: <T>(path: string, file: File, extraFields?: Record<string, string>) =>
+    uploadFile<T>(path, file, extraFields),
   uploadSigned: <T>(file: File, options?: SignedUploadOptions) =>
     uploadFileSigned<T>(file, options),
   download: (path: string, method?: "GET" | "POST", body?: unknown) =>

--- a/frontend/tests/components/infrastructure/AutoIngestControls.test.tsx
+++ b/frontend/tests/components/infrastructure/AutoIngestControls.test.tsx
@@ -85,7 +85,7 @@ describe("AutoIngestControls", () => {
   // Test 29: Update notice when Pub/Sub not deployed
   it("shows update notice when pubsub not configured", async () => {
     render(<AutoIngestControls storageDeployed={true} pubsubConfigured={false} />);
-    expect(screen.getByText(/infrastructure update/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pub\/Sub notification infrastructure/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /update storage/i }),
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- **CSV bulk sample upload**: Two-step preview/confirm flow with column mapping for unknown headers, custom field support, inline template preview, and template download
- **Pub/Sub infrastructure**: Fix storage post-apply hook to store topic/subscription names, add `/storage/update` endpoint for re-applying storage module, wire `pubsub_configured` status through to frontend
- **Per-experiment pipeline batching**: Refactor trigger batching from per-trigger to per-experiment-per-trigger so each experiment gets its own independent delay timer (default 15 min, configurable)
- **Scheduled trigger execution**: Wire background loop in main.py so cron-based triggers actually evaluate
- **Entity codes in UI**: Expose project and experiment codes in list tables and detail headers
- **Naming profile wizard**: Guided one-segment-at-a-time walkthrough for creating naming profiles from real filenames
- **Beta labels**: Mark naming profiles, auto-ingest, and pipeline triggers as beta

## Test plan

- [ ] CSV upload: create experiment, upload CSV via modal, verify samples created with correct field mappings
- [ ] CSV template: click "Download template CSV" from modal, verify it downloads correctly
- [ ] CSV unknown columns: upload CSV with unrecognized headers, verify mapping UI appears, map columns, confirm samples
- [ ] Pub/Sub: go to Infrastructure, verify "Update Storage Infrastructure" button triggers Terraform apply
- [ ] Auto-ingest toggle: enable auto-ingest from ingest bucket card, verify delay setting appears
- [ ] Entity codes: verify project codes appear in project list and detail, experiment codes in experiment list and detail
- [ ] Naming profile wizard: create profile using wizard, verify segment-by-segment walkthrough works
- [ ] Beta labels: verify "Beta" badge appears on naming profiles, auto-ingest controls, and pipeline triggers pages
- [ ] Pipeline triggers: create event-driven trigger, verify batching is per-experiment