### PR TITLE
Add Content-Security-Policy header (S3)

### DIFF
--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -6,7 +6,7 @@ from app.config import settings
 _CSP = "; ".join(
     [
         "default-src 'self'",
-        "script-src 'self'",
+        "script-src 'self' 'unsafe-inline'",
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' data:",
         "font-src 'self'",

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -3,6 +3,20 @@ from fastapi import Request
 
 from app.config import settings
 
+_CSP = "; ".join(
+    [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data:",
+        "font-src 'self'",
+        "connect-src 'self'",
+        "frame-ancestors 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+    ]
+)
+
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
@@ -11,6 +25,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Content-Security-Policy"] = _CSP
 
         if settings.ssl_enabled:
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.4"
+version = "0.3.5"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -25,3 +25,12 @@ async def test_hsts_header_when_ssl_enabled(client, monkeypatch):
     monkeypatch.setattr(settings, "ssl_enabled", False)
     resp = await client.get("/api/health/")
     assert "Strict-Transport-Security" not in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_content_security_policy_present(client):
+    """Every response must include a Content-Security-Policy header."""
+    resp = await client.get("/api/health/")
+    csp = resp.headers["Content-Security-Policy"]
+    assert "default-src" in csp
+    assert "frame-ancestors 'none'" in csp

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -41,7 +41,7 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
 
     # API routes go to FastAPI backend
     location /api/ {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -41,6 +41,7 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
 
     # API routes go to FastAPI backend
     location /api/ {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Added `Content-Security-Policy` header to `SecurityHeadersMiddleware` and `nginx.conf`, completing the four security headers called out in S3
- Policy: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'`
- `script-src` includes `'unsafe-inline'` because Next.js emits inline scripts for hydration

## Test plan
- [x] New test `test_content_security_policy_present` verifies CSP header on every response
- [x] All existing security header tests pass
- [x] Manually verified app loads and functions with CSP active in browser
- [x] Frontend and backend linting, type checks, and formatting pass