### PR TITLE
Gate UI by infrastructure component state

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.9"
+version = "0.3.10"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -105,6 +105,7 @@ const CATEGORY_ORDER = [
 
 export default function InfraComponentsPage() {
   const router = useRouter();
+  const [loading, setLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
   const [tfStatus, setTfStatus] = useState<TerraformStatus | null>(null);
   const [runs, setRuns] = useState<TerraformRun[]>([]);
@@ -178,35 +179,21 @@ export default function InfraComponentsPage() {
   }, [router, refreshKey]);
 
   async function loadData() {
-    try {
-      const status = await api.get<TerraformStatus>("/api/v1/infrastructure/terraform/status");
-      setTfStatus(status);
-      const runsData = await api.get<{ runs: TerraformRun[] }>("/api/v1/infrastructure/terraform/runs");
-      setRuns(runsData.runs);
-    } catch {
-      // non-admin users won't have access
-    }
+    // Fetch all data in parallel so the page renders once with complete state
+    const [tfResult, runsResult, ssResult, cdResult, ccResult] = await Promise.allSettled([
+      api.get<TerraformStatus>("/api/v1/infrastructure/terraform/status"),
+      api.get<{ runs: TerraformRun[] }>("/api/v1/infrastructure/terraform/runs"),
+      api.get<StackStatus>("/api/v1/infrastructure/stack/status"),
+      api.get<ComponentsData>("/api/v1/infrastructure/stack/components"),
+      api.get<ClusterConfig>("/api/v1/infrastructure/cluster/config"),
+    ]);
 
-    try {
-      const ss = await api.get<StackStatus>("/api/v1/infrastructure/stack/status");
-      setStackStatus(ss);
-    } catch {
-      // ignore
-    }
-
-    try {
-      const cd = await api.get<ComponentsData>("/api/v1/infrastructure/stack/components");
-      setComponentsData(cd);
-    } catch {
-      // ignore
-    }
-
-    try {
-      const cc = await api.get<ClusterConfig>("/api/v1/infrastructure/cluster/config");
-      setClusterConfig(cc);
-    } catch {
-      // ignore
-    }
+    if (tfResult.status === "fulfilled") setTfStatus(tfResult.value);
+    if (runsResult.status === "fulfilled") setRuns(runsResult.value.runs);
+    if (ssResult.status === "fulfilled") setStackStatus(ssResult.value);
+    if (cdResult.status === "fulfilled") setComponentsData(cdResult.value);
+    if (ccResult.status === "fulfilled") setClusterConfig(ccResult.value);
+    setLoading(false);
   }
 
   // Fetch build status when any component is provisioning or build_failed
@@ -379,6 +366,15 @@ export default function InfraComponentsPage() {
         <main className="flex-1 overflow-y-auto p-6">
           <h1 className="text-2xl font-bold mb-6">Components</h1>
 
+          {loading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="text-center">
+                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+                <p className="mt-3 text-sm text-gray-500">Loading infrastructure status...</p>
+              </div>
+            </div>
+          ) : (
+          <>
           {/* Stuck Terraform run banner */}
           {tfStatus?.active_run_id && (
             <div className="bg-amber-50 border border-amber-300 rounded-lg p-4 mb-6">
@@ -959,6 +955,8 @@ export default function InfraComponentsPage() {
             <h2 className="text-xl font-semibold mb-4">Recent Operations</h2>
             <TerraformRunHistory runs={runs} />
           </div>
+          </>
+          )}
         </main>
       </div>
 

--- a/frontend/src/app/notebooks/page.test.tsx
+++ b/frontend/src/app/notebooks/page.test.tsx
@@ -32,14 +32,31 @@ jest.mock("@/lib/auth", () => ({
   isAuthenticated: () => true,
 }));
 
+const mockComponents = jest.fn();
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => mockComponents(),
+}));
+
 import { api } from "@/lib/api";
 
 const mockGet = api.get as jest.Mock;
 const mockPost = api.post as jest.Mock;
 
+function makeComponent(key: string, category: string, enabled: boolean) {
+  return { key, name: key, description: "", category, enabled, status: enabled ? "ready" : "disabled", config: {}, dependencies: [], estimated_monthly_cost: "", updated_at: null };
+}
+
 beforeEach(() => {
   mockGet.mockReset();
   mockPost.mockReset();
+  mockComponents.mockReturnValue({
+    components: [
+      makeComponent("jupyter_k8s", "analysis", true),
+      makeComponent("rstudio_k8s", "analysis", true),
+    ],
+    loading: false,
+    refetch: jest.fn(),
+  });
 });
 
 const mockEnvironments = {
@@ -180,6 +197,75 @@ describe("NotebooksPage launch modal", () => {
 
     await waitFor(() => {
       expect(screen.getByText("The notebook image is currently building.")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("NotebooksPage launch button component gating", () => {
+  test("hides Launch RStudio when rstudio_k8s is not enabled", async () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("jupyter_k8s", "analysis", true),
+        makeComponent("rstudio_k8s", "analysis", false),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+    setupMocks({ build_id: null, build_status: null, image_uri: null });
+
+    render(<NotebooksPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Launch Session")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Launch Session"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Launch Jupyter")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Launch RStudio")).not.toBeInTheDocument();
+  });
+
+  test("hides Launch Jupyter when jupyter_k8s is not enabled", async () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("jupyter_k8s", "analysis", false),
+        makeComponent("rstudio_k8s", "analysis", true),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+    setupMocks({ build_id: null, build_status: null, image_uri: null });
+
+    render(<NotebooksPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Launch Session")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Launch Session"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Launch RStudio")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Launch Jupyter")).not.toBeInTheDocument();
+  });
+
+  test("shows both buttons when both components are enabled", async () => {
+    setupMocks({ build_id: null, build_status: null, image_uri: null });
+
+    render(<NotebooksPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Launch Session")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Launch Session"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Launch RStudio")).toBeInTheDocument();
+      expect(screen.getByText("Launch Jupyter")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/notebooks/page.test.tsx
+++ b/frontend/src/app/notebooks/page.test.tsx
@@ -51,8 +51,8 @@ beforeEach(() => {
   mockPost.mockReset();
   mockComponents.mockReturnValue({
     components: [
-      makeComponent("jupyter_k8s", "analysis", true),
-      makeComponent("rstudio_k8s", "analysis", true),
+      makeComponent("jupyterhub", "analysis", true),
+      makeComponent("rstudio", "analysis", true),
     ],
     loading: false,
     refetch: jest.fn(),
@@ -202,11 +202,11 @@ describe("NotebooksPage launch modal", () => {
 });
 
 describe("NotebooksPage launch button component gating", () => {
-  test("hides Launch RStudio when rstudio_k8s is not enabled", async () => {
+  test("hides Launch RStudio when rstudio is not enabled", async () => {
     mockComponents.mockReturnValue({
       components: [
-        makeComponent("jupyter_k8s", "analysis", true),
-        makeComponent("rstudio_k8s", "analysis", false),
+        makeComponent("jupyterhub", "analysis", true),
+        makeComponent("rstudio", "analysis", false),
       ],
       loading: false,
       refetch: jest.fn(),
@@ -227,11 +227,11 @@ describe("NotebooksPage launch button component gating", () => {
     expect(screen.queryByText("Launch RStudio")).not.toBeInTheDocument();
   });
 
-  test("hides Launch Jupyter when jupyter_k8s is not enabled", async () => {
+  test("hides Launch Jupyter when jupyterhub is not enabled", async () => {
     mockComponents.mockReturnValue({
       components: [
-        makeComponent("jupyter_k8s", "analysis", false),
-        makeComponent("rstudio_k8s", "analysis", true),
+        makeComponent("jupyterhub", "analysis", false),
+        makeComponent("rstudio", "analysis", true),
       ],
       loading: false,
       refetch: jest.fn(),

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -9,6 +9,7 @@ import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { DetailModal } from "@/components/shared/DetailModal";
 import { isAuthenticated } from "@/lib/auth";
 import { api } from "@/lib/api";
+import { useComponents } from "@/hooks/useComponents";
 import type {
   NotebookSession,
   SessionListResponse,
@@ -41,6 +42,9 @@ const SESSION_STATUS_COLORS: Record<string, string> = {
 
 export default function NotebooksPage() {
   const router = useRouter();
+  const { components } = useComponents();
+  const jupyterEnabled = components.some((c) => c.key === "jupyter_k8s" && c.enabled);
+  const rstudioEnabled = components.some((c) => c.key === "rstudio_k8s" && c.enabled);
   const [sessions, setSessions] = useState<NotebookSession[]>([]);
   const [viewingSession, setViewingSession] = useState<NotebookSession | null>(null);
   const [loading, setLoading] = useState(true);
@@ -590,20 +594,24 @@ export default function NotebooksPage() {
 
                 {/* Launch buttons */}
                 <div className="p-6 border-t bg-gray-50 flex gap-3">
-                  <button
-                    onClick={() => handleLaunch("rstudio")}
-                    disabled={launching}
-                    className="flex-1 bg-blue-600 text-white px-6 py-2.5 rounded-md text-sm hover:bg-blue-700 disabled:opacity-50"
-                  >
-                    {launching ? "Launching..." : "Launch RStudio"}
-                  </button>
-                  <button
-                    onClick={() => handleLaunch("jupyter")}
-                    disabled={launching}
-                    className="flex-1 bg-bioaf-600 text-white px-6 py-2.5 rounded-md text-sm hover:bg-bioaf-700 disabled:opacity-50"
-                  >
-                    {launching ? "Launching..." : "Launch Jupyter"}
-                  </button>
+                  {rstudioEnabled && (
+                    <button
+                      onClick={() => handleLaunch("rstudio")}
+                      disabled={launching}
+                      className="flex-1 bg-blue-600 text-white px-6 py-2.5 rounded-md text-sm hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {launching ? "Launching..." : "Launch RStudio"}
+                    </button>
+                  )}
+                  {jupyterEnabled && (
+                    <button
+                      onClick={() => handleLaunch("jupyter")}
+                      disabled={launching}
+                      className="flex-1 bg-bioaf-600 text-white px-6 py-2.5 rounded-md text-sm hover:bg-bioaf-700 disabled:opacity-50"
+                    >
+                      {launching ? "Launching..." : "Launch Jupyter"}
+                    </button>
+                  )}
                   <button
                     onClick={() => setShowLaunchModal(false)}
                     className="px-4 py-2.5 border rounded-md text-sm text-gray-600 hover:bg-gray-100"

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -43,8 +43,8 @@ const SESSION_STATUS_COLORS: Record<string, string> = {
 export default function NotebooksPage() {
   const router = useRouter();
   const { components } = useComponents();
-  const jupyterEnabled = components.some((c) => c.key === "jupyter_k8s" && c.enabled);
-  const rstudioEnabled = components.some((c) => c.key === "rstudio_k8s" && c.enabled);
+  const jupyterEnabled = components.some((c) => c.key === "jupyterhub" && c.enabled);
+  const rstudioEnabled = components.some((c) => c.key === "rstudio" && c.enabled);
   const [sessions, setSessions] = useState<NotebookSession[]>([]);
   const [viewingSession, setViewingSession] = useState<NotebookSession | null>(null);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Sidebar } from "./Sidebar";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: () => ({ role_name: "admin", email: "admin@test.com" }),
+}));
+
+jest.mock("@/hooks/usePermissions", () => ({
+  usePermissions: () => ({
+    canAccess: () => true,
+    roleName: "admin",
+    loading: false,
+  }),
+}));
+
+const mockComponents = jest.fn();
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => mockComponents(),
+}));
+
+beforeEach(() => {
+  mockComponents.mockReset();
+});
+
+function makeComponent(key: string, category: string, enabled: boolean) {
+  return { key, name: key, description: "", category, enabled, status: enabled ? "ready" : "disabled", config: {}, dependencies: [], estimated_monthly_cost: "", updated_at: null };
+}
+
+describe("Sidebar component gating", () => {
+  test("hides Pipelines section when no pipeline_orchestration component is enabled", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("nextflow_k8s", "pipeline_orchestration", false),
+        makeComponent("snakemake_k8s", "pipeline_orchestration", false),
+        makeComponent("jupyter_k8s", "analysis", true),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    expect(screen.queryByText("Pipelines")).not.toBeInTheDocument();
+  });
+
+  test("shows Pipelines section when a pipeline_orchestration component is enabled", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("nextflow_k8s", "pipeline_orchestration", true),
+        makeComponent("jupyter_k8s", "analysis", true),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    expect(screen.getByText("Pipelines")).toBeInTheDocument();
+  });
+
+  test("hides Notebooks child when neither jupyter_k8s nor rstudio_k8s is enabled", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("jupyter_k8s", "analysis", false),
+        makeComponent("rstudio_k8s", "analysis", false),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    // Expand Workbench to check children
+    fireEvent.click(screen.getByText("Workbench"));
+
+    expect(screen.queryByText("Notebooks")).not.toBeInTheDocument();
+  });
+
+  test("shows Notebooks child when jupyter_k8s is enabled", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("jupyter_k8s", "analysis", true),
+        makeComponent("rstudio_k8s", "analysis", false),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByText("Workbench"));
+
+    expect(screen.getByText("Notebooks")).toBeInTheDocument();
+  });
+
+  test("shows Notebooks child when rstudio_k8s is enabled", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("jupyter_k8s", "analysis", false),
+        makeComponent("rstudio_k8s", "analysis", true),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByText("Workbench"));
+
+    expect(screen.getByText("Notebooks")).toBeInTheDocument();
+  });
+
+  test("shows all sections when components are still loading", () => {
+    mockComponents.mockReturnValue({
+      components: [],
+      loading: true,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    // While loading, sections should still appear (no false negatives)
+    expect(screen.getByText("Pipelines")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Workbench"));
+    expect(screen.getByText("Notebooks")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -126,6 +126,42 @@ describe("Sidebar component gating", () => {
     expect(screen.getByText("Notebooks")).toBeInTheDocument();
   });
 
+  test("hides QC Dashboards when qc_dashboard component is not enabled", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("qc_dashboard", "visualization", false),
+        makeComponent("cellxgene", "visualization", true),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByText("Results"));
+
+    expect(screen.queryByText("QC Dashboards")).not.toBeInTheDocument();
+    expect(screen.getByText("Cellxgene")).toBeInTheDocument();
+  });
+
+  test("hides Cellxgene when cellxgene component is not enabled", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("qc_dashboard", "visualization", true),
+        makeComponent("cellxgene", "visualization", false),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByText("Results"));
+
+    expect(screen.getByText("QC Dashboards")).toBeInTheDocument();
+    expect(screen.queryByText("Cellxgene")).not.toBeInTheDocument();
+  });
+
   test("shows all sections when components are still loading", () => {
     mockComponents.mockReturnValue({
       components: [],

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -48,7 +48,7 @@ describe("Sidebar component gating", () => {
       components: [
         makeComponent("nextflow_k8s", "pipeline_orchestration", false),
         makeComponent("snakemake_k8s", "pipeline_orchestration", false),
-        makeComponent("jupyter_k8s", "analysis", true),
+        makeComponent("jupyterhub", "analysis", true),
       ],
       loading: false,
       refetch: jest.fn(),
@@ -63,7 +63,7 @@ describe("Sidebar component gating", () => {
     mockComponents.mockReturnValue({
       components: [
         makeComponent("nextflow_k8s", "pipeline_orchestration", true),
-        makeComponent("jupyter_k8s", "analysis", true),
+        makeComponent("jupyterhub", "analysis", true),
       ],
       loading: false,
       refetch: jest.fn(),
@@ -74,11 +74,11 @@ describe("Sidebar component gating", () => {
     expect(screen.getByText("Pipelines")).toBeInTheDocument();
   });
 
-  test("hides Notebooks child when neither jupyter_k8s nor rstudio_k8s is enabled", () => {
+  test("hides Notebooks child when neither jupyterhub nor rstudio is enabled", () => {
     mockComponents.mockReturnValue({
       components: [
-        makeComponent("jupyter_k8s", "analysis", false),
-        makeComponent("rstudio_k8s", "analysis", false),
+        makeComponent("jupyterhub", "analysis", false),
+        makeComponent("rstudio", "analysis", false),
       ],
       loading: false,
       refetch: jest.fn(),
@@ -92,11 +92,11 @@ describe("Sidebar component gating", () => {
     expect(screen.queryByText("Notebooks")).not.toBeInTheDocument();
   });
 
-  test("shows Notebooks child when jupyter_k8s is enabled", () => {
+  test("shows Notebooks child when jupyterhub is enabled", () => {
     mockComponents.mockReturnValue({
       components: [
-        makeComponent("jupyter_k8s", "analysis", true),
-        makeComponent("rstudio_k8s", "analysis", false),
+        makeComponent("jupyterhub", "analysis", true),
+        makeComponent("rstudio", "analysis", false),
       ],
       loading: false,
       refetch: jest.fn(),
@@ -109,11 +109,11 @@ describe("Sidebar component gating", () => {
     expect(screen.getByText("Notebooks")).toBeInTheDocument();
   });
 
-  test("shows Notebooks child when rstudio_k8s is enabled", () => {
+  test("shows Notebooks child when rstudio is enabled", () => {
     mockComponents.mockReturnValue({
       components: [
-        makeComponent("jupyter_k8s", "analysis", false),
-        makeComponent("rstudio_k8s", "analysis", true),
+        makeComponent("jupyterhub", "analysis", false),
+        makeComponent("rstudio", "analysis", true),
       ],
       loading: false,
       refetch: jest.fn(),

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,10 +2,11 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { getCurrentUser } from "@/lib/auth";
 import { usePermissions } from "@/hooks/usePermissions";
-import { navConfig, NavSection, NavChild, isChildActive } from "@/lib/navConfig";
+import { useComponents } from "@/hooks/useComponents";
+import { navConfig, NavSection, NavChild, ComponentGate, isChildActive } from "@/lib/navConfig";
 
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
@@ -105,12 +106,29 @@ export function Sidebar() {
   const pathname = usePathname();
   const [user, setUser] = useState<Record<string, unknown> | null>(null);
   const { canAccess, roleName, loading } = usePermissions();
+  const { components, loading: componentsLoading } = useComponents();
 
   useEffect(() => {
     setUser(getCurrentUser());
   }, []);
 
-  // Filter sections and children based on permissions
+  const passesComponentGate = useCallback(
+    (gate?: ComponentGate): boolean => {
+      if (!gate) return true;
+      // While components are loading, show everything to avoid flash-of-missing-nav
+      if (componentsLoading) return true;
+      if (gate.category) {
+        return components.some((c) => c.category === gate.category && c.enabled);
+      }
+      if (gate.keys) {
+        return components.some((c) => gate.keys!.includes(c.key) && c.enabled);
+      }
+      return true;
+    },
+    [components, componentsLoading],
+  );
+
+  // Filter sections and children based on permissions and component gates
   const visibleSections = useMemo(() => {
     if (loading) return [];
     return navConfig
@@ -119,9 +137,12 @@ export function Sidebar() {
         if (section.permission && !canAccess(section.permission.resource, section.permission.action)) {
           return false;
         }
+        if (!passesComponentGate(section.componentGate)) return false;
         if (section.children) {
           return section.children.some(
-            (child) => !child.permission || canAccess(child.permission.resource, child.permission.action),
+            (child) =>
+              (!child.permission || canAccess(child.permission.resource, child.permission.action)) &&
+              passesComponentGate(child.componentGate),
           );
         }
         return true;
@@ -129,11 +150,13 @@ export function Sidebar() {
       .map((section) => {
         if (!section.children) return section;
         const filteredChildren = section.children.filter(
-          (child) => !child.permission || canAccess(child.permission.resource, child.permission.action),
+          (child) =>
+            (!child.permission || canAccess(child.permission.resource, child.permission.action)) &&
+            passesComponentGate(child.componentGate),
         );
         return { ...section, children: filteredChildren };
       });
-  }, [loading, roleName, canAccess]);
+  }, [loading, roleName, canAccess, passesComponentGate]);
 
   // Initialize expanded state: auto-expand section containing active path
   const [expandedSections, setExpandedSections] = useState<Set<string>>(() => {

--- a/frontend/src/hooks/useComponents.ts
+++ b/frontend/src/hooks/useComponents.ts
@@ -4,14 +4,45 @@ import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import type { ComponentState } from "@/lib/types";
 
+interface StackComponentsResponse {
+  compute_stack: string | null;
+  compute_deployed: boolean;
+  storage_deployed: boolean;
+  components: Array<{
+    key: string;
+    name: string;
+    category: string;
+    description: string;
+    cost_estimate: string;
+    dependencies: string[];
+    status: string;
+    configurable: boolean;
+  }>;
+}
+
 export function useComponents() {
   const [components, setComponents] = useState<ComponentState[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchComponents = async () => {
     try {
-      const data = await api.get<{ components: ComponentState[] }>("/api/components");
-      setComponents(data.components);
+      const data = await api.get<StackComponentsResponse>(
+        "/api/v1/infrastructure/stack/components",
+      );
+      setComponents(
+        data.components.map((c) => ({
+          key: c.key,
+          name: c.name,
+          description: c.description,
+          category: c.category,
+          enabled: c.status === "enabled" || c.status === "provisioning",
+          status: c.status,
+          config: {},
+          dependencies: c.dependencies,
+          estimated_monthly_cost: c.cost_estimate,
+          updated_at: null,
+        })),
+      );
     } catch {
       // handled by api client
     } finally {

--- a/frontend/src/lib/navConfig.ts
+++ b/frontend/src/lib/navConfig.ts
@@ -62,7 +62,7 @@ export const navConfig: NavSection[] = [
     label: "Workbench",
     icon: "notebook",
     children: [
-      { label: "Notebooks", path: "/notebooks", permission: { resource: "notebooks", action: "view" }, componentGate: { keys: ["jupyter_k8s", "rstudio_k8s"] } },
+      { label: "Notebooks", path: "/notebooks", permission: { resource: "notebooks", action: "view" }, componentGate: { keys: ["jupyterhub", "rstudio"] } },
       { label: "Work Nodes", path: "/workbench/work-nodes", permission: { resource: "notebooks", action: "view" } },
       { label: "Environments", path: "/environments", permission: { resource: "environments", action: "view" } },
     ],

--- a/frontend/src/lib/navConfig.ts
+++ b/frontend/src/lib/navConfig.ts
@@ -3,10 +3,18 @@ export interface PermissionRef {
   action: string;
 }
 
+export interface ComponentGate {
+  /** At least one component matching these keys must be enabled */
+  keys?: string[];
+  /** At least one component in this category must be enabled */
+  category?: string;
+}
+
 export interface NavChild {
   label: string;
   path: string;
   permission?: PermissionRef;
+  componentGate?: ComponentGate;
 }
 
 export interface NavSection {
@@ -16,6 +24,7 @@ export interface NavSection {
   children?: NavChild[];
   adminOnly?: boolean;
   permission?: PermissionRef;
+  componentGate?: ComponentGate;
 }
 
 export const navConfig: NavSection[] = [
@@ -32,6 +41,7 @@ export const navConfig: NavSection[] = [
   {
     label: "Pipelines",
     icon: "play",
+    componentGate: { category: "pipeline_orchestration" },
     children: [
       { label: "Pipeline Catalog", path: "/pipelines/catalog", permission: { resource: "pipelines", action: "view" } },
       { label: "Pipeline Runs", path: "/pipelines/runs", permission: { resource: "pipelines", action: "view" } },
@@ -52,7 +62,7 @@ export const navConfig: NavSection[] = [
     label: "Workbench",
     icon: "notebook",
     children: [
-      { label: "Notebooks", path: "/notebooks", permission: { resource: "notebooks", action: "view" } },
+      { label: "Notebooks", path: "/notebooks", permission: { resource: "notebooks", action: "view" }, componentGate: { keys: ["jupyter_k8s", "rstudio_k8s"] } },
       { label: "Work Nodes", path: "/workbench/work-nodes", permission: { resource: "notebooks", action: "view" } },
       { label: "Environments", path: "/environments", permission: { resource: "environments", action: "view" } },
     ],

--- a/frontend/src/lib/navConfig.ts
+++ b/frontend/src/lib/navConfig.ts
@@ -33,8 +33,8 @@ export const navConfig: NavSection[] = [
     label: "Results",
     icon: "chart",
     children: [
-      { label: "QC Dashboards", path: "/results/qc-dashboards", permission: { resource: "experiments", action: "view" } },
-      { label: "Cellxgene", path: "/results/cellxgene", permission: { resource: "experiments", action: "view" } },
+      { label: "QC Dashboards", path: "/results/qc-dashboards", permission: { resource: "experiments", action: "view" }, componentGate: { keys: ["qc_dashboard"] } },
+      { label: "Cellxgene", path: "/results/cellxgene", permission: { resource: "experiments", action: "view" }, componentGate: { keys: ["cellxgene"] } },
       { label: "Plot Archive", path: "/results/plot-archive", permission: { resource: "experiments", action: "view" } },
     ],
   },

--- a/frontend/tests/pages/activity.test.tsx
+++ b/frontend/tests/pages/activity.test.tsx
@@ -12,6 +12,10 @@ jest.mock("@/lib/auth", () => ({
   getCurrentUser: () => ({ email: "test@bioaf.org", role: "admin", sub: "1" }),
 }));
 
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({ components: [], loading: false, refetch: jest.fn() }),
+}));
+
 const mockApiGet = jest.fn();
 jest.mock("@/lib/api", () => ({
   api: { get: (...args: unknown[]) => mockApiGet(...args) },

--- a/frontend/tests/pages/dashboard-gcp-banner.test.tsx
+++ b/frontend/tests/pages/dashboard-gcp-banner.test.tsx
@@ -26,6 +26,10 @@ jest.mock("@/hooks/usePermissions", () => ({
   clearPermissionsCache: jest.fn(),
 }));
 
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({ components: [], loading: false, refetch: jest.fn() }),
+}));
+
 const mockApiGet = jest.fn();
 jest.mock("@/lib/api", () => ({
   api: {

--- a/frontend/tests/pages/notebooks.test.tsx
+++ b/frontend/tests/pages/notebooks.test.tsx
@@ -20,6 +20,17 @@ jest.mock("@/lib/api", () => ({
   },
 }));
 
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: [
+      { key: "jupyter_k8s", category: "analysis", enabled: true },
+      { key: "rstudio_k8s", category: "analysis", enabled: true },
+    ],
+    loading: false,
+    refetch: jest.fn(),
+  }),
+}));
+
 // Mock layout components
 jest.mock("@/components/layout/Sidebar", () => ({
   Sidebar: () => <div data-testid="sidebar">Sidebar</div>,

--- a/frontend/tests/pages/notebooks.test.tsx
+++ b/frontend/tests/pages/notebooks.test.tsx
@@ -23,8 +23,8 @@ jest.mock("@/lib/api", () => ({
 jest.mock("@/hooks/useComponents", () => ({
   useComponents: () => ({
     components: [
-      { key: "jupyter_k8s", category: "analysis", enabled: true },
-      { key: "rstudio_k8s", category: "analysis", enabled: true },
+      { key: "jupyterhub", category: "analysis", enabled: true },
+      { key: "rstudio", category: "analysis", enabled: true },
     ],
     loading: false,
     refetch: jest.fn(),

--- a/frontend/tests/pages/pipeline-runs.test.tsx
+++ b/frontend/tests/pages/pipeline-runs.test.tsx
@@ -25,6 +25,10 @@ jest.mock("@/lib/auth", () => ({
     "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6ImFkbWluIn0.fake",
 }));
 
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({ components: [], loading: false, refetch: jest.fn() }),
+}));
+
 // Mock API
 const mockApiGet = jest.fn();
 const mockApiPost = jest.fn();

--- a/frontend/tests/pages/settings-gcp.test.tsx
+++ b/frontend/tests/pages/settings-gcp.test.tsx
@@ -12,6 +12,10 @@ jest.mock("@/lib/auth", () => ({
   getCurrentUser: () => ({ email: "admin@bioaf.org", role: "admin", sub: "1" }),
 }));
 
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({ components: [], loading: false, refetch: jest.fn() }),
+}));
+
 const mockApiGet = jest.fn();
 const mockApiPut = jest.fn();
 const mockApiPost = jest.fn();


### PR DESCRIPTION
## Summary

- Gate infrastructure components page behind a loading spinner until all API data is fetched in parallel, preventing the UI from flickering through intermediate states
- Hide Pipelines nav section when no pipeline_orchestration component is enabled
- Hide Notebooks nav item when neither JupyterHub nor RStudio is enabled
- Hide QC Dashboards and Cellxgene nav items when their respective components are disabled
- Gate Launch RStudio / Launch Jupyter buttons in the notebook launch modal by component enabled state
- Fix useComponents hook to call the stack components endpoint (which returns actual enabled/disabled state) instead of the catalog endpoint (which had no enabled field)

## Test plan

- [x] 382/382 frontend tests pass (8 new tests added for component gating)
- [x] TypeScript type-check passes with zero errors
- [x] Ruff format, ruff check, and mypy pass with zero errors
- [x] Markdown lint passes
- [ ] Verify infrastructure components page shows spinner then renders once
- [ ] Verify Pipelines menu hidden when no pipeline orchestration component enabled
- [ ] Verify Notebooks menu hidden when neither JupyterHub nor RStudio enabled
- [ ] Verify QC Dashboards / Cellxgene hidden when their components are disabled
- [ ] Verify notebook launch modal only shows buttons for enabled session types