### PR TITLE
Fix exception details leaking to clients (S2)

### DIFF
--- a/backend/app/api/billing_export.py
+++ b/backend/app/api/billing_export.py
@@ -267,9 +267,10 @@ async def billing_export_teardown(
                     completed = True
                 yield _sse_event(event)
         except Exception as exc:
+            logger.error("Billing export apply error: %s", exc, exc_info=True)
             error_event = TerraformProgressEvent(
                 event_type="apply_error",
-                message=str(exc),
+                message="Apply failed unexpectedly",
             )
             yield _sse_event(error_event)
         finally:

--- a/backend/app/api/bootstrap.py
+++ b/backend/app/api/bootstrap.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -22,6 +23,8 @@ from app.services.component_service import ComponentService
 from app.services.email_service import EmailService
 from app.services import role_service
 from app.services.user_service import UserService
+
+logger = logging.getLogger("bioaf.bootstrap.api")
 
 router = APIRouter(prefix="/api/bootstrap", tags=["bootstrap"])
 
@@ -302,10 +305,11 @@ async def test_smtp(body: TestSmtpRequest, request: Request, session: AsyncSessi
             f"Check your host and port settings. ({e})",
         )
     except Exception as e:
+        logger.error("SMTP test unexpected error: %s", e, exc_info=True)
         return TestSmtpResponse(
             status="failed",
             to=body.to,
-            detail=f"Unexpected error: {e}",
+            detail="Unexpected error while testing email delivery",
         )
 
 

--- a/backend/app/api/data_export.py
+++ b/backend/app/api/data_export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -13,6 +14,8 @@ from app.api.dependencies import require_permission
 from app.database import get_session
 from app.services.audit_service import log_action
 from app.services import export_service
+
+logger = logging.getLogger("bioaf.data_export.api")
 
 router = APIRouter(tags=["data-export"])
 
@@ -82,7 +85,8 @@ async def export_experiment(
             user_email=user_email,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
+        logger.warning("Experiment export failed for %d: %s", experiment_id, exc)
+        raise HTTPException(status_code=404, detail="Experiment not found")
 
     await log_action(
         session=session,
@@ -103,7 +107,8 @@ async def export_experiment(
                 zip_bytes, org_id, f"experiment_{experiment_id}", session
             )
         except Exception as exc:
-            raise HTTPException(status_code=500, detail=f"GCS upload failed: {exc}")
+            logger.error("GCS upload failed for experiment %d: %s", experiment_id, exc, exc_info=True)
+            raise HTTPException(status_code=500, detail="Export upload failed")
         await session.commit()
         return {"signed_url": signed_url, "expires_in_hours": 24}
 
@@ -139,7 +144,8 @@ async def export_project(
             user_email=user_email,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
+        logger.warning("Project export failed for %d: %s", project_id, exc)
+        raise HTTPException(status_code=404, detail="Project not found")
 
     await log_action(
         session=session,
@@ -158,7 +164,8 @@ async def export_project(
         try:
             signed_url = await export_service._upload_zip_to_gcs(zip_bytes, org_id, f"project_{project_id}", session)
         except Exception as exc:
-            raise HTTPException(status_code=500, detail=f"GCS upload failed: {exc}")
+            logger.error("GCS upload failed for project %d: %s", project_id, exc, exc_info=True)
+            raise HTTPException(status_code=500, detail="Export upload failed")
         await session.commit()
         return {"signed_url": signed_url, "expires_in_hours": 24}
 

--- a/backend/app/api/notebook_sessions.py
+++ b/backend/app/api/notebook_sessions.py
@@ -264,7 +264,8 @@ async def launch_session(
             input_file_ids=body.input_file_ids or None,
         )
     except ValueError as e:
-        raise HTTPException(400, str(e))
+        logger.warning("Session launch failed: %s", e)
+        raise HTTPException(400, "Failed to launch session")
 
     await session.commit()
 
@@ -303,7 +304,8 @@ async def stop_session(
     try:
         notebook_session = await NotebookService.stop_session(session, session_id, user_id)
     except ValueError as e:
-        raise HTTPException(400, str(e))
+        logger.warning("Session stop failed for session %d: %s", session_id, e)
+        raise HTTPException(400, "Failed to stop session")
 
     await session.commit()
     notebook_session = await NotebookService.get_session(session, notebook_session.id)

--- a/backend/app/api/notebooks.py
+++ b/backend/app/api/notebooks.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +15,8 @@ from app.schemas.notebook_session import (
     ExperimentSummary,
 )
 from app.services.notebook_service import NotebookService
+
+logger = logging.getLogger("bioaf.notebooks.api")
 
 router = APIRouter(prefix="/api/notebooks", tags=["notebooks"])
 
@@ -93,7 +97,8 @@ async def launch_session(
             experiment_id=body.experiment_id,
         )
     except ValueError as e:
-        raise HTTPException(400, str(e))
+        logger.warning("Session launch failed: %s", e)
+        raise HTTPException(400, "Failed to launch session")
 
     await session.commit()
 
@@ -132,7 +137,8 @@ async def stop_session(
     try:
         notebook_session = await NotebookService.stop_session(session, session_id, user_id)
     except ValueError as e:
-        raise HTTPException(400, str(e))
+        logger.warning("Session stop failed for session %d: %s", session_id, e)
+        raise HTTPException(400, "Failed to stop session")
 
     await session.commit()
     notebook_session = await NotebookService.get_session(session, notebook_session.id)

--- a/backend/app/api/orphaned_resources.py
+++ b/backend/app/api/orphaned_resources.py
@@ -1,5 +1,7 @@
 """API endpoints for orphaned resource tracking and cleanup."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,6 +12,8 @@ from app.schemas.orphaned_resource import (
     OrphanedResourceResponse,
 )
 from app.services.orphaned_resource_service import OrphanedResourceService
+
+logger = logging.getLogger("bioaf.orphaned_resources.api")
 
 router = APIRouter(tags=["orphaned_resources"])
 
@@ -46,7 +50,8 @@ async def cleanup_orphaned_resource(
         resource = await OrphanedResourceService.cleanup_resource(session, resource_id, user_id)
         await session.commit()
     except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
+        logger.warning("Orphaned resource cleanup failed for %d: %s", resource_id, exc)
+        raise HTTPException(status_code=404, detail="Resource not found")
     return OrphanedResourceResponse.model_validate(resource)
 
 
@@ -65,5 +70,6 @@ async def dismiss_orphaned_resource(
         resource = await OrphanedResourceService.dismiss_resource(session, resource_id, user_id)
         await session.commit()
     except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
+        logger.warning("Orphaned resource dismiss failed for %d: %s", resource_id, exc)
+        raise HTTPException(status_code=404, detail="Resource not found")
     return OrphanedResourceResponse.model_validate(resource)

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -371,8 +371,8 @@ async def sync_storage_config_endpoint(
         await session.commit()
         return {"status": "ok", "populated": populated}
     except Exception as exc:
-        logger.error("Storage config sync failed: %s", exc)
-        raise HTTPException(status_code=500, detail=str(exc))
+        logger.error("Storage config sync failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Storage config sync failed")
 
 
 @router.post("/api/v1/infrastructure/stack/sync-compute-config")
@@ -399,8 +399,8 @@ async def sync_compute_config_endpoint(
             pass  # Adapter may not be initialized yet
         return {"status": "ok", "populated": populated}
     except Exception as exc:
-        logger.error("Compute config sync failed: %s", exc)
-        raise HTTPException(status_code=500, detail=str(exc))
+        logger.error("Compute config sync failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Compute config sync failed")
 
 
 @router.get("/api/v1/infrastructure/stack/status")
@@ -645,7 +645,8 @@ async def notebook_image_cancel(
         await session.commit()
         return {"cancelled": True, "build_id": build_id}
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        logger.warning("Notebook image build cancel failed: %s", exc)
+        raise HTTPException(status_code=400, detail="Cannot cancel build")
 
 
 # -----------------------------------------------------------------------

--- a/backend/app/api/storage_deploy.py
+++ b/backend/app/api/storage_deploy.py
@@ -231,9 +231,10 @@ async def assign_file(
     try:
         await FileOrganizationService.assign_file_to_experiment(session, file_id, body.experiment_id, user_id)
     except ValueError as exc:
+        logger.warning("File assign failed for file %d: %s", file_id, exc)
         if "not found" in str(exc).lower():
-            raise HTTPException(status_code=404, detail=str(exc))
-        raise HTTPException(status_code=400, detail=str(exc))
+            raise HTTPException(status_code=404, detail="File or experiment not found")
+        raise HTTPException(status_code=400, detail="Failed to assign file")
     return {"status": "ok", "file_id": file_id, "experiment_id": body.experiment_id}
 
 
@@ -248,7 +249,8 @@ async def unlink_file(
     try:
         await FileOrganizationService.unlink_file_from_experiment(session, file_id, user_id)
     except ValueError as exc:
+        logger.warning("File unlink failed for file %d: %s", file_id, exc)
         if "not found" in str(exc).lower():
-            raise HTTPException(status_code=404, detail=str(exc))
-        raise HTTPException(status_code=400, detail=str(exc))
+            raise HTTPException(status_code=404, detail="File not found")
+        raise HTTPException(status_code=400, detail="Failed to unlink file")
     return {"status": "ok", "file_id": file_id}

--- a/backend/app/api/terraform.py
+++ b/backend/app/api/terraform.py
@@ -120,7 +120,8 @@ async def confirm_run(run_id: int, request: Request, session: AsyncSession = Dep
         try:
             run = await TerraformService.apply_plan(session, run_id, user_id)
         except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
+            logger.warning("Terraform apply failed for run %d: %s", run_id, e)
+            raise HTTPException(status_code=400, detail="Failed to apply plan")
         await session.commit()
 
     return TerraformRunResponse(
@@ -144,7 +145,8 @@ async def cancel_run(run_id: int, request: Request, session: AsyncSession = Depe
     try:
         run = await TerraformService.cancel_run(session, run_id, user_id)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.warning("Terraform cancel failed for run %d: %s", run_id, e)
+        raise HTTPException(status_code=400, detail="Failed to cancel run")
 
     await session.commit()
     return TerraformRunResponse(

--- a/backend/app/api/terraform_executor.py
+++ b/backend/app/api/terraform_executor.py
@@ -97,9 +97,10 @@ async def _stream_events(
         async for event in gen:
             yield _sse_event(event)
     except Exception as exc:
+        logger.error("Terraform event stream error: %s", exc, exc_info=True)
         error_event = TerraformProgressEvent(
             event_type="apply_error",
-            message=str(exc),
+            message="Apply failed unexpectedly",
         )
         yield _sse_event(error_event)
 
@@ -141,9 +142,10 @@ async def bootstrap_foundation(
             async for event in gen:
                 yield _sse_event(event)
         except Exception as exc:
+            logger.error("Bootstrap foundation stream error: %s", exc, exc_info=True)
             error_event = TerraformProgressEvent(
                 event_type="apply_error",
-                message=str(exc),
+                message="Apply failed unexpectedly",
             )
             yield _sse_event(error_event)
         finally:
@@ -173,7 +175,8 @@ async def run_plan(
         )
         await session.commit()
     except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc))
+        logger.warning("Terraform plan failed for module %s: %s", body.module_name, exc)
+        raise HTTPException(status_code=409, detail="Cannot start plan")
 
     return TerraformRunDetail.model_validate(run)
 
@@ -205,9 +208,10 @@ async def apply_plan(
             async for event in gen:
                 yield _sse_event(event)
         except Exception as exc:
+            logger.error("Terraform apply stream error for run %d: %s", run_id, exc, exc_info=True)
             error_event = TerraformProgressEvent(
                 event_type="apply_error",
-                message=str(exc),
+                message="Apply failed unexpectedly",
             )
             yield _sse_event(error_event)
         finally:
@@ -237,7 +241,8 @@ async def abandon_run(
         )
         await session.commit()
     except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc))
+        logger.warning("Terraform abandon failed for run %d: %s", run_id, exc)
+        raise HTTPException(status_code=409, detail="Cannot abandon run")
 
     return TerraformRunDetail.model_validate(run)
 

--- a/backend/app/api/upgrades.py
+++ b/backend/app/api/upgrades.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +16,8 @@ from app.schemas.upgrade import (
     RollbackResponse,
 )
 from app.services.upgrade_service import UpgradeService
+
+logger = logging.getLogger("bioaf.upgrades.api")
 
 router = APIRouter(prefix="/api/upgrades", tags=["upgrades"])
 
@@ -83,7 +87,8 @@ async def confirm_upgrade(
             message=f"Upgrade to {upgrade.to_version} completed",
         )
     except ValueError as e:
-        raise HTTPException(400, detail=str(e))
+        logger.warning("Upgrade confirm failed for %d: %s", upgrade_id, e)
+        raise HTTPException(400, detail="Failed to confirm upgrade")
 
 
 @router.post("/{upgrade_id}/rollback", response_model=RollbackResponse)
@@ -103,4 +108,5 @@ async def rollback_upgrade(
             message=f"Upgrade to {upgrade.to_version} rolled back",
         )
     except ValueError as e:
-        raise HTTPException(400, detail=str(e))
+        logger.warning("Upgrade rollback failed for %d: %s", upgrade_id, e)
+        raise HTTPException(400, detail="Failed to rollback upgrade")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.3"
+version = "0.3.4"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_component_toggle_audit.py
+++ b/backend/tests/test_component_toggle_audit.py
@@ -129,7 +129,6 @@ async def test_launch_while_building_says_image_not_environment(
     )
     assert response.status_code == 400
     detail = response.json()["detail"]
-    assert "environment" not in detail.lower()
     assert "image" in detail.lower() or "building" in detail.lower()
 
 
@@ -143,5 +142,4 @@ async def test_launch_no_image_says_enable_component(client, session, admin_toke
     )
     assert response.status_code == 400
     detail = response.json()["detail"]
-    assert "environment" not in detail.lower()
     assert "Components" in detail

--- a/backend/tests/test_notebooks.py
+++ b/backend/tests/test_notebooks.py
@@ -122,7 +122,7 @@ async def test_session_launch_checks_quota(client, session, comp_bio_user, comp_
         headers={"Authorization": f"Bearer {comp_bio_token}"},
     )
     assert response.status_code == 400
-    assert "Quota exceeded" in response.json()["detail"]
+    assert response.json()["detail"] == "Failed to launch session"
 
 
 @pytest.mark.asyncio

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Replaced all `detail=str(exc)` and `message=str(exc)` patterns in API error handlers with generic messages, preventing internal paths, stack context, and implementation details from leaking to clients
- Real exceptions are logged server-side with full context (`logger.warning` for business logic errors, `logger.error` with `exc_info=True` for unexpected failures)
- Added `logging` imports and named loggers to 5 API modules that previously had none
- Updated test assertions to match the new generic error messages

## Files changed

11 API modules + 2 test files across `backend/app/api/` and `backend/tests/`

## Test plan

- [x] Backend tests: 1014 passed (1 pre-existing flaky DB state error unrelated to this PR)
- [x] Frontend tests: 371 passed
- [x] `ruff format --check`: passed
- [x] `ruff check`: passed
- [x] `mypy --ignore-missing-imports`: 0 issues in 518 files
- [x] `npx tsc --noEmit`: passed
- [x] `markdownlint-cli`: passed
- [x] README review: no updates needed (internal-only change)