### PR TITLE
Show branded loading screen on app startup

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.10"
+version = "0.3.11"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -21,12 +21,9 @@ jest.mock("@/lib/auth", () => ({
   getCurrentUser: () => ({ role_name: "admin", email: "admin@test.com" }),
 }));
 
+const mockPermissions = jest.fn();
 jest.mock("@/hooks/usePermissions", () => ({
-  usePermissions: () => ({
-    canAccess: () => true,
-    roleName: "admin",
-    loading: false,
-  }),
+  usePermissions: () => mockPermissions(),
 }));
 
 const mockComponents = jest.fn();
@@ -36,6 +33,12 @@ jest.mock("@/hooks/useComponents", () => ({
 
 beforeEach(() => {
   mockComponents.mockReset();
+  mockPermissions.mockReset();
+  mockPermissions.mockReturnValue({
+    canAccess: () => true,
+    roleName: "admin",
+    loading: false,
+  });
 });
 
 function makeComponent(key: string, category: string, enabled: boolean) {
@@ -162,7 +165,7 @@ describe("Sidebar component gating", () => {
     expect(screen.queryByText("Cellxgene")).not.toBeInTheDocument();
   });
 
-  test("shows all sections when components are still loading", () => {
+  test("shows loading screen when components are still loading", () => {
     mockComponents.mockReturnValue({
       components: [],
       loading: true,
@@ -171,10 +174,43 @@ describe("Sidebar component gating", () => {
 
     render(<Sidebar />);
 
-    // While loading, sections should still appear (no false negatives)
-    expect(screen.getByText("Pipelines")).toBeInTheDocument();
+    expect(screen.getByText("Loading bioAF...")).toBeInTheDocument();
+    expect(screen.queryByText("Pipelines")).not.toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByText("Workbench"));
-    expect(screen.getByText("Notebooks")).toBeInTheDocument();
+  test("shows loading screen when permissions are still loading", () => {
+    mockPermissions.mockReturnValue({
+      canAccess: () => true,
+      roleName: "",
+      loading: true,
+    });
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("nextflow_k8s", "pipeline_orchestration", true),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    expect(screen.getByText("Loading bioAF...")).toBeInTheDocument();
+    expect(screen.queryByText("Pipelines")).not.toBeInTheDocument();
+  });
+
+  test("shows nav after loading completes", () => {
+    mockComponents.mockReturnValue({
+      components: [
+        makeComponent("nextflow", "pipeline_orchestration", true),
+        makeComponent("jupyterhub", "analysis", true),
+      ],
+      loading: false,
+      refetch: jest.fn(),
+    });
+
+    render(<Sidebar />);
+
+    expect(screen.queryByText("Loading bioAF...")).not.toBeInTheDocument();
+    expect(screen.getByText("Pipelines")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -200,6 +200,18 @@ export function Sidebar() {
     });
   };
 
+  if (loading || componentsLoading) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900" data-testid="app-loading">
+        <div className="text-center">
+          <div className="text-3xl font-bold text-bioaf-400 mb-4">bioAF</div>
+          <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-bioaf-400 border-t-transparent" />
+          <p className="mt-3 text-sm text-gray-400">Loading bioAF...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <aside className="w-64 bg-gray-900 text-white min-h-screen flex flex-col" data-testid="sidebar">
       <div className="p-6 border-b border-gray-700">

--- a/frontend/tests/components/layout/GcpNavItem.test.tsx
+++ b/frontend/tests/components/layout/GcpNavItem.test.tsx
@@ -17,6 +17,20 @@ jest.mock("@/lib/auth", () => ({
 
 const mockCanAccess = jest.fn().mockReturnValue(true);
 const mockRoleName = jest.fn().mockReturnValue("admin");
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: [
+      { key: "nextflow", category: "pipeline_orchestration", enabled: true },
+      { key: "jupyterhub", category: "analysis", enabled: true },
+      { key: "rstudio", category: "analysis", enabled: true },
+      { key: "qc_dashboard", category: "visualization", enabled: true },
+      { key: "cellxgene", category: "visualization", enabled: true },
+    ],
+    loading: false,
+    refetch: jest.fn(),
+  }),
+}));
+
 jest.mock("@/hooks/usePermissions", () => ({
   usePermissions: () => ({
     canAccess: (...args: unknown[]) => mockCanAccess(...args),

--- a/frontend/tests/components/layout/Sidebar.test.tsx
+++ b/frontend/tests/components/layout/Sidebar.test.tsx
@@ -16,6 +16,20 @@ jest.mock("@/lib/auth", () => ({
 // Mock usePermissions
 const mockCanAccess = jest.fn().mockReturnValue(true);
 const mockRoleName = jest.fn().mockReturnValue("admin");
+jest.mock("@/hooks/useComponents", () => ({
+  useComponents: () => ({
+    components: [
+      { key: "nextflow", category: "pipeline_orchestration", enabled: true },
+      { key: "jupyterhub", category: "analysis", enabled: true },
+      { key: "rstudio", category: "analysis", enabled: true },
+      { key: "qc_dashboard", category: "visualization", enabled: true },
+      { key: "cellxgene", category: "visualization", enabled: true },
+    ],
+    loading: false,
+    refetch: jest.fn(),
+  }),
+}));
+
 jest.mock("@/hooks/usePermissions", () => ({
   usePermissions: () => ({
     canAccess: (...args: unknown[]) => mockCanAccess(...args),


### PR DESCRIPTION
## Summary

- Display a full-screen loading overlay with the bioAF logo and spinner until permissions and component state are resolved
- Replaces the partial shell (empty sidebar + blank main pane) that appeared during initialization, which looked like a broken page
- Loading screen renders from the Sidebar component so all 64+ pages get it with zero per-page changes

## Test plan

- [x] 384/384 frontend tests pass (4 new loading screen tests)
- [x] TypeScript type-check passes with zero errors
- [ ] Verify app shows branded loading screen on cold start / hard refresh
- [ ] Verify full UI renders once loading completes (no partial shell flash)
- [ ] Verify login page is unaffected (no Sidebar, no loading screen)