### PR TITLE
Proxy-aware rate limiting (S5)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,6 +49,7 @@ class Settings(BaseSettings):
     rate_limit_login: int = 10
     rate_limit_verify: int = 5
     rate_limit_reset: int = 3
+    trusted_proxy_cidrs: str = "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,::1/128"
 
     # Compute
     compute_mode: str = "kubernetes"

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -1,3 +1,4 @@
+import ipaddress
 import time
 from collections import defaultdict
 
@@ -15,6 +16,58 @@ RATE_LIMITS: dict[str, int] = {
     "/api/auth/reset-password": settings.rate_limit_verify,
 }
 
+# Default trusted proxy networks (private ranges + loopback)
+_DEFAULT_TRUSTED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+    ipaddress.ip_network(cidr.strip()) for cidr in settings.trusted_proxy_cidrs.split(",") if cidr.strip()
+]
+
+
+def _parse_trusted_networks(
+    cidrs: list[str] | None,
+) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    if cidrs is None:
+        return _DEFAULT_TRUSTED_NETWORKS
+    return [ipaddress.ip_network(c.strip()) for c in cidrs if c.strip()]
+
+
+def _is_trusted(ip_str: str, networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network]) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip_str.strip())
+    except ValueError:
+        return False
+    return any(addr in net for net in networks)
+
+
+def get_client_ip(request: Request, *, trusted_cidrs: list[str] | None = None) -> str:
+    """Resolve the real client IP, respecting X-Forwarded-For from trusted proxies.
+
+    Walks the X-Forwarded-For chain from right to left, skipping trusted proxy
+    IPs, and returns the first untrusted address (the real client). If the
+    direct connection is not from a trusted proxy, the header is ignored to
+    prevent spoofing.
+    """
+    if request.client is None:
+        return "unknown"
+
+    direct_ip = request.client.host
+    networks = _parse_trusted_networks(trusted_cidrs)
+
+    if not _is_trusted(direct_ip, networks):
+        return direct_ip
+
+    forwarded = request.headers.get("x-forwarded-for")
+    if not forwarded:
+        return direct_ip
+
+    # Walk right-to-left, skipping trusted proxies
+    ips = [ip.strip() for ip in forwarded.split(",")]
+    for ip in reversed(ips):
+        if not _is_trusted(ip, networks):
+            return ip
+
+    # Every IP in the chain is trusted; return the leftmost
+    return ips[0]
+
 
 # Module-level storage so tests can call rate_limit_requests.clear()
 rate_limit_requests: dict[tuple[str, str], list[float]] = defaultdict(list)
@@ -29,7 +82,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         limit = RATE_LIMITS.get(path)
 
         if limit is not None and request.method == "POST":
-            client_ip = request.client.host if request.client else "unknown"
+            client_ip = get_client_ip(request)
             key = (path, client_ip)
             now = time.time()
             window_start = now - 60  # 1-minute sliding window

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.6"
+version = "0.3.7"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_rate_limit_proxy.py
+++ b/backend/tests/test_rate_limit_proxy.py
@@ -1,0 +1,84 @@
+from app.middleware.rate_limit import get_client_ip
+
+
+class FakeClient:
+    def __init__(self, host: str):
+        self.host = host
+
+
+class FakeRequest:
+    def __init__(self, client_host: str, headers: dict[str, str] | None = None):
+        self.client = FakeClient(client_host)
+        self.headers = headers or {}
+
+
+class TestGetClientIp:
+    """get_client_ip should resolve the real client IP behind trusted proxies."""
+
+    def test_direct_connection_no_forwarded_header(self):
+        """Without X-Forwarded-For, return the socket address."""
+        request = FakeRequest("203.0.113.50")
+        assert get_client_ip(request) == "203.0.113.50"
+
+    def test_untrusted_proxy_ignores_forwarded_header(self):
+        """When the direct connection is not a trusted proxy, ignore the header."""
+        request = FakeRequest(
+            "198.51.100.1",
+            {"x-forwarded-for": "203.0.113.50"},
+        )
+        assert get_client_ip(request) == "198.51.100.1"
+
+    def test_trusted_proxy_uses_forwarded_for(self):
+        """When the direct connection is a trusted proxy, use X-Forwarded-For."""
+        request = FakeRequest(
+            "172.18.0.2",  # Docker bridge network, trusted by default
+            {"x-forwarded-for": "203.0.113.50"},
+        )
+        assert get_client_ip(request) == "203.0.113.50"
+
+    def test_trusted_proxy_chained_forwarded_for(self):
+        """With multiple proxies, use the rightmost untrusted IP."""
+        request = FakeRequest(
+            "172.18.0.2",
+            {"x-forwarded-for": "203.0.113.50, 10.0.0.1, 172.18.0.3"},
+        )
+        # 172.18.0.3 and 10.0.0.1 are trusted; 203.0.113.50 is the real client
+        assert get_client_ip(request) == "203.0.113.50"
+
+    def test_localhost_is_trusted(self):
+        """127.0.0.1 connections should use X-Forwarded-For."""
+        request = FakeRequest(
+            "127.0.0.1",
+            {"x-forwarded-for": "198.51.100.99"},
+        )
+        assert get_client_ip(request) == "198.51.100.99"
+
+    def test_trusted_proxy_no_forwarded_header_falls_back(self):
+        """Trusted proxy without X-Forwarded-For falls back to socket address."""
+        request = FakeRequest("172.18.0.2")
+        assert get_client_ip(request) == "172.18.0.2"
+
+    def test_all_forwarded_ips_trusted_returns_leftmost(self):
+        """If every IP in the chain is trusted, return the leftmost."""
+        request = FakeRequest(
+            "172.18.0.2",
+            {"x-forwarded-for": "10.0.0.1, 172.16.0.5"},
+        )
+        assert get_client_ip(request) == "10.0.0.1"
+
+    def test_no_client_returns_unknown(self):
+        """When request.client is None, return 'unknown'."""
+        request = FakeRequest("0.0.0.0")
+        request.client = None  # type: ignore[assignment]
+        assert get_client_ip(request) == "unknown"
+
+    def test_custom_trusted_cidrs(self):
+        """Caller can supply custom trusted CIDRs."""
+        request = FakeRequest(
+            "198.51.100.1",
+            {"x-forwarded-for": "203.0.113.50"},
+        )
+        # 198.51.100.1 is not trusted by default, so header is ignored
+        assert get_client_ip(request) == "198.51.100.1"
+        # But it is if we pass a custom list that includes it
+        assert get_client_ip(request, trusted_cidrs=["198.51.100.0/24"]) == "203.0.113.50"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Rate limiter now resolves real client IPs behind reverse proxies by parsing `X-Forwarded-For` right-to-left, skipping trusted proxy CIDRs
- Ignores the header entirely when the direct connection is not from a trusted proxy (prevents spoofing)
- Default trusted CIDRs cover RFC 1918 private ranges and loopback, configurable via `BIOAF_TRUSTED_PROXY_CIDRS`
- Bumps version to 0.3.7

## Test plan

- [x] 9 unit tests for `get_client_ip()` covering direct connections, trusted/untrusted proxies, chained forwarding, missing headers, custom CIDRs
- [x] Existing `test_rate_limiting` integration test still passes
- [x] Full backend suite: 1529 passed
- [x] Frontend suite: 371 passed
- [x] ruff format, ruff check, mypy, tsc, markdownlint all clean