### PR TITLE
Dismissable deploy modal with poll-based progress

### DIFF
--- a/backend/alembic/versions/054_add_deploy_progress_to_terraform_runs.py
+++ b/backend/alembic/versions/054_add_deploy_progress_to_terraform_runs.py
@@ -1,0 +1,34 @@
+"""Add deploy_phase and completed_resources to terraform_runs.
+
+Supports the poll-based deployment progress UI. The frontend polls
+for progress instead of maintaining an SSE connection, so phase
+and per-resource completion must be persisted server-side.
+
+Revision ID: 054
+Revises: 053
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "054"
+down_revision = "053"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "terraform_runs",
+        sa.Column("deploy_phase", sa.String(50), nullable=True),
+    )
+    op.add_column(
+        "terraform_runs",
+        sa.Column("completed_resources", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("terraform_runs", "completed_resources")
+    op.drop_column("terraform_runs", "deploy_phase")

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -270,11 +270,17 @@ async def stack_deploy_background_endpoint(
         raise HTTPException(status_code=400, detail="Terraform has not been initialized")
 
     async def _run_deploy():
-        """Drain the deploy_stack generator in the background with its own session."""
+        """Drain the deploy_stack generator in the background with its own session.
+
+        Commits after each event so the progress polling endpoint can see
+        intermediate state (resource counts, phase, completed_resources).
+        Without per-event commits, all flush() calls stay invisible to
+        other sessions under PostgreSQL READ COMMITTED isolation.
+        """
         async with async_session_factory() as bg_session:
             try:
                 async for _event in deploy_stack(bg_session, stack_type, user_id, org_id=org_id):
-                    pass  # Events are consumed; terraform runs as a subprocess
+                    await bg_session.commit()
                 await bg_session.commit()
             except Exception:
                 logger.exception("Background deploy failed")

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -108,6 +108,17 @@ class ComponentToggleResponse(BaseModel):
     status: str
 
 
+class DeployProgressResponse(BaseModel):
+    active: bool
+    status: str | None = None
+    phase: str | None = None
+    resources_completed: int = 0
+    resources_total: int = 0
+    completed_resources: list[str] = []
+    error_message: str | None = None
+    run_id: int | None = None
+
+
 class NotebookImageBuildStatus(BaseModel):
     build_id: str | None
     build_status: str | None
@@ -272,6 +283,41 @@ async def stack_deploy_background_endpoint(
     asyncio.get_event_loop().create_task(_run_deploy())
 
     return {"message": "Deployment started"}
+
+
+@router.get(
+    "/api/v1/infrastructure/stack/deploy/progress",
+    response_model=DeployProgressResponse,
+)
+async def stack_deploy_progress(
+    current_user: dict = require_permission("infrastructure", "deploy"),
+    session: AsyncSession = Depends(get_session),
+) -> DeployProgressResponse:
+    """Poll deployment progress. Returns the most recent active run or idle state."""
+    from app.models.component import TerraformRun
+    from sqlalchemy import select
+
+    result = await session.execute(
+        select(TerraformRun)
+        .where(TerraformRun.status.in_(["planning", "applying", "awaiting_confirmation"]))
+        .order_by(TerraformRun.started_at.desc())
+        .limit(1)
+    )
+    run = result.scalar_one_or_none()
+
+    if run is None:
+        return DeployProgressResponse(active=False)
+
+    return DeployProgressResponse(
+        active=True,
+        status=run.status,
+        phase=run.deploy_phase,
+        resources_completed=run.resources_completed,
+        resources_total=run.resources_planned or 0,
+        completed_resources=run.completed_resources or [],
+        error_message=run.error_message,
+        run_id=run.id,
+    )
 
 
 @router.post("/api/v1/infrastructure/stack/teardown")

--- a/backend/app/api/terraform_executor.py
+++ b/backend/app/api/terraform_executor.py
@@ -69,6 +69,7 @@ class TerraformStatusResponse(BaseModel):
     gcp_credentials_configured: bool
     active_run_id: int | None = None
     active_run_status: str | None = None
+    last_completed_module: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -271,12 +272,23 @@ async def get_terraform_status(
     )
     active_run = active_result.scalar_one_or_none()
 
+    # Find the most recently completed run so the banner can show
+    # a phase-specific toast ("storage deployed" vs "compute deployed").
+    last_completed_result = await session.execute(
+        select(TerraformRun)
+        .where(TerraformRun.status == "completed")
+        .order_by(TerraformRun.completed_at.desc())
+        .limit(1)
+    )
+    last_completed = last_completed_result.scalar_one_or_none()
+
     return TerraformStatusResponse(
         terraform_initialized=config.get("terraform_initialized", "false") == "true",
         terraform_state_bucket=config.get("terraform_state_bucket", ""),
         gcp_credentials_configured=config.get("gcp_credentials_configured", "false") == "true",
         active_run_id=active_run.id if active_run else None,
         active_run_status=active_run.status if active_run else None,
+        last_completed_module=last_completed.module_name if last_completed else None,
     )
 
 

--- a/backend/app/models/component.py
+++ b/backend/app/models/component.py
@@ -38,6 +38,8 @@ class TerraformRun(Base):
     plan_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     resources_planned: Mapped[int | None] = mapped_column(Integer, nullable=True)
     resources_completed: Mapped[int] = mapped_column(Integer, server_default="0", default=0)
+    deploy_phase: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    completed_resources: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     apply_log: Mapped[str | None] = mapped_column(Text, nullable=True)
     terraform_state_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -319,7 +319,18 @@ async def deploy_stack(
             event_type="progress",
             message="Deploying storage infrastructure...",
         )
+        storage_phase_tagged = False
         async for event in _run_module(session, user_id, "storage"):
+            if not storage_phase_tagged:
+                await session.execute(
+                    text("""
+                    UPDATE terraform_runs SET deploy_phase = 'storage'
+                    WHERE module_name = 'storage'
+                      AND status IN ('planning', 'applying', 'awaiting_confirmation')
+                    """)
+                )
+                await session.flush()
+                storage_phase_tagged = True
             if event.event_type == "apply_error":
                 storage_failed = True
                 yield event
@@ -385,7 +396,18 @@ async def deploy_stack(
         event_type="progress",
         message="Deploying compute infrastructure...",
     )
+    compute_phase_tagged = False
     async for event in _run_module(session, user_id, "compute"):
+        if not compute_phase_tagged:
+            await session.execute(
+                text("""
+                UPDATE terraform_runs SET deploy_phase = 'compute'
+                WHERE module_name = 'compute'
+                  AND status IN ('planning', 'applying', 'awaiting_confirmation')
+                """)
+            )
+            await session.flush()
+            compute_phase_tagged = True
         if event.event_type == "apply_error":
             compute_failed = True
             yield event

--- a/backend/app/services/terraform_executor.py
+++ b/backend/app/services/terraform_executor.py
@@ -219,6 +219,9 @@ class TerraformExecutor:
 
                     resources_completed += 1
                     run.resources_completed = resources_completed
+                    if run.completed_resources is None:
+                        run.completed_resources = []
+                    run.completed_resources = [*run.completed_resources, addr]
                     await session.flush()
                     yield TerraformProgressEvent(
                         event_type="resource_complete",
@@ -642,6 +645,9 @@ class TerraformExecutor:
 
                     resources_completed += 1
                     run.resources_completed = resources_completed
+                    if run.completed_resources is None:
+                        run.completed_resources = []
+                    run.completed_resources = [*run.completed_resources, addr]
                     await session.flush()
                     yield TerraformProgressEvent(
                         event_type="resource_complete",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.8"
+version = "0.3.9"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_deploy_progress.py
+++ b/backend/tests/test_deploy_progress.py
@@ -1,0 +1,214 @@
+"""Tests for the deploy progress polling endpoint.
+
+1. test_progress_no_active_deploy -- returns active=false when idle
+2. test_progress_active_deploy_storage_phase -- returns phase/resources during storage
+3. test_progress_active_deploy_compute_phase -- returns phase/resources during compute
+4. test_progress_completed_deploy -- returns active=false after completion
+5. test_progress_failed_deploy -- returns error_message on failure
+6. test_progress_requires_permission -- viewer gets 403
+"""
+
+import pytest
+from sqlalchemy import text
+
+
+async def _set_config(session, key: str, value: str):
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value) VALUES (:k, :v) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        ).bindparams(k=key, v=value)
+    )
+    await session.flush()
+
+
+async def _create_run(
+    session,
+    *,
+    user_id: int,
+    action: str = "apply",
+    module_name: str = "storage",
+    status: str = "applying",
+    resources_planned: int | None = None,
+    resources_completed: int = 0,
+    deploy_phase: str | None = None,
+    completed_resources: list | None = None,
+    error_message: str | None = None,
+) -> int:
+    from app.models.component import TerraformRun
+
+    run = TerraformRun(
+        triggered_by_user_id=user_id,
+        action=action,
+        module_name=module_name,
+        status=status,
+        resources_planned=resources_planned,
+        resources_completed=resources_completed,
+        deploy_phase=deploy_phase,
+        completed_resources=completed_resources,
+        error_message=error_message,
+    )
+    session.add(run)
+    await session.flush()
+    return run.id
+
+
+class TestDeployProgressEndpoint:
+    @pytest.mark.asyncio
+    async def test_progress_no_active_deploy(self, client, admin_token, session):
+        """Returns active=false when no deployment is running."""
+        response = await client.get(
+            "/api/v1/infrastructure/stack/deploy/progress",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["active"] is False
+        assert data["phase"] is None
+        assert data["resources_completed"] == 0
+        assert data["resources_total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_progress_active_deploy_storage_phase(self, client, admin_token, admin_user, session):
+        """Returns storage phase progress during active deploy."""
+        run_id = await _create_run(
+            session,
+            user_id=admin_user.id,
+            action="apply",
+            module_name="storage",
+            status="applying",
+            resources_planned=8,
+            resources_completed=3,
+            deploy_phase="storage",
+            completed_resources=[
+                "google_storage_bucket.ingest",
+                "google_storage_bucket.raw",
+                "google_storage_bucket.working",
+            ],
+        )
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/stack/deploy/progress",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["active"] is True
+        assert data["status"] == "applying"
+        assert data["phase"] == "storage"
+        assert data["resources_completed"] == 3
+        assert data["resources_total"] == 8
+        assert len(data["completed_resources"]) == 3
+        assert "google_storage_bucket.ingest" in data["completed_resources"]
+        assert data["run_id"] == run_id
+
+    @pytest.mark.asyncio
+    async def test_progress_active_deploy_compute_phase(self, client, admin_token, admin_user, session):
+        """Returns compute phase progress during active deploy."""
+        run_id = await _create_run(
+            session,
+            user_id=admin_user.id,
+            action="apply",
+            module_name="compute",
+            status="applying",
+            resources_planned=16,
+            resources_completed=10,
+            deploy_phase="compute",
+            completed_resources=[
+                "google_container_cluster.bioaf",
+                "google_container_node_pool.pipelines",
+            ],
+        )
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/stack/deploy/progress",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["active"] is True
+        assert data["phase"] == "compute"
+        assert data["resources_completed"] == 10
+        assert data["resources_total"] == 16
+        assert data["run_id"] == run_id
+
+    @pytest.mark.asyncio
+    async def test_progress_completed_deploy(self, client, admin_token, admin_user, session):
+        """Returns active=false after deployment completes."""
+        await _create_run(
+            session,
+            user_id=admin_user.id,
+            action="apply",
+            module_name="compute",
+            status="completed",
+            resources_planned=16,
+            resources_completed=16,
+            deploy_phase="compute",
+        )
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/stack/deploy/progress",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["active"] is False
+
+    @pytest.mark.asyncio
+    async def test_progress_failed_deploy(self, client, admin_token, admin_user, session):
+        """Returns error_message on failed deployment."""
+        await _create_run(
+            session,
+            user_id=admin_user.id,
+            action="apply",
+            module_name="storage",
+            status="failed",
+            resources_planned=8,
+            resources_completed=3,
+            deploy_phase="storage",
+            error_message="Quota exceeded for storage buckets",
+        )
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/stack/deploy/progress",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # Failed runs are not active
+        assert data["active"] is False
+
+    @pytest.mark.asyncio
+    async def test_progress_planning_is_active(self, client, admin_token, admin_user, session):
+        """Planning phase counts as active."""
+        await _create_run(
+            session,
+            user_id=admin_user.id,
+            action="apply",
+            module_name="storage",
+            status="planning",
+            deploy_phase="storage",
+        )
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/stack/deploy/progress",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["active"] is True
+        assert data["status"] == "planning"
+
+    @pytest.mark.asyncio
+    async def test_progress_requires_permission(self, client, viewer_token, session):
+        """Viewer role gets 403."""
+        response = await client.get(
+            "/api/v1/infrastructure/stack/deploy/progress",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert response.status_code == 403

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -252,7 +252,11 @@ export default function InfraComponentsPage() {
     };
   }, [hasBuildRelated, componentsData]);
 
+  const [deployLoading, setDeployLoading] = useState(false);
+
   async function handleStartDeploy() {
+    if (deployLoading) return;
+    setDeployLoading(true);
     try {
       await api.post("/api/v1/infrastructure/stack/deploy-background", {
         stack_type: "kubernetes",
@@ -262,6 +266,8 @@ export default function InfraComponentsPage() {
     } catch (e) {
       const message = e instanceof Error ? e.message : "Failed to start deployment";
       alert(message);
+    } finally {
+      setDeployLoading(false);
     }
   }
 
@@ -484,9 +490,10 @@ export default function InfraComponentsPage() {
                   ) : (
                     <button
                       onClick={handleStartDeploy}
-                      className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 font-medium"
+                      disabled={deployLoading}
+                      className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      Deploy
+                      {deployLoading ? "Starting..." : "Deploy"}
                     </button>
                   )}
                 </div>
@@ -966,10 +973,10 @@ export default function InfraComponentsPage() {
       )}
 
       {/* Deploy Stack Modal (poll-based) */}
-      {showDeployModal && deployProgress.active && (
+      {showDeployModal && (
         <DeployProgressModal
           phase={deployProgress.phase}
-          status={deployProgress.status}
+          status={deployProgress.active ? deployProgress.status : deployStarted ? "planning" : deployProgress.status}
           resourcesCompleted={deployProgress.resources_completed}
           resourcesTotal={deployProgress.resources_total}
           completedResources={deployProgress.completed_resources}
@@ -980,33 +987,6 @@ export default function InfraComponentsPage() {
             setShowAbortConfirm(true);
           }}
           onDone={handleDeployComplete}
-        />
-      )}
-      {/* Deploy complete/error modal -- show briefly after completion */}
-      {showDeployModal && !deployProgress.active && deployProgress.status === "completed" && (
-        <DeployProgressModal
-          phase={deployProgress.phase}
-          status={deployProgress.status}
-          resourcesCompleted={deployProgress.resources_completed}
-          resourcesTotal={deployProgress.resources_total}
-          completedResources={deployProgress.completed_resources}
-          errorMessage={null}
-          onDismiss={() => setShowDeployModal(false)}
-          onAbort={() => {}}
-          onDone={handleDeployComplete}
-        />
-      )}
-      {showDeployModal && !deployProgress.active && deployProgress.status === "failed" && (
-        <DeployProgressModal
-          phase={deployProgress.phase}
-          status={deployProgress.status}
-          resourcesCompleted={deployProgress.resources_completed}
-          resourcesTotal={deployProgress.resources_total}
-          completedResources={deployProgress.completed_resources}
-          errorMessage={deployProgress.error_message}
-          onDismiss={() => setShowDeployModal(false)}
-          onAbort={() => {}}
-          onDone={() => setShowDeployModal(false)}
         />
       )}
 

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -7,8 +7,10 @@ import { Header } from "@/components/layout/Header";
 import { StorageSection } from "@/components/components/StorageSection";
 import { BootstrapCard } from "@/components/infrastructure/BootstrapCard";
 import { TerraformProgressModal } from "@/components/infrastructure/TerraformProgressModal";
+import { DeployProgressModal } from "@/components/infrastructure/DeployProgressModal";
 import { TerraformRunHistory } from "@/components/infrastructure/TerraformRunHistory";
 import { OrphanedResourcesCard } from "@/components/infrastructure/OrphanedResourcesCard";
+import { useDeploymentProgress } from "@/hooks/useDeploymentProgress";
 import { isAuthenticated } from "@/lib/auth";
 import { api } from "@/lib/api";
 
@@ -111,6 +113,9 @@ export default function InfraComponentsPage() {
   const [clusterConfig, setClusterConfig] = useState<ClusterConfig | null>(null);
   const [showBootstrapModal, setShowBootstrapModal] = useState(false);
   const [showDeployModal, setShowDeployModal] = useState(false);
+  const [deployStarted, setDeployStarted] = useState(false);
+  const [showAbortConfirm, setShowAbortConfirm] = useState(false);
+  const [abortLoading, setAbortLoading] = useState(false);
   const [showTeardownModal, setShowTeardownModal] = useState(false);
   const [showTeardownProgress, setShowTeardownProgress] = useState(false);
   const [teardownChecked, setTeardownChecked] = useState(false);
@@ -143,6 +148,26 @@ export default function InfraComponentsPage() {
   const [abandonLoading, setAbandonLoading] = useState(false);
 
   const DESTROY_STORAGE_PHRASE = "delete my data";
+
+  // Always poll for deployment progress on this page. This catches
+  // in-progress deploys on page load (e.g. after a refresh).
+  const deployProgress = useDeploymentProgress(true);
+
+  // Detect an in-progress deployment on page load and set deployStarted
+  useEffect(() => {
+    if (deployProgress.active && !deployStarted) {
+      setDeployStarted(true);
+    }
+  }, [deployProgress.active, deployStarted]);
+
+  // When a tracked deployment finishes, refresh page data
+  useEffect(() => {
+    if (!deployStarted) return;
+    if (!deployProgress.active && deployProgress.status !== null) {
+      setDeployStarted(false);
+      setRefreshKey((k) => k + 1);
+    }
+  }, [deployStarted, deployProgress.active, deployProgress.status]);
 
   useEffect(() => {
     if (!isAuthenticated()) {
@@ -227,9 +252,40 @@ export default function InfraComponentsPage() {
     };
   }, [hasBuildRelated, componentsData]);
 
+  async function handleStartDeploy() {
+    try {
+      await api.post("/api/v1/infrastructure/stack/deploy-background", {
+        stack_type: "kubernetes",
+      });
+      setDeployStarted(true);
+      setShowDeployModal(true);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to start deployment";
+      alert(message);
+    }
+  }
+
   function handleDeployComplete() {
     setShowDeployModal(false);
+    setDeployStarted(false);
     setRefreshKey((k) => k + 1);
+  }
+
+  async function handleAbortDeploy() {
+    if (!deployProgress.run_id) return;
+    setAbortLoading(true);
+    try {
+      await api.post(`/api/v1/infrastructure/terraform/abandon/${deployProgress.run_id}`);
+      setShowAbortConfirm(false);
+      setShowDeployModal(false);
+      setDeployStarted(false);
+      setRefreshKey((k) => k + 1);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Abort failed";
+      alert(message);
+    } finally {
+      setAbortLoading(false);
+    }
   }
 
   function handleBootstrapComplete() {
@@ -397,12 +453,42 @@ export default function InfraComponentsPage() {
                   <p className="text-xs text-gray-500 mb-4">
                     $0 when idle. Scales automatically with your workloads.
                   </p>
-                  <button
-                    onClick={() => setShowDeployModal(true)}
-                    className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 font-medium"
-                  >
-                    Deploy
-                  </button>
+                  {deployProgress.active ? (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <span className="inline-block h-2 w-2 bg-blue-500 rounded-full animate-pulse" />
+                        <span className="text-sm text-blue-700 font-medium">
+                          Deployment in progress
+                        </span>
+                      </div>
+                      {deployProgress.resources_total > 0 && (
+                        <p className="text-xs text-gray-500">
+                          {deployProgress.resources_completed} of {deployProgress.resources_total} components
+                        </p>
+                      )}
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => setShowDeployModal(true)}
+                          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 font-medium"
+                        >
+                          View Progress
+                        </button>
+                        <button
+                          onClick={() => setShowAbortConfirm(true)}
+                          className="px-3 py-1.5 text-sm bg-red-50 text-red-600 rounded hover:bg-red-100 font-medium"
+                        >
+                          Abort
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={handleStartDeploy}
+                      className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 font-medium"
+                    >
+                      Deploy
+                    </button>
+                  )}
                 </div>
 
                 {/* SLURM + NFS card (coming soon) */}
@@ -849,7 +935,7 @@ export default function InfraComponentsPage() {
                   storageDeployed={stackStatus?.storage_deployed ?? false}
                   terraformInitialized={tfInitialized}
                   pubsubConfigured={stackStatus?.pubsub_configured ?? false}
-                  onDeploy={() => setShowDeployModal(true)}
+                  onDeploy={handleStartDeploy}
                   onUpdateStorage={() => setRefreshKey((k) => k + 1)}
                 />
               </div>
@@ -879,13 +965,48 @@ export default function InfraComponentsPage() {
         />
       )}
 
-      {/* Deploy Stack Modal */}
-      {showDeployModal && (
-        <TerraformProgressModal
-          title="Deploy Compute Stack"
-          sseUrl="/api/v1/infrastructure/stack/deploy"
-          onComplete={handleDeployComplete}
-          onClose={() => setShowDeployModal(false)}
+      {/* Deploy Stack Modal (poll-based) */}
+      {showDeployModal && deployProgress.active && (
+        <DeployProgressModal
+          phase={deployProgress.phase}
+          status={deployProgress.status}
+          resourcesCompleted={deployProgress.resources_completed}
+          resourcesTotal={deployProgress.resources_total}
+          completedResources={deployProgress.completed_resources}
+          errorMessage={deployProgress.error_message}
+          onDismiss={() => setShowDeployModal(false)}
+          onAbort={() => {
+            setShowDeployModal(false);
+            setShowAbortConfirm(true);
+          }}
+          onDone={handleDeployComplete}
+        />
+      )}
+      {/* Deploy complete/error modal -- show briefly after completion */}
+      {showDeployModal && !deployProgress.active && deployProgress.status === "completed" && (
+        <DeployProgressModal
+          phase={deployProgress.phase}
+          status={deployProgress.status}
+          resourcesCompleted={deployProgress.resources_completed}
+          resourcesTotal={deployProgress.resources_total}
+          completedResources={deployProgress.completed_resources}
+          errorMessage={null}
+          onDismiss={() => setShowDeployModal(false)}
+          onAbort={() => {}}
+          onDone={handleDeployComplete}
+        />
+      )}
+      {showDeployModal && !deployProgress.active && deployProgress.status === "failed" && (
+        <DeployProgressModal
+          phase={deployProgress.phase}
+          status={deployProgress.status}
+          resourcesCompleted={deployProgress.resources_completed}
+          resourcesTotal={deployProgress.resources_total}
+          completedResources={deployProgress.completed_resources}
+          errorMessage={deployProgress.error_message}
+          onDismiss={() => setShowDeployModal(false)}
+          onAbort={() => {}}
+          onDone={() => setShowDeployModal(false)}
         />
       )}
 
@@ -1016,6 +1137,42 @@ export default function InfraComponentsPage() {
           onComplete={handleDestroyStorageComplete}
           onClose={() => setShowDestroyStorageProgress(false)}
         />
+      )}
+
+      {/* Abort Deployment Confirmation Modal */}
+      {showAbortConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-xl p-6 max-w-md w-full mx-4">
+            <h2 className="text-lg font-semibold mb-3">Abort Deployment</h2>
+
+            <div className="bg-amber-50 border border-amber-200 rounded p-3 mb-4">
+              <p className="text-sm font-medium text-amber-800 mb-1">
+                This may leave infrastructure in an unexpected state
+              </p>
+              <p className="text-xs text-amber-700">
+                Aborting will cancel the current deployment. Some resources may
+                have already been created and will need to be cleaned up manually
+                or by re-running the deployment.
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowAbortConfirm(false)}
+                className="px-4 py-2 text-sm border border-gray-300 rounded hover:bg-gray-50"
+              >
+                Continue Deploying
+              </button>
+              <button
+                onClick={handleAbortDeploy}
+                disabled={abortLoading}
+                className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+              >
+                {abortLoading ? "Aborting..." : "Abort Deployment"}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Abandon Run Confirmation Modal */}

--- a/frontend/src/components/infrastructure/DeployProgressModal.tsx
+++ b/frontend/src/components/infrastructure/DeployProgressModal.tsx
@@ -150,7 +150,8 @@ function StatusBadge({ status }: { status: ResourceStatus }) {
 }
 
 function phaseTitle(phase: string | null, status: string | null): string {
-  if (status === "planning") return "Preparing deployment";
+  if (status === null || status === "planning" || status === "awaiting_confirmation")
+    return "Preparing deployment";
   if (phase === "storage") return "Deploying storage infrastructure";
   if (phase === "compute") return "Deploying compute infrastructure";
   return "Preparing deployment";
@@ -174,7 +175,7 @@ export function DeployProgressModal({
   const listRef = useRef<HTMLUListElement | null>(null);
   const [patienceIndex, setPatienceIndex] = useState(0);
 
-  const isRunning = status === "planning" || status === "applying" || status === "awaiting_confirmation";
+  const isRunning = status === null || status === "planning" || status === "applying" || status === "awaiting_confirmation";
   const isComplete = status === "completed";
   const isError = status === "failed";
   const showTimingWarning = phase === "compute";
@@ -219,7 +220,9 @@ export function DeployProgressModal({
             <div>
               <p className="text-sm text-blue-600 flex items-center gap-2">
                 <span className="inline-block h-3 w-3 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
-                {status === "planning" ? "Planning resources..." : "Applying changes..."}
+                {status === null || status === "planning" || status === "awaiting_confirmation"
+                  ? "Planning resources..."
+                  : "Applying changes..."}
               </p>
               <div className="mt-2">
                 {showTimingWarning && (

--- a/frontend/src/components/infrastructure/DeployProgressModal.tsx
+++ b/frontend/src/components/infrastructure/DeployProgressModal.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Friendly names for Terraform resource types
+// ---------------------------------------------------------------------------
+
+const FRIENDLY_NAMES: Record<string, string> = {
+  // Storage resources
+  "google_storage_bucket.ingest": "Ingest data storage",
+  "google_storage_bucket.raw": "Raw data storage",
+  "google_storage_bucket.working": "Working data storage",
+  "google_storage_bucket.results": "Results storage",
+  "google_storage_bucket.config_backups": "Configuration backups",
+  // Pub/Sub
+  "google_pubsub_topic.ingest_events": "Data ingest notifications",
+  "google_pubsub_subscription.ingest_worker": "Ingest processing queue",
+  "google_pubsub_topic.ingest_dead_letter": "Failed ingest retry queue",
+  "google_pubsub_subscription.ingest_dead_letter_sub":
+    "Failed ingest retry handler",
+  "google_storage_notification.ingest_notification":
+    "Automatic file detection",
+  "google_pubsub_topic_iam_member.gcs_publisher":
+    "Storage notification permissions",
+  // Compute resources
+  "google_container_cluster.bioaf": "Compute cluster",
+  "google_container_node_pool.pipelines": "Pipeline processing nodes",
+  "google_container_node_pool.interactive": "Interactive session nodes",
+  "google_project_iam_member.gke_storage_access":
+    "Cluster storage permissions",
+  "google_project_iam_member.gke_default_node_sa":
+    "Node service account permissions",
+  "google_service_account.notebook_runner":
+    "Notebook service account",
+  "google_project_iam_member.notebook_runner_storage":
+    "Notebook storage permissions",
+  "google_service_account_iam_member.notebook_runner_workload_identity":
+    "Notebook identity binding",
+};
+
+const PATIENCE_MESSAGES = [
+  "Doing the science...",
+  "Arguing with reviewer #2...",
+  "Negotiating with the sequencer...",
+  "Asking the compute cluster nicely...",
+  "Wrangling sample metadata...",
+  "Spinning up nodes (they're shy)...",
+  "Convincing Kubernetes this is a good idea...",
+  "Almost there. Probably.",
+  "Aligning reads...",
+  "Realigning reads...",
+  "Realigning the realignment...",
+  "Counting reads...",
+  "Counting them again to be sure...",
+  "Finding that one weird SNP...",
+  "Ignoring mitochondiral reads...",
+  "Blaming the reference genome...",
+  "Indexing the reference genome...",
+  "Re-indexing the reference genome...",
+  "Scaffolding genomes...",
+  "Looking for structural variants...",
+  "Pretending we understand structural variants...",
+  "Explaining TPM to the system again...",
+  "Explaining FPKM to the system again...",
+  "Pretending TPM vs FPKM matters less than it does...",
+  "Arguing about cluster labels",
+  "Growing cells...",
+  "Waiting for cells to grow...",
+  "Waiting longer for cells to grow...",
+  "Checking the incubator...",
+  "Feeding the cells...",
+  "Sacrificing a pipette tip...",
+  "Running another gel...",
+  "Waiting for the centrifuge...",
+  "Balancing the centrifuge again just in case...",
+  "Submitting job to the queue...",
+  "Waiting in the queue...",
+  "Still waiting in the queue...",
+  "Looking for the missing sample...",
+  "Looking harder for the missling sample...",
+  "Checking the -80...",
+  "Defrosting the -80...",
+  "Questioning the methods section...",
+  "Questioning everything...",
+  "Untangling phylogenetic trees...",
+  "Teaching BLAST new tricks...",
+  "Negotiating with NCBI...",
+  "Bribing the alignment algorithm...",
+  "Searching for conserved domains...",
+  "Looking for signal peptides...",
+  "Convincing proteins to fold correctly...",
+  "Consulting the ribosome...",
+  "SLURM says maybe...",
+  "Explaining TPM to the PI...",
+  "Downloading another 200GB reference genome...",
+  "Recreating the environment (again)...",
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DeployProgressModalProps {
+  phase: string | null;
+  status: string | null;
+  resourcesCompleted: number;
+  resourcesTotal: number;
+  completedResources: string[];
+  errorMessage: string | null;
+  onDismiss: () => void;
+  onAbort: () => void;
+  onDone: () => void;
+}
+
+type ResourceStatus = "pending" | "complete";
+
+interface TrackedResource {
+  address: string;
+  label: string;
+  status: ResourceStatus;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function friendlyLabel(address: string): string {
+  if (FRIENDLY_NAMES[address]) return FRIENDLY_NAMES[address];
+  const parts = address.split(".");
+  if (parts.length === 2) {
+    return parts[1].replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+  return address;
+}
+
+function StatusBadge({ status }: { status: ResourceStatus }) {
+  if (status === "complete") {
+    return (
+      <span className="text-xs font-medium text-green-600 uppercase tracking-wide">
+        Done
+      </span>
+    );
+  }
+  return (
+    <span className="text-xs text-gray-400 uppercase tracking-wide">
+      Queued
+    </span>
+  );
+}
+
+function phaseTitle(phase: string | null, status: string | null): string {
+  if (status === "planning") return "Preparing deployment";
+  if (phase === "storage") return "Deploying storage infrastructure";
+  if (phase === "compute") return "Deploying compute infrastructure";
+  return "Preparing deployment";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DeployProgressModal({
+  phase,
+  status,
+  resourcesCompleted,
+  resourcesTotal,
+  completedResources,
+  errorMessage,
+  onDismiss,
+  onAbort,
+  onDone,
+}: DeployProgressModalProps) {
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const [patienceIndex, setPatienceIndex] = useState(0);
+
+  const isRunning = status === "planning" || status === "applying" || status === "awaiting_confirmation";
+  const isComplete = status === "completed";
+  const isError = status === "failed";
+  const showTimingWarning = phase === "compute";
+
+  // Rotate patience messages every 10 seconds while running
+  useEffect(() => {
+    if (!isRunning) return;
+    const interval = setInterval(() => {
+      setPatienceIndex((prev) => (prev + 1) % PATIENCE_MESSAGES.length);
+    }, 10000);
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  // Build resource list from completedResources
+  const resources: TrackedResource[] = completedResources.map((addr) => ({
+    address: addr,
+    label: friendlyLabel(addr),
+    status: "complete" as const,
+  }));
+
+  // Auto-scroll resource list
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [resources.length]);
+
+  const progressPct =
+    resourcesTotal > 0
+      ? Math.min(100, Math.round((resourcesCompleted / resourcesTotal) * 100))
+      : 0;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 p-6">
+        <h2 className="text-lg font-semibold mb-1">
+          {isComplete ? "Deployment complete" : isError ? "Deployment failed" : phaseTitle(phase, status)}
+        </h2>
+
+        <div data-testid="deploy-modal-status" className="mb-4">
+          {isRunning && (
+            <div>
+              <p className="text-sm text-blue-600 flex items-center gap-2">
+                <span className="inline-block h-3 w-3 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
+                {status === "planning" ? "Planning resources..." : "Applying changes..."}
+              </p>
+              <div className="mt-2">
+                {showTimingWarning && (
+                  <p className="text-xs text-gray-400">
+                    This can take 10-30 minutes based on Google Cloud traffic.
+                  </p>
+                )}
+                <p className="text-xs text-gray-300 mt-1">
+                  {PATIENCE_MESSAGES[patienceIndex]}
+                </p>
+              </div>
+            </div>
+          )}
+          {isComplete && (
+            <p className="text-sm text-green-600 font-medium">
+              All systems ready
+            </p>
+          )}
+          {isError && (
+            <p
+              data-testid="deploy-modal-error"
+              className="text-sm text-red-600 font-medium"
+            >
+              Setup failed: {errorMessage}
+            </p>
+          )}
+        </div>
+
+        {resourcesTotal > 0 && (
+          <div data-testid="deploy-progress-bar" className="mb-4">
+            <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
+              <div
+                className="bg-blue-600 h-2 rounded-full transition-all duration-500"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-400 mt-1 text-right">
+              {resourcesCompleted} of {resourcesTotal} components
+            </p>
+          </div>
+        )}
+
+        {resources.length > 0 && (
+          <ul
+            ref={listRef}
+            className="space-y-0.5 mb-4 max-h-52 overflow-y-auto"
+          >
+            {resources.map((r) => (
+              <li
+                key={r.address}
+                className="flex items-center justify-between py-1.5 px-2 rounded text-sm"
+              >
+                <span className="text-gray-700">{r.label}</span>
+                <StatusBadge status={r.status} />
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex justify-end gap-2">
+          {isComplete && (
+            <button
+              data-testid="deploy-modal-done-btn"
+              onClick={onDone}
+              className="px-4 py-2 bg-green-600 text-white rounded-lg text-sm font-medium hover:bg-green-700"
+            >
+              Done
+            </button>
+          )}
+          {isError && (
+            <button
+              onClick={onDismiss}
+              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-300"
+            >
+              Close
+            </button>
+          )}
+          {isRunning && (
+            <>
+              <button
+                onClick={onAbort}
+                className="px-4 py-2 bg-red-50 text-red-600 rounded-lg text-sm font-medium hover:bg-red-100"
+              >
+                Abort Deployment
+              </button>
+              <button
+                onClick={onDismiss}
+                className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-300"
+              >
+                Minimize
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/infrastructure/DeploymentBanner.test.tsx
+++ b/frontend/src/components/infrastructure/DeploymentBanner.test.tsx
@@ -46,6 +46,7 @@ describe("DeploymentBanner", () => {
       gcp_credentials_configured: true,
       active_run_id: null,
       active_run_status: null,
+      last_completed_module: null,
     });
 
     const { container } = render(<DeploymentBanner />);
@@ -61,6 +62,7 @@ describe("DeploymentBanner", () => {
       gcp_credentials_configured: true,
       active_run_id: 42,
       active_run_status: "applying",
+      last_completed_module: null,
     });
 
     render(<DeploymentBanner />);
@@ -77,6 +79,7 @@ describe("DeploymentBanner", () => {
       gcp_credentials_configured: true,
       active_run_id: 42,
       active_run_status: "applying",
+      last_completed_module: null,
     });
 
     render(<DeploymentBanner />);
@@ -87,13 +90,14 @@ describe("DeploymentBanner", () => {
     });
   });
 
-  test("shows success toast when deployment completes", async () => {
+  test("shows storage toast when storage deploy completes", async () => {
     // First poll: active deployment
     mockGet.mockResolvedValueOnce({
       terraform_initialized: true,
       gcp_credentials_configured: true,
       active_run_id: 42,
       active_run_status: "applying",
+      last_completed_module: null,
     });
 
     render(<DeploymentBanner />);
@@ -102,12 +106,13 @@ describe("DeploymentBanner", () => {
       expect(screen.getByTestId("deployment-banner")).toBeInTheDocument();
     });
 
-    // Second poll: deployment complete
+    // Second poll: storage complete, compute not started yet
     mockGet.mockResolvedValueOnce({
       terraform_initialized: true,
       gcp_credentials_configured: true,
       active_run_id: null,
       active_run_status: null,
+      last_completed_module: "storage",
     });
 
     await act(async () => {
@@ -116,7 +121,7 @@ describe("DeploymentBanner", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("deployment-toast")).toBeInTheDocument();
-      expect(screen.getByText(/Compute stack deployed/)).toBeInTheDocument();
+      expect(screen.getByText(/Storage deployed successfully/)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/infrastructure/DeploymentBanner.tsx
+++ b/frontend/src/components/infrastructure/DeploymentBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { api } from "@/lib/api";
 
@@ -9,14 +9,34 @@ interface TerraformStatus {
   gcp_credentials_configured: boolean;
   active_run_id: number | null;
   active_run_status: string | null;
+  last_completed_module: string | null;
 }
 
 const POLL_INTERVAL_MS = 10_000;
 
+const TOAST_MESSAGES: Record<string, { text: string; link: string; linkText: string }> = {
+  storage: {
+    text: "Storage deployed successfully on Google GCS. You can now upload files.",
+    link: "/infrastructure/components",
+    linkText: "Go to Components",
+  },
+  compute: {
+    text: "Compute cluster successfully deployed on Google GKE. You can now select components and run pipelines.",
+    link: "/infrastructure/components",
+    linkText: "Go to Components",
+  },
+  default: {
+    text: "Infrastructure operation complete.",
+    link: "/infrastructure/components",
+    linkText: "Go to Components",
+  },
+};
+
 export function DeploymentBanner() {
   const [deploying, setDeploying] = useState(false);
   const [previouslyDeploying, setPreviouslyDeploying] = useState(false);
-  const [showToast, setShowToast] = useState(false);
+  const [toast, setToast] = useState<{ text: string; link: string; linkText: string } | null>(null);
+  const lastSeenModuleRef = useRef<string | null>(null);
 
   const checkStatus = useCallback(async () => {
     try {
@@ -26,15 +46,25 @@ export function DeploymentBanner() {
       const isActive = status.active_run_id !== null;
 
       if (previouslyDeploying && !isActive) {
-        // Deployment just finished
+        // A run just finished -- show a phase-specific toast
+        const module = status.last_completed_module;
+        // Only show the toast if the completed module changed (avoids
+        // re-showing the same toast on every poll after completion).
+        if (module !== lastSeenModuleRef.current) {
+          lastSeenModuleRef.current = module;
+          const message = TOAST_MESSAGES[module ?? "default"] ?? TOAST_MESSAGES.default;
+          setToast(message);
+          setTimeout(() => setToast(null), 10_000);
+        }
         setDeploying(false);
-        setShowToast(true);
         setPreviouslyDeploying(false);
-        // Auto-dismiss toast after 10 seconds
-        setTimeout(() => setShowToast(false), 10_000);
       } else {
         setDeploying(isActive);
         setPreviouslyDeploying(isActive);
+        if (isActive) {
+          // Track current module so we detect the transition
+          lastSeenModuleRef.current = status.last_completed_module;
+        }
       }
     } catch {
       // Silently ignore -- user may not be admin or not logged in
@@ -69,23 +99,23 @@ export function DeploymentBanner() {
         </div>
       )}
 
-      {showToast && (
+      {toast && (
         <div
           data-testid="deployment-toast"
-          className="fixed top-4 right-4 z-50 bg-green-600 text-white px-4 py-3 rounded-lg shadow-lg flex items-center gap-3"
+          className="fixed top-4 right-4 z-50 bg-green-600 text-white px-4 py-3 rounded-lg shadow-lg flex items-center gap-3 max-w-md"
         >
           <span className="text-sm font-medium">
-            Compute stack deployed. You can now select components.
+            {toast.text}
           </span>
           <Link
-            href="/infrastructure/components"
-            className="text-sm underline text-green-100 hover:text-white"
+            href={toast.link}
+            className="text-sm underline text-green-100 hover:text-white shrink-0"
           >
-            Go to Components
+            {toast.linkText}
           </Link>
           <button
-            onClick={() => setShowToast(false)}
-            className="text-green-200 hover:text-white ml-2"
+            onClick={() => setToast(null)}
+            className="text-green-200 hover:text-white ml-2 shrink-0"
             aria-label="Dismiss"
           >
             x

--- a/frontend/src/components/infrastructure/DeploymentBanner.tsx
+++ b/frontend/src/components/infrastructure/DeploymentBanner.tsx
@@ -47,12 +47,12 @@ export function DeploymentBanner() {
 
       if (previouslyDeploying && !isActive) {
         // A run just finished -- show a phase-specific toast
-        const module = status.last_completed_module;
+        const completedModule = status.last_completed_module;
         // Only show the toast if the completed module changed (avoids
         // re-showing the same toast on every poll after completion).
-        if (module !== lastSeenModuleRef.current) {
-          lastSeenModuleRef.current = module;
-          const message = TOAST_MESSAGES[module ?? "default"] ?? TOAST_MESSAGES.default;
+        if (completedModule !== lastSeenModuleRef.current) {
+          lastSeenModuleRef.current = completedModule;
+          const message = TOAST_MESSAGES[completedModule ?? "default"] ?? TOAST_MESSAGES.default;
           setToast(message);
           setTimeout(() => setToast(null), 10_000);
         }

--- a/frontend/src/hooks/useDeploymentProgress.ts
+++ b/frontend/src/hooks/useDeploymentProgress.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState, useCallback, useRef } from "react";
+import { api } from "@/lib/api";
+
+export interface DeploymentProgress {
+  active: boolean;
+  status: string | null;
+  phase: string | null;
+  resources_completed: number;
+  resources_total: number;
+  completed_resources: string[];
+  error_message: string | null;
+  run_id: number | null;
+}
+
+const EMPTY: DeploymentProgress = {
+  active: false,
+  status: null,
+  phase: null,
+  resources_completed: 0,
+  resources_total: 0,
+  completed_resources: [],
+  error_message: null,
+  run_id: null,
+};
+
+/**
+ * Poll the deploy progress endpoint at a fixed interval.
+ *
+ * @param enabled  Pass `true` to start polling. Set to `false` to pause.
+ * @param intervalMs  Polling interval in milliseconds (default 4000).
+ */
+export function useDeploymentProgress(
+  enabled: boolean,
+  intervalMs = 4000,
+) {
+  const [progress, setProgress] = useState<DeploymentProgress>(EMPTY);
+  const [loading, setLoading] = useState(false);
+  const mountedRef = useRef(true);
+
+  const poll = useCallback(async () => {
+    try {
+      const data = await api.get<DeploymentProgress>(
+        "/api/v1/infrastructure/stack/deploy/progress",
+      );
+      if (mountedRef.current) {
+        setProgress(data);
+      }
+    } catch {
+      // Silently ignore -- user may not have permission or server is down
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    setLoading(true);
+    poll();
+    const interval = setInterval(poll, intervalMs);
+    return () => clearInterval(interval);
+  }, [enabled, intervalMs, poll]);
+
+  return { ...progress, loading, refetch: poll };
+}

--- a/frontend/tests/components/infrastructure/ComponentsPage.test.tsx
+++ b/frontend/tests/components/infrastructure/ComponentsPage.test.tsx
@@ -179,9 +179,21 @@ describe("InfraComponentsPage", () => {
     });
   });
 
-  // Test 26: Deploy button opens modal
-  it("deploy button opens progress modal", async () => {
+  // Test 26: Deploy button starts background deploy
+  it("deploy button calls deploy-background endpoint", async () => {
+    const idleProgress = {
+      active: false,
+      status: null,
+      phase: null,
+      resources_completed: 0,
+      resources_total: 0,
+      completed_resources: [],
+      error_message: null,
+      run_id: null,
+    };
+
     mockApiGet.mockImplementation((url: string) => {
+      if (url.includes("deploy/progress")) return Promise.resolve(idleProgress);
       if (url.includes("terraform/status")) return Promise.resolve(mockTfStatus());
       if (url.includes("terraform/runs")) return Promise.resolve({ runs: [] });
       if (url.includes("stack/status")) return Promise.resolve(mockStackStatus());
@@ -189,7 +201,7 @@ describe("InfraComponentsPage", () => {
         return Promise.resolve({ compute_stack: null, compute_deployed: false, storage_deployed: false, components: [] });
       return Promise.reject(new Error("Not found"));
     });
-    mockApiPost.mockResolvedValue({ status: "ok" });
+    mockApiPost.mockResolvedValue({ message: "Deployment started" });
 
     await act(async () => {
       render(<InfraComponentsPage />);
@@ -199,11 +211,16 @@ describe("InfraComponentsPage", () => {
       expect(screen.getByText(/Kubernetes \+ GCS/)).toBeInTheDocument();
     });
 
-    const deployButton = screen.getByRole("button", { name: /Deploy/i });
-    fireEvent.click(deployButton);
+    const deployButton = screen.getByRole("button", { name: /^Deploy$/i });
+    await act(async () => {
+      fireEvent.click(deployButton);
+    });
 
     await waitFor(() => {
-      expect(screen.getByText(/Deploy Compute Stack/i)).toBeInTheDocument();
+      expect(mockApiPost).toHaveBeenCalledWith(
+        "/api/v1/infrastructure/stack/deploy-background",
+        { stack_type: "kubernetes" },
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace the SSE-connected deployment modal with a fire-and-forget + poll pattern (matching the existing notebook image build flow). Users can dismiss the modal, navigate freely, and refresh the page without losing deployment progress.
- Fix three bugs in the initial implementation: background deploy not committing intermediate progress (invisible to polling under PostgreSQL READ COMMITTED), modal gated on poll result before first poll returned, and no double-click protection on the Deploy button.
- Show phase-specific toast messages when deploy phases complete ("Storage deployed on GCS" vs "Compute cluster deployed on GKE") instead of the generic "Compute stack deployed" message that fired after every phase.

## Changes

**Backend**
- Migration 054: add `deploy_phase` and `completed_resources` columns to `terraform_runs`
- `GET /stack/deploy/progress` polling endpoint returns phase, resource counts, completed resource addresses, and error state
- Executor persists per-resource completion addresses to `completed_resources` JSONB during apply/destroy
- Orchestrator tags active runs with `deploy_phase` at storage/compute transitions
- Background deploy commits after each event so progress is visible to the polling endpoint
- `/terraform/status` response includes `last_completed_module` for phase-specific toasts

**Frontend**
- New `DeployProgressModal` display component with dynamic title based on phase, Minimize button, and Abort Deployment button
- New `useDeploymentProgress` polling hook (4s interval)
- Deploy button calls `deploy-background`, shows poll-based modal immediately, prevents double-click
- Modal dismissable during deployment; inline progress + "View Progress" / "Abort" shown when dismissed
- Auto-detects active deployment on page load after refresh
- Abort confirmation modal with warning about partial state
- Phase-specific toast messages in `DeploymentBanner`
- `TerraformProgressModal` (SSE) retained for bootstrap, teardown, and destroy-storage

## Test plan

- [x] Backend: 1538 tests pass, 7 new tests for progress endpoint
- [x] Frontend: 371 tests pass, updated ComponentsPage and DeploymentBanner tests
- [x] `ruff format --check`, `ruff check`, `mypy` all clean
- [x] `tsc --noEmit` clean
- [x] Markdown linting clean
- [x] Manual testing: deploy, dismiss modal, refresh page, re-open modal, abort