### PR TITLE
Fix orphaned cluster recovery for GKE deployment timeouts

### DIFF
--- a/backend/app/adapters/compute/kubernetes.py
+++ b/backend/app/adapters/compute/kubernetes.py
@@ -291,7 +291,7 @@ class KubernetesComputeProvider(ComputeProvider):
                     "WHERE key IN ("
                     "  'gke_cluster_endpoint', 'gke_cluster_ca_cert',"
                     "  'gcp_credential_source', 'gcp_service_account_key',"
-                    "  'gke_cluster_name', 'gcp_project_id', 'gcp_zone',"
+                    "  'gke_cluster_name', 'gcp_project_id', 'gcp_region',"
                     "  'raw_bucket_name'"
                     ")"
                 )
@@ -1257,10 +1257,10 @@ class KubernetesComputeProvider(ComputeProvider):
         cfg = self._cluster_config or {}
         cluster_name = cfg.get("gke_cluster_name") or os.environ.get("GKE_CLUSTER_NAME", "")
         project_id = cfg.get("gcp_project_id") or os.environ.get("GCP_PROJECT_ID", "")
-        zone = cfg.get("gcp_zone") or os.environ.get("GCP_ZONE", "")
+        region = cfg.get("gcp_region") or os.environ.get("GCP_REGION", "us-central1")
 
         gke_client = self._get_gke_client()
-        cluster = gke_client.get_cluster(name=f"projects/{project_id}/locations/{zone}/clusters/{cluster_name}")
+        cluster = gke_client.get_cluster(name=f"projects/{project_id}/locations/{region}/clusters/{cluster_name}")
 
         node_pools = []
         total_nodes = 0
@@ -1336,7 +1336,7 @@ class KubernetesComputeProvider(ComputeProvider):
         cfg = self._cluster_config or {}
         cluster_name = cfg.get("gke_cluster_name") or os.environ.get("GKE_CLUSTER_NAME", "")
         project_id = cfg.get("gcp_project_id") or os.environ.get("GCP_PROJECT_ID", "")
-        zone = cfg.get("gcp_zone") or os.environ.get("GCP_ZONE", "")
+        region = cfg.get("gcp_region") or os.environ.get("GCP_REGION", "us-central1")
 
         _fallback = {
             "cpu_utilization_pct": 0.0,
@@ -1345,19 +1345,19 @@ class KubernetesComputeProvider(ComputeProvider):
             "node_pools": [],
         }
 
-        if not cluster_name or not project_id or not zone:
+        if not cluster_name or not project_id or not region:
             logger.warning(
-                "Missing GKE cluster identity (name=%s, project=%s, zone=%s). "
-                "Store gke_cluster_name, gcp_project_id, gcp_zone in platform_config.",
+                "Missing GKE cluster identity (name=%s, project=%s, region=%s). "
+                "Store gke_cluster_name, gcp_project_id, gcp_region in platform_config.",
                 cluster_name,
                 project_id,
-                zone,
+                region,
             )
             return _fallback
 
         try:
             gke_client = self._get_gke_client()
-            cluster = gke_client.get_cluster(name=f"projects/{project_id}/locations/{zone}/clusters/{cluster_name}")
+            cluster = gke_client.get_cluster(name=f"projects/{project_id}/locations/{region}/clusters/{cluster_name}")
         except Exception:
             logger.exception("Failed to fetch GKE cluster metrics")
             return _fallback

--- a/backend/app/api/infrastructure.py
+++ b/backend/app/api/infrastructure.py
@@ -130,16 +130,21 @@ async def get_components(
     row = result.first()
     compute_stack = row[0] if row else "kubernetes"
 
+    # Components with no backend implementation yet, regardless of compute stack
+    unimplemented = {"snakemake_k8s", "snakemake"}
+
     components = []
     for key, defn in COMPONENT_CATALOG.items():
         comp_stack = defn.get("compute_stack")
-        if compute_stack == "kubernetes":
+        if key in unimplemented:
+            status = "coming_soon"
+        elif compute_stack == "kubernetes":
             if comp_stack == "slurm":
                 status = "coming_soon"
             else:
                 status = "available"
         else:
-            # slurm stack — all adapters are stubbed so mark k8s as coming_soon
+            # slurm stack -- all adapters are stubbed so mark k8s as coming_soon
             if comp_stack == "kubernetes":
                 status = "coming_soon"
             else:

--- a/backend/app/api/orphaned_resources.py
+++ b/backend/app/api/orphaned_resources.py
@@ -3,6 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_permission
@@ -16,6 +17,28 @@ from app.services.orphaned_resource_service import OrphanedResourceService
 logger = logging.getLogger("bioaf.orphaned_resources.api")
 
 router = APIRouter(tags=["orphaned_resources"])
+
+
+class RecoveryCheckItem(BaseModel):
+    id: int
+    resource_name: str
+    gcp_project_id: str
+    gcp_zone: str | None
+    stack_uid: str
+    gke_status: str
+    detected_at: str | None
+
+
+class RecoveryCheckResponse(BaseModel):
+    recoverable: list[RecoveryCheckItem]
+    provisioning: list[RecoveryCheckItem]
+    dead: list[RecoveryCheckItem]
+
+
+class CleanupAllResponse(BaseModel):
+    cleaned: int
+    skipped: int
+    failed: int
 
 
 @router.get(
@@ -33,6 +56,49 @@ async def list_orphaned_resources(
         items=[OrphanedResourceResponse.model_validate(r) for r in resources],
         total=len(resources),
     )
+
+
+# Static path endpoints MUST be registered before {resource_id} to avoid
+# FastAPI matching "recovery-check" or "cleanup-all" as a path parameter.
+
+
+@router.get(
+    "/api/v1/infrastructure/orphaned-resources/recovery-check",
+    response_model=RecoveryCheckResponse,
+)
+async def recovery_check(
+    current_user: dict = require_permission("infrastructure", "deploy"),
+    session: AsyncSession = Depends(get_session),
+) -> RecoveryCheckResponse:
+    """Check all orphaned GKE clusters and classify as recoverable, provisioning, or dead."""
+    result = await OrphanedResourceService.recovery_check(session)
+    return RecoveryCheckResponse(
+        recoverable=[RecoveryCheckItem(**item) for item in result["recoverable"]],
+        provisioning=[RecoveryCheckItem(**item) for item in result["provisioning"]],
+        dead=[RecoveryCheckItem(**item) for item in result["dead"]],
+    )
+
+
+@router.post(
+    "/api/v1/infrastructure/orphaned-resources/cleanup-all",
+    response_model=CleanupAllResponse,
+)
+async def cleanup_all_orphaned_resources(
+    current_user: dict = require_permission("infrastructure", "deploy"),
+    session: AsyncSession = Depends(get_session),
+) -> CleanupAllResponse:
+    """Clean up all dead orphaned GKE clusters in one shot.
+
+    Skips clusters that are RUNNING (should be adopted) or PROVISIONING
+    (still starting). Deletes ERROR clusters and dismisses NOT_FOUND ones.
+    """
+    user_id = int(current_user["sub"])
+    result = await OrphanedResourceService.cleanup_dead_orphans(session, user_id)
+    await session.commit()
+    return CleanupAllResponse(**result)
+
+
+# Dynamic path endpoints with {resource_id} come after static paths.
 
 
 @router.post(
@@ -72,4 +138,32 @@ async def dismiss_orphaned_resource(
     except ValueError as exc:
         logger.warning("Orphaned resource dismiss failed for %d: %s", resource_id, exc)
         raise HTTPException(status_code=404, detail="Resource not found")
+    return OrphanedResourceResponse.model_validate(resource)
+
+
+@router.post(
+    "/api/v1/infrastructure/orphaned-resources/{resource_id}/adopt",
+    response_model=OrphanedResourceResponse,
+)
+async def adopt_orphaned_resource(
+    resource_id: int,
+    current_user: dict = require_permission("infrastructure", "deploy"),
+    session: AsyncSession = Depends(get_session),
+) -> OrphanedResourceResponse:
+    """Adopt an orphaned GKE cluster that is actually running.
+
+    Populates platform_config with cluster details and marks the resource
+    as adopted. Returns 409 if the cluster is not in a running state.
+    """
+    user_id = int(current_user["sub"])
+    try:
+        resource = await OrphanedResourceService.adopt_resource(session, resource_id, user_id)
+        await session.commit()
+    except ValueError as exc:
+        msg = str(exc)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail="Resource not found")
+        if "not in a running state" in msg:
+            raise HTTPException(status_code=409, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
     return OrphanedResourceResponse.model_validate(resource)

--- a/backend/app/api/plots.py
+++ b/backend/app/api/plots.py
@@ -25,6 +25,7 @@ def _plot_response(p) -> PlotArchiveResponse:
             uploader=UserSummary(id=p.file.uploader.id, name=p.file.uploader.name, email=p.file.uploader.email)
             if p.file and p.file.uploader
             else None,
+            storage_deleted=p.file.storage_deleted,
             upload_timestamp=p.file.upload_timestamp,
             created_at=p.file.created_at,
         )

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -503,17 +503,23 @@ async def stack_components_list(
     state_rows = (await session.execute(text("SELECT component_key, enabled, status FROM component_states"))).fetchall()
     state_map = {r[0]: {"enabled": r[1], "status": r[2]} for r in state_rows}
 
+    # Components with no backend implementation yet
+    unimplemented = {"snakemake"}
+
     components = []
     for comp_def in KUBERNETES_COMPONENTS:
-        state = state_map.get(comp_def["key"], {"enabled": False, "status": "disabled"})
-        if state["enabled"]:
-            # Preserve provisioning/build_failed status from component_states
-            if state["status"] in ("provisioning", "build_failed"):
-                status = state["status"]
-            else:
-                status = "enabled"
+        if comp_def["key"] in unimplemented:
+            status = "coming_soon"
         else:
-            status = "disabled"
+            state = state_map.get(comp_def["key"], {"enabled": False, "status": "disabled"})
+            if state["enabled"]:
+                # Preserve provisioning/build_failed status from component_states
+                if state["status"] in ("provisioning", "build_failed"):
+                    status = state["status"]
+                else:
+                    status = "enabled"
+            else:
+                status = "disabled"
 
         components.append(
             ComponentInfo(

--- a/backend/app/services/orphaned_resource_service.py
+++ b/backend/app/services/orphaned_resource_service.py
@@ -4,12 +4,48 @@ import logging
 from datetime import datetime, timezone
 
 from google.cloud import storage
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.orphaned_resource import OrphanedResource
 
 logger = logging.getLogger(__name__)
+
+# GKE cluster status enum mapping (mirrors stack_deployment._GKE_STATUS_MAP)
+_GKE_STATUS_MAP = {
+    0: "STATUS_UNSPECIFIED",
+    1: "PROVISIONING",
+    2: "RUNNING",
+    3: "RECONCILING",
+    4: "STOPPING",
+    5: "ERROR",
+    6: "DEGRADED",
+}
+
+# Statuses that indicate the cluster is alive and usable
+_RECOVERABLE_STATUSES = {"RUNNING", "RECONCILING"}
+
+# Statuses that indicate the cluster is not yet ready but still starting
+_PROVISIONING_STATUSES = {"PROVISIONING"}
+
+# Statuses that indicate the cluster is dead or should be cleaned up
+_DEAD_STATUSES = {"ERROR", "DEGRADED", "STOPPING", "STATUS_UNSPECIFIED"}
+
+
+def _get_gke_client(credentials=None):
+    """Get a GKE ClusterManager client. Tests mock this function."""
+    from google.cloud import container_v1
+
+    if credentials:
+        return container_v1.ClusterManagerClient(credentials=credentials)
+    return container_v1.ClusterManagerClient()
+
+
+async def _get_gke_credentials(session: AsyncSession):
+    """Read SA credentials from platform_config for GKE API calls."""
+    from app.services.stack_deployment import _get_gke_credentials as _get_creds
+
+    return await _get_creds(session)
 
 
 class OrphanedResourceService:
@@ -157,3 +193,228 @@ class OrphanedResourceService:
         resource.resolved_by_user_id = user_id
         await session.flush()
         return resource
+
+    @staticmethod
+    async def _query_gke_status(
+        session: AsyncSession,
+        resource: OrphanedResource,
+    ) -> tuple[str, object | None]:
+        """Query GKE API for the live status of an orphaned cluster.
+
+        Returns (status_string, cluster_object_or_None).
+        If the cluster cannot be found, returns ("NOT_FOUND", None).
+        """
+        credentials = await _get_gke_credentials(session)
+        client = _get_gke_client(credentials)
+        cluster_path = (
+            f"projects/{resource.gcp_project_id}/locations/{resource.gcp_zone}/clusters/{resource.resource_name}"
+        )
+        try:
+            cluster = client.get_cluster(name=cluster_path)
+            status_str = _GKE_STATUS_MAP.get(cluster.status, "UNKNOWN")
+            return status_str, cluster
+        except Exception as exc:
+            logger.info(
+                "GKE cluster %s not reachable: %s",
+                resource.resource_name,
+                exc,
+            )
+            return "NOT_FOUND", None
+
+    @staticmethod
+    async def recovery_check(
+        session: AsyncSession,
+    ) -> dict[str, list[dict]]:
+        """Check all unresolved orphaned GKE clusters and classify them.
+
+        Returns a dict with three lists:
+        - recoverable: clusters in RUNNING/RECONCILING state (can be adopted)
+        - provisioning: clusters still being created
+        - dead: clusters in ERROR state or not found in GCP
+        """
+        unresolved = {"detected", "failed"}
+        stmt = (
+            select(OrphanedResource)
+            .where(
+                OrphanedResource.resource_type == "gke_cluster",
+                OrphanedResource.status.in_(unresolved),
+            )
+            .order_by(OrphanedResource.detected_at.desc())
+        )
+        result = await session.execute(stmt)
+        resources = list(result.scalars().all())
+
+        recoverable: list[dict] = []
+        provisioning: list[dict] = []
+        dead: list[dict] = []
+
+        for resource in resources:
+            gke_status, _cluster = await OrphanedResourceService._query_gke_status(session, resource)
+
+            entry = {
+                "id": resource.id,
+                "resource_name": resource.resource_name,
+                "gcp_project_id": resource.gcp_project_id,
+                "gcp_zone": resource.gcp_zone,
+                "stack_uid": resource.stack_uid,
+                "gke_status": gke_status,
+                "detected_at": resource.detected_at.isoformat() if resource.detected_at else None,
+            }
+
+            if gke_status in _RECOVERABLE_STATUSES:
+                recoverable.append(entry)
+            elif gke_status in _PROVISIONING_STATUSES:
+                provisioning.append(entry)
+            else:
+                dead.append(entry)
+
+        return {
+            "recoverable": recoverable,
+            "provisioning": provisioning,
+            "dead": dead,
+        }
+
+    @staticmethod
+    async def adopt_resource(
+        session: AsyncSession,
+        resource_id: int,
+        user_id: int,
+    ) -> OrphanedResource:
+        """Adopt an orphaned GKE cluster that is actually running.
+
+        Queries GKE API to confirm the cluster is in a running state,
+        then populates platform_config with its details and marks the
+        orphaned resource as adopted.
+        """
+        result = await session.execute(select(OrphanedResource).where(OrphanedResource.id == resource_id))
+        resource = result.scalar_one_or_none()
+        if not resource:
+            raise ValueError(f"Orphaned resource {resource_id} not found")
+
+        if resource.resource_type != "gke_cluster":
+            raise ValueError(f"Only GKE clusters can be adopted, got {resource.resource_type}")
+
+        gke_status, cluster = await OrphanedResourceService._query_gke_status(session, resource)
+
+        if gke_status not in _RECOVERABLE_STATUSES:
+            raise ValueError(
+                f"Cluster {resource.resource_name} is not in a running state (current status: {gke_status})"
+            )
+
+        # Populate platform_config with cluster details
+        from app.services.stack_deployment import _set_config
+
+        await _set_config(session, "compute_stack", "kubernetes")
+        await _set_config(session, "compute_deployed", "true")
+        await _set_config(session, "gke_cluster_name", resource.resource_name)
+
+        if cluster:
+            endpoint = getattr(cluster, "endpoint", "") or ""
+            ca_cert = ""
+            if hasattr(cluster, "master_auth") and cluster.master_auth:
+                ca_cert = getattr(cluster.master_auth, "cluster_ca_certificate", "") or ""
+            await _set_config(session, "gke_cluster_endpoint", endpoint or "null")
+            await _set_config(session, "gke_cluster_ca_cert", ca_cert or "null")
+
+        # Update kubernetes_cluster component state
+        await session.execute(
+            text("""
+            UPDATE component_states
+            SET enabled = true, status = 'running'
+            WHERE component_key = 'kubernetes_cluster'
+            """)
+        )
+
+        # Log the adoption in audit
+        from app.services.audit_service import log_action
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="infrastructure",
+            entity_id=0,
+            action="adopt_orphaned_cluster",
+            details={
+                "cluster_name": resource.resource_name,
+                "gke_status": gke_status,
+            },
+        )
+
+        resource.status = "adopted"
+        resource.resolved_at = datetime.now(timezone.utc)
+        resource.resolved_by_user_id = user_id
+        await session.flush()
+
+        logger.info(
+            "Adopted orphaned GKE cluster %s (status: %s)",
+            resource.resource_name,
+            gke_status,
+        )
+        return resource
+
+    @staticmethod
+    async def cleanup_dead_orphans(
+        session: AsyncSession,
+        user_id: int,
+    ) -> dict[str, int]:
+        """Clean up all orphaned GKE clusters that are dead (ERROR or NOT_FOUND).
+
+        Skips clusters that are RUNNING (should be adopted) or PROVISIONING
+        (still starting). For NOT_FOUND clusters, just marks them dismissed.
+        For ERROR clusters, attempts to delete then marks cleaned.
+
+        Returns counts: {"cleaned": N, "skipped": N, "failed": N}.
+        """
+        unresolved = {"detected", "failed"}
+        stmt = select(OrphanedResource).where(
+            OrphanedResource.resource_type == "gke_cluster",
+            OrphanedResource.status.in_(unresolved),
+        )
+        result = await session.execute(stmt)
+        resources = list(result.scalars().all())
+
+        cleaned = 0
+        skipped = 0
+        failed = 0
+
+        for resource in resources:
+            gke_status, _cluster = await OrphanedResourceService._query_gke_status(session, resource)
+
+            if gke_status in _RECOVERABLE_STATUSES or gke_status in _PROVISIONING_STATUSES:
+                skipped += 1
+                continue
+
+            if gke_status == "NOT_FOUND":
+                # Cluster is already gone, just dismiss the record
+                resource.status = "cleaned"
+                resource.resolved_at = datetime.now(timezone.utc)
+                resource.resolved_by_user_id = user_id
+                cleaned += 1
+                continue
+
+            # Cluster exists but is in a bad state -- try to delete it
+            try:
+                credentials = await _get_gke_credentials(session)
+                client = _get_gke_client(credentials)
+                cluster_path = (
+                    f"projects/{resource.gcp_project_id}"
+                    f"/locations/{resource.gcp_zone}"
+                    f"/clusters/{resource.resource_name}"
+                )
+                client.delete_cluster(name=cluster_path)
+                resource.status = "cleaned"
+                resource.resolved_at = datetime.now(timezone.utc)
+                resource.resolved_by_user_id = user_id
+                cleaned += 1
+            except Exception as exc:
+                resource.status = "failed"
+                resource.error_message = str(exc)
+                failed += 1
+                logger.warning(
+                    "Failed to delete orphaned cluster %s: %s",
+                    resource.resource_name,
+                    exc,
+                )
+
+        await session.flush()
+        return {"cleaned": cleaned, "skipped": skipped, "failed": failed}

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -134,12 +134,12 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
     # Query GKE API for cluster details
     cluster_name = await _read_config(session, "gke_cluster_name")
     project_id = await _read_config(session, "gcp_project_id")
-    zone = await _read_config(session, "gcp_zone")
+    region = await _read_config(session, "gcp_region") or "us-central1"
 
     try:
         credentials = await _get_gke_credentials(session)
         client = _get_gke_client(credentials)
-        cluster = client.get_cluster(name=f"projects/{project_id}/locations/{zone}/clusters/{cluster_name}")
+        cluster = client.get_cluster(name=f"projects/{project_id}/locations/{region}/clusters/{cluster_name}")
 
         pipeline_pool = None
         interactive_pool = None
@@ -483,7 +483,7 @@ async def deploy_stack(
     if compute_failed:
         # Log the expected cluster as an orphaned resource
         project_id = await _read_config(session, "gcp_project_id")
-        zone = await _read_config(session, "gcp_zone")
+        region = await _read_config(session, "gcp_region") or "us-central1"
         org_slug = await _read_config(session, "org_slug")
         suffix = await _read_config(session, "deploy_suffix")
         if suffix and suffix != "null" and org_slug and org_slug != "null":
@@ -493,7 +493,7 @@ async def deploy_stack(
                 resource_type="gke_cluster",
                 resource_name=cluster_name,
                 gcp_project_id=project_id if project_id != "null" else "",
-                gcp_zone=zone if zone != "null" else None,
+                gcp_zone=region,
                 stack_uid=suffix,
             )
             await session.flush()
@@ -539,7 +539,7 @@ async def teardown_stack(
     if teardown_failed:
         # Log the cluster as orphaned for later cleanup
         project_id = await _read_config(session, "gcp_project_id")
-        zone = await _read_config(session, "gcp_zone")
+        region = await _read_config(session, "gcp_region") or "us-central1"
         cluster_name = await _read_config(session, "gke_cluster_name")
         if cluster_name and cluster_name != "null":
             await OrphanedResourceService.log_resource(
@@ -547,7 +547,7 @@ async def teardown_stack(
                 resource_type="gke_cluster",
                 resource_name=cluster_name,
                 gcp_project_id=project_id if project_id != "null" else "",
-                gcp_zone=zone if zone != "null" else None,
+                gcp_zone=region,
                 stack_uid=cluster_name.rsplit("-", 1)[-1],
             )
             await session.flush()

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -63,6 +63,7 @@ class StackStatus(BaseModel):
     storage_deployed: bool
     pubsub_configured: bool = False
     cluster: ClusterInfo | None = None
+    has_orphaned_clusters: bool = False
 
 
 async def _get_gke_credentials(session: AsyncSession):
@@ -122,6 +123,15 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
     storage = storage_deployed == "true"
     pubsub = pubsub_topic not in ("null", "")
 
+    # Check for unresolved orphaned GKE clusters
+    orphan_result = await session.execute(
+        text(
+            "SELECT COUNT(*) FROM orphaned_resources "
+            "WHERE resource_type = 'gke_cluster' AND status IN ('detected', 'failed')"
+        )
+    )
+    has_orphans = (orphan_result.scalar() or 0) > 0
+
     if not is_deployed:
         return StackStatus(
             compute_stack=stack,
@@ -129,6 +139,7 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
             storage_deployed=storage,
             pubsub_configured=pubsub,
             cluster=None,
+            has_orphaned_clusters=has_orphans,
         )
 
     # Query GKE API for cluster details
@@ -196,6 +207,7 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
             storage_deployed=storage,
             pubsub_configured=pubsub,
             cluster=cluster_info,
+            has_orphaned_clusters=has_orphans,
         )
 
     except Exception as exc:
@@ -206,6 +218,7 @@ async def get_cluster_status(session: AsyncSession) -> StackStatus:
             storage_deployed=storage,
             pubsub_configured=pubsub,
             cluster=None,
+            has_orphaned_clusters=has_orphans,
         )
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.11"
+version = "0.3.12"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/terraform/modules/compute/main.tf
+++ b/backend/terraform/modules/compute/main.tf
@@ -14,7 +14,7 @@ terraform {
 resource "google_container_cluster" "bioaf" {
   name     = "bioaf-${var.org_slug}-${var.stack_uid}"
   project  = var.project_id
-  location = var.zone
+  location = var.region
 
   # Terraform-managed lifecycle -- teardown handles deletion
   deletion_protection      = false
@@ -43,7 +43,7 @@ resource "google_container_node_pool" "pipelines" {
   name           = "bioaf-pipelines"
   cluster        = google_container_cluster.bioaf.id
   project        = var.project_id
-  location       = var.zone
+  location       = var.region
   node_locations = var.k8s_node_zones
 
   autoscaling {
@@ -78,7 +78,7 @@ resource "google_container_node_pool" "interactive" {
   name           = "bioaf-interactive"
   cluster        = google_container_cluster.bioaf.id
   project        = var.project_id
-  location       = var.zone
+  location       = var.region
   node_locations = var.k8s_node_zones
 
   autoscaling {

--- a/backend/terraform/modules/compute/variables.tf
+++ b/backend/terraform/modules/compute/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
 
 variable "zone" {
   type        = string
-  description = "GCP zone for the zonal GKE cluster"
+  description = "GCP zone (retained for backward compatibility with tfvars generation)"
 }
 
 variable "org_slug" {

--- a/backend/tests/test_infrastructure_components.py
+++ b/backend/tests/test_infrastructure_components.py
@@ -68,6 +68,52 @@ class TestComponentsEndpoint:
         assert filestore["status"] == "coming_soon"
 
     @pytest.mark.asyncio
+    async def test_snakemake_listed_as_coming_soon_on_kubernetes(self, client, admin_token, session):
+        await session.execute(
+            text(
+                "INSERT INTO platform_config (key, value) VALUES ('compute_stack', 'kubernetes') "
+                "ON CONFLICT (key) DO UPDATE SET value = 'kubernetes'"
+            )
+        )
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/components",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        snakemake_k8s = next((c for c in data["components"] if c["key"] == "snakemake_k8s"), None)
+        assert snakemake_k8s is not None
+        assert snakemake_k8s["status"] == "coming_soon"
+
+        snakemake_slurm = next((c for c in data["components"] if c["key"] == "snakemake"), None)
+        assert snakemake_slurm is not None
+        assert snakemake_slurm["status"] == "coming_soon"
+
+    @pytest.mark.asyncio
+    async def test_nextflow_k8s_available_on_kubernetes(self, client, admin_token, session):
+        await session.execute(
+            text(
+                "INSERT INTO platform_config (key, value) VALUES ('compute_stack', 'kubernetes') "
+                "ON CONFLICT (key) DO UPDATE SET value = 'kubernetes'"
+            )
+        )
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/components",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        nextflow_k8s = next((c for c in data["components"] if c["key"] == "nextflow_k8s"), None)
+        assert nextflow_k8s is not None
+        assert nextflow_k8s["status"] == "available"
+
+    @pytest.mark.asyncio
     async def test_response_includes_all_expected_categories(self, client, admin_token, session):
         await session.execute(
             text(

--- a/backend/tests/test_k8s_metrics_from_config.py
+++ b/backend/tests/test_k8s_metrics_from_config.py
@@ -1,6 +1,6 @@
 """Tests that _k8s_get_cluster_metrics reads cluster identity from platform_config.
 
-The GKE cluster name, project ID, and zone are stored in platform_config
+The GKE cluster name, project ID, and region are stored in platform_config
 (written during stack deployment). The metrics method should read them from
 _cluster_config rather than requiring separate environment variables.
 Also, if the GKE API call fails, get_cluster_metrics must return a safe
@@ -23,7 +23,7 @@ def adapter(monkeypatch):
         "gke_cluster_endpoint": "https://10.0.0.1",
         "gke_cluster_name": "bioaf-cluster-1",
         "gcp_project_id": "my-project",
-        "gcp_zone": "us-central1-a",
+        "gcp_region": "us-central1",
         "gcp_service_account_key": '{"type": "service_account", "project_id": "test"}',
     }
     return provider
@@ -49,7 +49,7 @@ class TestMetricsFromConfig:
             result = await adapter._k8s_get_cluster_metrics()
 
         # Verify the GKE client was called with the config values, not env vars
-        expected_name = "projects/my-project/locations/us-central1-a/clusters/bioaf-cluster-1"
+        expected_name = "projects/my-project/locations/us-central1/clusters/bioaf-cluster-1"
         mock_gke.get_cluster.assert_called_once_with(name=expected_name)
         assert result["cost_burn_rate_hourly"] > 0
 

--- a/backend/tests/test_orphaned_recovery.py
+++ b/backend/tests/test_orphaned_recovery.py
@@ -1,0 +1,625 @@
+"""Tests for orphaned resource recovery: recovery-check, adopt, and cleanup-all."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_platform_config(session, overrides: dict | None = None):
+    """Seed platform_config keys needed by orphaned resource service."""
+    defaults = {
+        "gcp_credential_source": "service_account_key",
+        "gcp_service_account_key": '{"type":"service_account","project_id":"test"}',
+        "gcp_project_id": "test-project",
+        "gcp_region": "us-central1",
+        "terraform_state_bucket": "bioaf-tfstate-test",
+        "terraform_initialized": "true",
+        "compute_deployed": "false",
+        "compute_stack": "null",
+        "storage_deployed": "true",
+        "org_slug": "demo",
+    }
+    if overrides:
+        defaults.update(overrides)
+    for key, value in defaults.items():
+        await session.execute(
+            text(
+                "INSERT INTO platform_config (key, value) VALUES (:k, :v) "
+                "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+            ).bindparams(k=key, v=value)
+        )
+    await session.commit()
+
+
+def _make_gke_cluster(status_code: int = 2, name: str = "bioaf-demo-abc123"):
+    """Create a mock GKE cluster object.
+
+    Status codes: 1=PROVISIONING, 2=RUNNING, 5=ERROR.
+    """
+    cluster = MagicMock()
+    cluster.name = name
+    cluster.status = status_code
+    cluster.current_node_count = 3
+    cluster.endpoint = "10.0.0.1"
+    cluster.master_auth.cluster_ca_certificate = "fake-ca-cert"
+
+    pool = MagicMock()
+    pool.name = "bioaf-pipelines"
+    pool.config.machine_type = "e2-standard-4"
+    pool.config.spot = False
+    pool.autoscaling.min_node_count = 0
+    pool.autoscaling.max_node_count = 3
+    pool.initial_node_count = 1
+    pool.status = 2
+    cluster.node_pools = [pool]
+    return cluster
+
+
+# ---------------------------------------------------------------------------
+# Service: recovery_check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_running_cluster(session, admin_user):
+    """A RUNNING orphaned cluster should be flagged as recoverable."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=2)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.recovery_check(session)
+
+    assert len(result["recoverable"]) == 1
+    assert result["recoverable"][0]["gke_status"] == "RUNNING"
+    assert len(result["provisioning"]) == 0
+    assert len(result["dead"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_provisioning_cluster(session, admin_user):
+    """A PROVISIONING cluster should be reported as still waiting."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=1)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.recovery_check(session)
+
+    assert len(result["recoverable"]) == 0
+    assert len(result["provisioning"]) == 1
+    assert result["provisioning"][0]["gke_status"] == "PROVISIONING"
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_dead_cluster(session, admin_user):
+    """A cluster that returns NOT_FOUND should be classified as dead."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.side_effect = Exception("404 Not Found")
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.recovery_check(session)
+
+    assert len(result["recoverable"]) == 0
+    assert len(result["provisioning"]) == 0
+    assert len(result["dead"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_no_orphans(session, admin_user):
+    """With no orphaned resources, all lists should be empty."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    result = await OrphanedResourceService.recovery_check(session)
+
+    assert result["recoverable"] == []
+    assert result["provisioning"] == []
+    assert result["dead"] == []
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_ignores_non_cluster_orphans(session, admin_user):
+    """GCS bucket orphans should be ignored by recovery check."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gcs_bucket",
+        resource_name="bioaf-ingest-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+    )
+    await session.flush()
+
+    result = await OrphanedResourceService.recovery_check(session)
+
+    assert result["recoverable"] == []
+    assert result["provisioning"] == []
+    assert result["dead"] == []
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_error_cluster(session, admin_user):
+    """A cluster in ERROR state should be classified as dead."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=5)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.recovery_check(session)
+
+    assert len(result["dead"]) == 1
+    assert result["dead"][0]["gke_status"] == "ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Service: adopt_resource
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_adopt_running_cluster(session, admin_user):
+    """Adopting a RUNNING cluster should populate platform_config and mark resolved."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    resource = await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=2)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.adopt_resource(session, resource.id, admin_user.id)
+
+    assert result.status == "adopted"
+    assert result.resolved_at is not None
+    assert result.resolved_by_user_id == admin_user.id
+
+    # Verify platform_config was populated
+    row = (await session.execute(text("SELECT value FROM platform_config WHERE key = 'compute_deployed'"))).fetchone()
+    assert row[0] == "true"
+
+    row = (await session.execute(text("SELECT value FROM platform_config WHERE key = 'gke_cluster_name'"))).fetchone()
+    assert row[0] == "bioaf-demo-abc123"
+
+    row = (await session.execute(text("SELECT value FROM platform_config WHERE key = 'compute_stack'"))).fetchone()
+    assert row[0] == "kubernetes"
+
+
+@pytest.mark.asyncio
+async def test_adopt_provisioning_cluster_rejected(session, admin_user):
+    """Cannot adopt a cluster that is still provisioning."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    resource = await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=1)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        with pytest.raises(ValueError, match="not in a running state"):
+            await OrphanedResourceService.adopt_resource(session, resource.id, admin_user.id)
+
+
+@pytest.mark.asyncio
+async def test_adopt_nonexistent_resource_rejected(session, admin_user):
+    """Adopting a non-existent resource should raise."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    with pytest.raises(ValueError, match="not found"):
+        await OrphanedResourceService.adopt_resource(session, 9999, admin_user.id)
+
+
+# ---------------------------------------------------------------------------
+# Service: cleanup_dead_orphans
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dead_orphans(session, admin_user):
+    """cleanup_dead_orphans should delete NOT_FOUND clusters and dismiss them."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.side_effect = Exception("404 Not Found")
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.cleanup_dead_orphans(session, admin_user.id)
+
+    assert result["cleaned"] == 1
+    assert result["skipped"] == 0
+
+    # Verify the resource is now resolved
+    resources = await OrphanedResourceService.list_resources(session, status="detected")
+    assert len(resources) == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dead_orphans_skips_running(session, admin_user):
+    """cleanup_dead_orphans should skip RUNNING clusters (they should be adopted)."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=2)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.cleanup_dead_orphans(session, admin_user.id)
+
+    assert result["cleaned"] == 0
+    assert result["skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dead_deletes_error_clusters(session, admin_user):
+    """cleanup_dead_orphans should delete ERROR clusters from GCP."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=5)
+    mock_client.delete_cluster = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await OrphanedResourceService.cleanup_dead_orphans(session, admin_user.id)
+
+    assert result["cleaned"] == 1
+    mock_client.delete_cluster.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# StackStatus includes has_orphaned_clusters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stack_status_includes_orphaned_flag(session, admin_user):
+    """StackStatus should report has_orphaned_clusters when unresolved orphans exist."""
+    from app.services.orphaned_resource_service import OrphanedResourceService
+    from app.services.stack_deployment import get_cluster_status
+
+    await _seed_platform_config(session)
+
+    status = await get_cluster_status(session)
+    assert status.has_orphaned_clusters is False
+
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+    )
+    await session.flush()
+
+    status = await get_cluster_status(session)
+    assert status.has_orphaned_clusters is True
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_endpoint(client: AsyncClient, admin_token: str, session):
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+    await session.commit()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=2)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        response = await client.get(
+            "/api/v1/infrastructure/orphaned-resources/recovery-check",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["recoverable"]) == 1
+    assert data["recoverable"][0]["gke_status"] == "RUNNING"
+
+
+@pytest.mark.asyncio
+async def test_adopt_endpoint(client: AsyncClient, admin_token: str, session):
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    resource = await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+    await session.commit()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=2)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/infrastructure/orphaned-resources/{resource.id}/adopt",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "adopted"
+
+
+@pytest.mark.asyncio
+async def test_adopt_endpoint_rejects_provisioning(client: AsyncClient, admin_token: str, session):
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    resource = await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+    await session.commit()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.return_value = _make_gke_cluster(status_code=1)
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/infrastructure/orphaned-resources/{resource.id}/adopt",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_cleanup_all_endpoint(client: AsyncClient, admin_token: str, session):
+    from app.services.orphaned_resource_service import OrphanedResourceService
+
+    await _seed_platform_config(session)
+    await OrphanedResourceService.log_resource(
+        session,
+        resource_type="gke_cluster",
+        resource_name="bioaf-demo-abc123",
+        gcp_project_id="test-project",
+        stack_uid="abc123",
+        gcp_zone="us-central1",
+    )
+    await session.flush()
+    await session.commit()
+
+    mock_client = MagicMock()
+    mock_client.get_cluster.side_effect = Exception("404 Not Found")
+
+    with (
+        patch("app.services.orphaned_resource_service._get_gke_client", return_value=mock_client),
+        patch(
+            "app.services.orphaned_resource_service._get_gke_credentials",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+    ):
+        response = await client.post(
+            "/api/v1/infrastructure/orphaned-resources/cleanup-all",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cleaned"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_recovery_check_requires_permission(client: AsyncClient, viewer_token: str):
+    response = await client.get(
+        "/api/v1/infrastructure/orphaned-resources/recovery-check",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_plots.py
+++ b/backend/tests/test_plots.py
@@ -1,5 +1,6 @@
 import pytest
 import pytest_asyncio
+from sqlalchemy import text
 
 
 @pytest_asyncio.fixture
@@ -59,6 +60,56 @@ async def test_search_plots(client, admin_token, sample_plot):
     data = resp.json()
     assert data["total"] >= 1
     assert any(p["title"] == "UMAP Clustering" for p in data["plots"])
+
+
+@pytest.mark.asyncio
+async def test_search_plots_includes_storage_deleted_flag(
+    client, admin_token, session, admin_user, experiment_for_plots
+):
+    from app.models.file import File
+    from app.models.plot_archive_entry import PlotArchiveEntry
+    from datetime import datetime, timezone
+
+    f = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri="gs://test-bucket/plots/deleted-plot.png",
+        filename="deleted-plot.png",
+        size_bytes=10000,
+        file_type="image",
+        uploader_user_id=admin_user.id,
+    )
+    session.add(f)
+    await session.flush()
+
+    plot = PlotArchiveEntry(
+        organization_id=admin_user.organization_id,
+        file_id=f.id,
+        title="Deleted Plot",
+        experiment_id=experiment_for_plots.id,
+        tags_json=["deleted"],
+        indexed_at=datetime.now(timezone.utc),
+    )
+    session.add(plot)
+    await session.flush()
+    await session.commit()
+
+    # Mark as storage_deleted after insert to avoid server_default override
+    await session.execute(text("UPDATE files SET storage_deleted = true WHERE id = :fid").bindparams(fid=f.id))
+    await session.commit()
+
+    # Verify the update took effect
+    check = await session.execute(text("SELECT storage_deleted FROM files WHERE id = :fid").bindparams(fid=f.id))
+    assert check.scalar() is True
+
+    resp = await client.get(
+        "/api/plots",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    deleted_plot = next((p for p in data["plots"] if p["title"] == "Deleted Plot"), None)
+    assert deleted_plot is not None
+    assert deleted_plot["file"]["storage_deleted"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_stack_api.py
+++ b/backend/tests/test_stack_api.py
@@ -175,6 +175,30 @@ class TestComponentsListEndpoint:
         for comp in data["components"]:
             assert "K8s" not in comp["name"], f"Component name should not contain 'K8s': {comp['name']}"
 
+    @pytest.mark.asyncio
+    async def test_snakemake_listed_as_coming_soon(self, client, admin_token, session):
+        """Snakemake has no backend implementation yet so it must be coming_soon."""
+        await _set_config(session, "compute_stack", "kubernetes")
+        await _set_config(session, "compute_deployed", "true")
+        await _set_config(session, "storage_deployed", "true")
+        await session.commit()
+
+        response = await client.get(
+            "/api/v1/infrastructure/stack/components",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        snakemake = next((c for c in data["components"] if c["key"] == "snakemake"), None)
+        assert snakemake is not None
+        assert snakemake["status"] == "coming_soon"
+
+        # Nextflow should still be toggleable (disabled, not coming_soon)
+        nextflow = next((c for c in data["components"] if c["key"] == "nextflow"), None)
+        assert nextflow is not None
+        assert nextflow["status"] != "coming_soon"
+
 
 class TestComponentToggleEndpoint:
     @pytest.mark.asyncio

--- a/bioaf
+++ b/bioaf
@@ -400,22 +400,34 @@ cmd_reset_db() {
         exit 0
     fi
 
-    echo "Stopping backend..."
-    $DC stop backend
+    echo "Stopping backend and frontend..."
+    $DC stop backend frontend nginx 2>/dev/null || true
 
+    # Ensure the db container is running so we can drop the database
+    local db_state
+    db_state=$($DC ps --format "{{.State}}" db 2>/dev/null || echo "not created")
+    if [ "$db_state" != "running" ]; then
+        echo "Starting database..."
+        $DC up -d db
+    fi
+    wait_for_db
+
+    # Terminate any lingering connections before dropping
     echo "Dropping and recreating database..."
+    $DC exec -T db psql -U bioaf -d postgres -c \
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'bioaf' AND pid <> pg_backend_pid();" \
+        > /dev/null 2>&1 || true
     $DC exec -T db dropdb -U bioaf --if-exists bioaf
     $DC exec -T db createdb -U bioaf bioaf
 
     echo "Starting backend..."
-    $DC start backend
-
+    $DC up -d backend
     wait_for_db
 
     echo "Running migrations..."
     $DC exec -T backend alembic -c alembic/alembic.ini upgrade head
 
-    green "Database reset complete. Run './bioaf setup' to create a new admin account."
+    green "Database reset complete. Run './bioaf create-admin' to create a new admin account."
 }
 
 cmd_register_outputs() {

--- a/docs/user-guide-admin.md
+++ b/docs/user-guide-admin.md
@@ -29,6 +29,17 @@ Navigate to **Infrastructure > Components**:
 - View component health status
 - Dependencies are enforced (e.g., JupyterHub requires SLURM + Filestore)
 
+### Deployment Recovery
+
+If a deployment times out (e.g., due to a Google Cloud service delay), the app
+automatically detects orphaned clusters on your next visit:
+
+- **Cluster came online**: you are prompted to resume where you left off or start fresh
+- **Cluster still provisioning**: you are told Google Cloud is still working and to check back later
+- **Cluster failed or disappeared**: cleaned up automatically in the background
+
+The deploy button is disabled while orphaned resources exist to prevent duplicate clusters.
+
 ## Cost Center
 
 Navigate to **Infrastructure > Cost Center**:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -806,7 +806,20 @@ export default function InfraComponentsPage() {
                       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                         {componentsData.components
                           .filter((c) => c.category === category)
-                          .map((comp) => (
+                          .map((comp) => comp.status === "coming_soon" ? (
+                            <div
+                              key={comp.key}
+                              className="bg-white rounded-lg shadow p-5 border border-gray-200 opacity-60"
+                            >
+                              <div className="flex items-start justify-between mb-2">
+                                <h3 className="font-semibold text-sm text-gray-400">{comp.name}</h3>
+                                <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full font-medium">
+                                  Coming Soon
+                                </span>
+                              </div>
+                              <p className="text-xs text-gray-400">{comp.description}</p>
+                            </div>
+                          ) : (
                             <div
                               key={comp.key}
                               className="bg-white rounded-lg shadow p-5 border border-gray-200"

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -10,6 +10,7 @@ import { TerraformProgressModal } from "@/components/infrastructure/TerraformPro
 import { DeployProgressModal } from "@/components/infrastructure/DeployProgressModal";
 import { TerraformRunHistory } from "@/components/infrastructure/TerraformRunHistory";
 import { OrphanedResourcesCard } from "@/components/infrastructure/OrphanedResourcesCard";
+import { DeployRecoveryModal } from "@/components/infrastructure/DeployRecoveryModal";
 import { useDeploymentProgress } from "@/hooks/useDeploymentProgress";
 import { isAuthenticated } from "@/lib/auth";
 import { api } from "@/lib/api";
@@ -61,6 +62,7 @@ interface StackStatus {
   storage_deployed: boolean;
   pubsub_configured: boolean;
   cluster: ClusterInfo | null;
+  has_orphaned_clusters: boolean;
 }
 
 interface ComponentDef {
@@ -147,6 +149,8 @@ export default function InfraComponentsPage() {
   } | null>(null);
   const [showAbandonModal, setShowAbandonModal] = useState(false);
   const [abandonLoading, setAbandonLoading] = useState(false);
+  const [showRecoveryModal, setShowRecoveryModal] = useState(false);
+  const [recoveryCheckedOnLoad, setRecoveryCheckedOnLoad] = useState(false);
 
   const DESTROY_STORAGE_PHRASE = "delete my data";
 
@@ -196,6 +200,17 @@ export default function InfraComponentsPage() {
     setLoading(false);
   }
 
+  // Auto-open recovery modal when orphaned clusters exist and compute is not deployed
+  useEffect(() => {
+    if (recoveryCheckedOnLoad) return;
+    if (!stackStatus) return;
+    if (stackStatus.compute_deployed) return;
+    if (!stackStatus.has_orphaned_clusters) return;
+    if (deployProgress.active) return;
+    setRecoveryCheckedOnLoad(true);
+    setShowRecoveryModal(true);
+  }, [stackStatus, deployProgress.active, recoveryCheckedOnLoad]);
+
   // Fetch build status when any component is provisioning or build_failed
   const hasBuildRelated = componentsData?.components.some(
     (c) => c.status === "provisioning" || c.status === "build_failed",
@@ -243,6 +258,13 @@ export default function InfraComponentsPage() {
 
   async function handleStartDeploy() {
     if (deployLoading) return;
+
+    // Check for orphaned clusters before deploying to prevent duplicates
+    if (stackStatus?.has_orphaned_clusters) {
+      setShowRecoveryModal(true);
+      return;
+    }
+
     setDeployLoading(true);
     try {
       await api.post("/api/v1/infrastructure/stack/deploy-background", {
@@ -262,6 +284,29 @@ export default function InfraComponentsPage() {
     setShowDeployModal(false);
     setDeployStarted(false);
     setRefreshKey((k) => k + 1);
+  }
+
+  function handleRecoveryComplete() {
+    setShowRecoveryModal(false);
+    setRefreshKey((k) => k + 1);
+  }
+
+  async function handleStartFresh() {
+    setShowRecoveryModal(false);
+    // Orphans were cleaned by the modal, now start fresh deploy
+    setDeployLoading(true);
+    try {
+      await api.post("/api/v1/infrastructure/stack/deploy-background", {
+        stack_type: "kubernetes",
+      });
+      setDeployStarted(true);
+      setShowDeployModal(true);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to start deployment";
+      alert(message);
+    } finally {
+      setDeployLoading(false);
+    }
   }
 
   async function handleAbortDeploy() {
@@ -982,6 +1027,14 @@ export default function InfraComponentsPage() {
           onClose={() => setShowBootstrapModal(false)}
         />
       )}
+
+      {/* Deploy Recovery Modal */}
+      <DeployRecoveryModal
+        open={showRecoveryModal}
+        onClose={() => setShowRecoveryModal(false)}
+        onRecovered={handleRecoveryComplete}
+        onStartFresh={handleStartFresh}
+      />
 
       {/* Deploy Stack Modal (poll-based) */}
       {showDeployModal && (

--- a/frontend/src/app/results/plot-archive/page.tsx
+++ b/frontend/src/app/results/plot-archive/page.tsx
@@ -39,6 +39,19 @@ function PlotThumbnail({
   );
 }
 
+function StorageDeletedPlaceholder() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1.5 text-center px-2">
+      <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-red-100 text-red-600">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+        </svg>
+      </span>
+      <span className="text-gray-400 text-xs">Storage deleted</span>
+    </div>
+  );
+}
+
 export default function PlotArchivePage() {
   const [plots, setPlots] = useState<PlotArchiveResponse[]>([]);
   const [query, setQuery] = useState("");
@@ -231,43 +244,48 @@ export default function PlotArchivePage() {
             ) : (
               <>
                 <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
-                  {plots.map((plot) => (
-                    <div
-                      key={plot.id}
-                      className="bg-white rounded-lg shadow overflow-hidden hover:shadow-md transition-shadow"
-                    >
-                      <div className="aspect-square bg-gray-100 flex items-center justify-center">
-                        {plot.file ? (
-                          <PlotThumbnail
-                            fileId={plot.file.id}
-                            title={plot.title ?? "Plot"}
-                            onClick={(url) => handleExpand(plot, url)}
-                          />
-                        ) : (
-                          <span className="text-gray-400 text-xs">
-                            No preview
-                          </span>
-                        )}
+                  {plots.map((plot) => {
+                    const deleted = plot.file?.storage_deleted === true;
+                    return (
+                      <div
+                        key={plot.id}
+                        className={`bg-white rounded-lg shadow overflow-hidden transition-shadow ${deleted ? "opacity-60" : "hover:shadow-md"}`}
+                      >
+                        <div className="aspect-square bg-gray-100 flex items-center justify-center">
+                          {deleted ? (
+                            <StorageDeletedPlaceholder />
+                          ) : plot.file ? (
+                            <PlotThumbnail
+                              fileId={plot.file.id}
+                              title={plot.title ?? "Plot"}
+                              onClick={(url) => handleExpand(plot, url)}
+                            />
+                          ) : (
+                            <span className="text-gray-400 text-xs">
+                              No preview
+                            </span>
+                          )}
+                        </div>
+                        <div className="p-2">
+                          <p className={`text-xs font-medium truncate ${deleted ? "text-gray-400" : ""}`}>
+                            {plot.title}
+                          </p>
+                          {plot.tags.length > 0 && (
+                            <div className="flex flex-wrap gap-1 mt-1">
+                              {plot.tags.slice(0, 3).map((tag) => (
+                                <span
+                                  key={tag}
+                                  className="px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded text-[10px]"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
                       </div>
-                      <div className="p-2">
-                        <p className="text-xs font-medium truncate">
-                          {plot.title}
-                        </p>
-                        {plot.tags.length > 0 && (
-                          <div className="flex flex-wrap gap-1 mt-1">
-                            {plot.tags.slice(0, 3).map((tag) => (
-                              <span
-                                key={tag}
-                                className="px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded text-[10px]"
-                              >
-                                {tag}
-                              </span>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
 
                 <div className="flex justify-between items-center text-sm text-gray-500">

--- a/frontend/src/components/infrastructure/DeployRecoveryModal.test.tsx
+++ b/frontend/src/components/infrastructure/DeployRecoveryModal.test.tsx
@@ -1,0 +1,210 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { DeployRecoveryModal } from "./DeployRecoveryModal";
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getToken: () => "fake-token",
+  removeToken: jest.fn(),
+  getCurrentUser: () => ({ role_name: "admin", email: "admin@test.com" }),
+  isAuthenticated: () => true,
+}));
+
+import { api } from "@/lib/api";
+
+const mockGet = api.get as jest.Mock;
+const mockPost = api.post as jest.Mock;
+
+const defaultProps = {
+  open: true,
+  onClose: jest.fn(),
+  onRecovered: jest.fn(),
+  onStartFresh: jest.fn(),
+};
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  defaultProps.onClose.mockReset();
+  defaultProps.onRecovered.mockReset();
+  defaultProps.onStartFresh.mockReset();
+});
+
+describe("DeployRecoveryModal", () => {
+  test("shows loading state while checking", async () => {
+    // Never resolve so we stay in loading
+    mockGet.mockReturnValue(new Promise(() => {}));
+    render(<DeployRecoveryModal {...defaultProps} />);
+    expect(screen.getByText(/Checking deployment status/)).toBeInTheDocument();
+  });
+
+  test("shows recovery option when cluster is RUNNING", async () => {
+    mockGet.mockResolvedValue({
+      recoverable: [
+        {
+          id: 1,
+          resource_name: "bioaf-demo-abc123",
+          gcp_project_id: "test-project",
+          gcp_zone: "us-central1",
+          stack_uid: "abc123",
+          gke_status: "RUNNING",
+          detected_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+      provisioning: [],
+      dead: [],
+    });
+
+    render(<DeployRecoveryModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Previous deployment found/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Resume Deployment/)).toBeInTheDocument();
+    expect(screen.getByText(/Start Fresh/)).toBeInTheDocument();
+  });
+
+  test("shows provisioning state when cluster is still starting", async () => {
+    mockGet.mockResolvedValue({
+      recoverable: [],
+      provisioning: [
+        {
+          id: 1,
+          resource_name: "bioaf-demo-abc123",
+          gcp_project_id: "test-project",
+          gcp_zone: "us-central1",
+          stack_uid: "abc123",
+          gke_status: "PROVISIONING",
+          detected_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+      dead: [],
+    });
+
+    render(<DeployRecoveryModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Deployment still in progress/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Google Cloud is still setting up/)).toBeInTheDocument();
+    expect(screen.getByText(/Google Cloud Status/)).toBeInTheDocument();
+    expect(screen.getByText(/Got It/)).toBeInTheDocument();
+  });
+
+  test("calls onRecovered after successful adopt", async () => {
+    mockGet.mockResolvedValue({
+      recoverable: [
+        {
+          id: 42,
+          resource_name: "bioaf-demo-abc123",
+          gcp_project_id: "test-project",
+          gcp_zone: "us-central1",
+          stack_uid: "abc123",
+          gke_status: "RUNNING",
+          detected_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+      provisioning: [],
+      dead: [],
+    });
+    mockPost.mockResolvedValue({ status: "adopted" });
+
+    render(<DeployRecoveryModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Resume Deployment/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/Resume Deployment/));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/api/v1/infrastructure/orphaned-resources/42/adopt",
+      );
+      expect(defaultProps.onRecovered).toHaveBeenCalled();
+    });
+  });
+
+  test("calls onStartFresh after cleanup", async () => {
+    mockGet.mockResolvedValue({
+      recoverable: [
+        {
+          id: 1,
+          resource_name: "bioaf-demo-abc123",
+          gcp_project_id: "test-project",
+          gcp_zone: "us-central1",
+          stack_uid: "abc123",
+          gke_status: "RUNNING",
+          detected_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+      provisioning: [],
+      dead: [],
+    });
+    mockPost.mockResolvedValue({ cleaned: 1, skipped: 0, failed: 0 });
+
+    render(<DeployRecoveryModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Start Fresh/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/Start Fresh/));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/api/v1/infrastructure/orphaned-resources/cleanup-all",
+      );
+      expect(defaultProps.onStartFresh).toHaveBeenCalled();
+    });
+  });
+
+  test("auto-cleans dead orphans in background", async () => {
+    mockGet.mockResolvedValue({
+      recoverable: [],
+      provisioning: [],
+      dead: [
+        {
+          id: 5,
+          resource_name: "bioaf-demo-dead",
+          gcp_project_id: "test-project",
+          gcp_zone: "us-central1",
+          stack_uid: "dead01",
+          gke_status: "NOT_FOUND",
+          detected_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+    });
+    mockPost.mockResolvedValue({ cleaned: 1, skipped: 0, failed: 0 });
+
+    render(<DeployRecoveryModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/api/v1/infrastructure/orphaned-resources/cleanup-all",
+      );
+    });
+  });
+
+  test("does not render when open is false", () => {
+    const { container } = render(
+      <DeployRecoveryModal {...defaultProps} open={false} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("shows error when recovery check fails", async () => {
+    mockGet.mockRejectedValue(new Error("Network error"));
+
+    render(<DeployRecoveryModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not check deployment status/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/infrastructure/DeployRecoveryModal.tsx
+++ b/frontend/src/components/infrastructure/DeployRecoveryModal.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RecoveryItem {
+  id: number;
+  resource_name: string;
+  gcp_project_id: string;
+  gcp_zone: string | null;
+  stack_uid: string;
+  gke_status: string;
+  detected_at: string | null;
+}
+
+interface RecoveryCheckResponse {
+  recoverable: RecoveryItem[];
+  provisioning: RecoveryItem[];
+  dead: RecoveryItem[];
+}
+
+type ModalState =
+  | "loading"
+  | "recoverable"
+  | "provisioning"
+  | "none";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onRecovered: () => void;
+  onStartFresh: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DeployRecoveryModal({
+  open,
+  onClose,
+  onRecovered,
+  onStartFresh,
+}: Props) {
+  const [state, setState] = useState<ModalState>("loading");
+  const [recoverable, setRecoverable] = useState<RecoveryItem[]>([]);
+  const [provisioning, setProvisioning] = useState<RecoveryItem[]>([]);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runCheck = useCallback(async () => {
+    setState("loading");
+    setError(null);
+    try {
+      const data = await api.get<RecoveryCheckResponse>(
+        "/api/v1/infrastructure/orphaned-resources/recovery-check",
+      );
+      setRecoverable(data.recoverable);
+      setProvisioning(data.provisioning);
+
+      // Auto-clean dead orphans in the background
+      if (data.dead.length > 0) {
+        api.post("/api/v1/infrastructure/orphaned-resources/cleanup-all").catch(() => {
+          // Best-effort cleanup
+        });
+      }
+
+      if (data.recoverable.length > 0) {
+        setState("recoverable");
+      } else if (data.provisioning.length > 0) {
+        setState("provisioning");
+      } else {
+        // Nothing to recover or wait on -- close and allow normal flow
+        setState("none");
+      }
+    } catch {
+      setError("Could not check deployment status. Try again in a moment.");
+      setState("none");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      runCheck();
+    }
+  }, [open, runCheck]);
+
+  const handleRecover = async () => {
+    if (recoverable.length === 0) return;
+    setActionLoading(true);
+    setError(null);
+    try {
+      await api.post(
+        `/api/v1/infrastructure/orphaned-resources/${recoverable[0].id}/adopt`,
+      );
+      onRecovered();
+    } catch {
+      setError(
+        "Recovery failed. You can try again or start a fresh deployment.",
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleStartFresh = async () => {
+    setActionLoading(true);
+    setError(null);
+    try {
+      // Clean up all orphans before starting fresh
+      await api.post("/api/v1/infrastructure/orphaned-resources/cleanup-all");
+      onStartFresh();
+    } catch {
+      setError(
+        "Could not clean up previous resources. Try again in a moment.",
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  // If nothing to show, close immediately
+  if (state === "none" && !error) {
+    // Use a microtask to avoid updating state during render
+    Promise.resolve().then(onClose);
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl shadow-2xl max-w-lg w-full mx-4 overflow-hidden">
+        {/* Loading */}
+        {state === "loading" && (
+          <div className="p-8 text-center">
+            <div className="inline-block h-8 w-8 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin mb-4" />
+            <p className="text-sm text-gray-600">
+              Checking deployment status...
+            </p>
+          </div>
+        )}
+
+        {/* Recoverable: previous deploy finished successfully */}
+        {state === "recoverable" && (
+          <>
+            <div className="p-6 pb-0">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="flex items-center justify-center h-10 w-10 rounded-full bg-green-100">
+                  <svg className="h-5 w-5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Previous deployment found
+                </h3>
+              </div>
+              <p className="text-sm text-gray-600 mb-2">
+                Your previous deployment took longer than expected, but it
+                finished successfully. We can pick up right where you left off.
+              </p>
+              <p className="text-xs text-gray-400 mb-4">
+                This sometimes happens when Google Cloud is experiencing
+                delays in your region.
+              </p>
+              {error && (
+                <p className="text-sm text-red-600 bg-red-50 rounded p-2 mb-4">
+                  {error}
+                </p>
+              )}
+            </div>
+            <div className="bg-gray-50 px-6 py-4 flex justify-end gap-3">
+              <button
+                onClick={handleStartFresh}
+                disabled={actionLoading}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Start Fresh
+              </button>
+              <button
+                onClick={handleRecover}
+                disabled={actionLoading}
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {actionLoading ? "Recovering..." : "Resume Deployment"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* Provisioning: cluster is still being created by GCP */}
+        {state === "provisioning" && (
+          <>
+            <div className="p-6 pb-0">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="flex items-center justify-center h-10 w-10 rounded-full bg-amber-100">
+                  <svg className="h-5 w-5 text-amber-600 animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Deployment still in progress
+                </h3>
+              </div>
+              <p className="text-sm text-gray-600 mb-2">
+                Google Cloud is still setting up your compute cluster. This is
+                taking longer than usual, likely due to a service delay on
+                Google&apos;s side.
+              </p>
+              <p className="text-sm text-gray-600 mb-2">
+                There&apos;s nothing you need to do. Come back later and
+                we&apos;ll check again automatically.
+              </p>
+              <p className="text-xs text-gray-400 mb-4">
+                You can check{" "}
+                <a
+                  href="https://status.cloud.google.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline"
+                >
+                  Google Cloud Status
+                </a>{" "}
+                for current service health.
+              </p>
+              {error && (
+                <p className="text-sm text-red-600 bg-red-50 rounded p-2 mb-4">
+                  {error}
+                </p>
+              )}
+            </div>
+            <div className="bg-gray-50 px-6 py-4 flex justify-end gap-3">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                Got It
+              </button>
+              <button
+                onClick={runCheck}
+                disabled={actionLoading}
+                className="px-4 py-2 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-lg hover:bg-blue-100 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Check Again
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* Error with no state */}
+        {state === "none" && error && (
+          <>
+            <div className="p-6">
+              <p className="text-sm text-red-600 bg-red-50 rounded p-2">
+                {error}
+              </p>
+            </div>
+            <div className="bg-gray-50 px-6 py-4 flex justify-end">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                Close
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -21,6 +21,10 @@ jest.mock("@/lib/auth", () => ({
   getCurrentUser: () => ({ role_name: "admin", email: "admin@test.com" }),
 }));
 
+jest.mock("@/hooks/useBackendReady", () => ({
+  useBackendReady: () => ({ ready: true }),
+}));
+
 const mockPermissions = jest.fn();
 jest.mock("@/hooks/usePermissions", () => ({
   usePermissions: () => mockPermissions(),

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useMemo, useCallback } from "react";
 import { getCurrentUser } from "@/lib/auth";
 import { usePermissions } from "@/hooks/usePermissions";
 import { useComponents } from "@/hooks/useComponents";
+import { useBackendReady } from "@/hooks/useBackendReady";
 import { navConfig, NavSection, NavChild, ComponentGate, isChildActive } from "@/lib/navConfig";
 
 function ChevronIcon({ expanded }: { expanded: boolean }) {
@@ -105,6 +106,7 @@ function SidebarSection({
 export function Sidebar() {
   const pathname = usePathname();
   const [user, setUser] = useState<Record<string, unknown> | null>(null);
+  const { ready: backendReady } = useBackendReady();
   const { canAccess, roleName, loading } = usePermissions();
   const { components, loading: componentsLoading } = useComponents();
 
@@ -200,7 +202,7 @@ export function Sidebar() {
     });
   };
 
-  if (loading || componentsLoading) {
+  if (!backendReady || loading || componentsLoading) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900" data-testid="app-loading">
         <div className="text-center">

--- a/frontend/src/hooks/useBackendReady.ts
+++ b/frontend/src/hooks/useBackendReady.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Polls the backend health endpoint until it responds successfully.
+ * Returns { ready: false } while the backend is unreachable or unhealthy,
+ * and { ready: true } once confirmed healthy. Stops polling after that.
+ */
+export function useBackendReady() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    async function check() {
+      try {
+        const res = await fetch(`${API_URL}/api/health/ready`, {
+          cache: "no-store",
+        });
+        if (!cancelled && res.ok) {
+          const body = await res.json();
+          if (body.status === "ok") {
+            setReady(true);
+            return;
+          }
+        }
+      } catch {
+        // Backend not reachable yet
+      }
+      if (!cancelled) {
+        timer = setTimeout(check, POLL_INTERVAL_MS);
+      }
+    }
+
+    check();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, []);
+
+  return { ready };
+}

--- a/frontend/src/hooks/useBackendReady.ts
+++ b/frontend/src/hooks/useBackendReady.ts
@@ -4,18 +4,31 @@ import { useEffect, useState } from "react";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 const POLL_INTERVAL_MS = 2000;
+const SESSION_KEY = "bioaf_backend_ready";
 
 /**
- * Polls the backend health endpoint until it responds successfully.
- * Returns { ready: false } while the backend is unreachable or unhealthy,
- * and { ready: true } once confirmed healthy. Stops polling after that.
+ * Ensures the backend is healthy before dismissing the loading screen.
+ *
+ * - If the backend responds on the first check, sets ready immediately
+ *   (normal app load with a running backend).
+ * - If the first check fails, polls every 2s and reloads the page once
+ *   the backend becomes available so all hooks start fresh.
+ * - Caches readiness in sessionStorage so subsequent navigations within
+ *   the same tab never re-trigger the loading screen.
  */
 export function useBackendReady() {
-  const [ready, setReady] = useState(false);
+  const alreadyConfirmed =
+    typeof window !== "undefined" &&
+    sessionStorage.getItem(SESSION_KEY) === "true";
+
+  const [ready, setReady] = useState(alreadyConfirmed);
 
   useEffect(() => {
+    if (alreadyConfirmed) return;
+
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout>;
+    let isFirstAttempt = true;
 
     async function check() {
       try {
@@ -25,13 +38,22 @@ export function useBackendReady() {
         if (!cancelled && res.ok) {
           const body = await res.json();
           if (body.status === "ok") {
-            setReady(true);
+            sessionStorage.setItem(SESSION_KEY, "true");
+            if (isFirstAttempt) {
+              // Backend was already up -- no reload needed
+              setReady(true);
+            } else {
+              // Backend just came up after we waited -- reload so hooks
+              // that already failed can start fresh
+              window.location.reload();
+            }
             return;
           }
         }
       } catch {
         // Backend not reachable yet
       }
+      isFirstAttempt = false;
       if (!cancelled) {
         timer = setTimeout(check, POLL_INTERVAL_MS);
       }
@@ -43,7 +65,7 @@ export function useBackendReady() {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, []);
+  }, [alreadyConfirmed]);
 
   return { ready };
 }

--- a/frontend/src/hooks/useComponents.ts
+++ b/frontend/src/hooks/useComponents.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { api } from "@/lib/api";
 import type { ComponentState } from "@/lib/types";
 
@@ -20,39 +20,70 @@ interface StackComponentsResponse {
   }>;
 }
 
-export function useComponents() {
-  const [components, setComponents] = useState<ComponentState[]>([]);
-  const [loading, setLoading] = useState(true);
+/** Module-level cache so navigation doesn't re-fetch or flash loading. */
+let cachedComponents: ComponentState[] | null = null;
+let fetchPromise: Promise<void> | null = null;
 
-  const fetchComponents = async () => {
+function mapComponents(
+  data: StackComponentsResponse,
+): ComponentState[] {
+  return data.components.map((c) => ({
+    key: c.key,
+    name: c.name,
+    description: c.description,
+    category: c.category,
+    enabled: c.status === "enabled" || c.status === "provisioning",
+    status: c.status,
+    config: {},
+    dependencies: c.dependencies,
+    estimated_monthly_cost: c.cost_estimate,
+    updated_at: null,
+  }));
+}
+
+export function useComponents() {
+  const [components, setComponents] = useState<ComponentState[]>(
+    cachedComponents ?? [],
+  );
+  const [loading, setLoading] = useState(!cachedComponents);
+
+  useEffect(() => {
+    if (cachedComponents) {
+      setComponents(cachedComponents);
+      setLoading(false);
+      return;
+    }
+
+    if (!fetchPromise) {
+      fetchPromise = api
+        .get<StackComponentsResponse>(
+          "/api/v1/infrastructure/stack/components",
+        )
+        .then((data) => {
+          cachedComponents = mapComponents(data);
+        })
+        .catch(() => {
+          cachedComponents = [];
+        });
+    }
+
+    fetchPromise.then(() => {
+      setComponents(cachedComponents!);
+      setLoading(false);
+    });
+  }, []);
+
+  const refetch = useCallback(async () => {
     try {
       const data = await api.get<StackComponentsResponse>(
         "/api/v1/infrastructure/stack/components",
       );
-      setComponents(
-        data.components.map((c) => ({
-          key: c.key,
-          name: c.name,
-          description: c.description,
-          category: c.category,
-          enabled: c.status === "enabled" || c.status === "provisioning",
-          status: c.status,
-          config: {},
-          dependencies: c.dependencies,
-          estimated_monthly_cost: c.cost_estimate,
-          updated_at: null,
-        })),
-      );
+      cachedComponents = mapComponents(data);
+      setComponents(cachedComponents);
     } catch {
       // handled by api client
-    } finally {
-      setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    fetchComponents();
   }, []);
 
-  return { components, loading, refetch: fetchComponents };
+  return { components, loading, refetch };
 }

--- a/frontend/tests/components/layout/GcpNavItem.test.tsx
+++ b/frontend/tests/components/layout/GcpNavItem.test.tsx
@@ -31,6 +31,10 @@ jest.mock("@/hooks/useComponents", () => ({
   }),
 }));
 
+jest.mock("@/hooks/useBackendReady", () => ({
+  useBackendReady: () => ({ ready: true }),
+}));
+
 jest.mock("@/hooks/usePermissions", () => ({
   usePermissions: () => ({
     canAccess: (...args: unknown[]) => mockCanAccess(...args),

--- a/frontend/tests/components/layout/Sidebar.test.tsx
+++ b/frontend/tests/components/layout/Sidebar.test.tsx
@@ -30,6 +30,10 @@ jest.mock("@/hooks/useComponents", () => ({
   }),
 }));
 
+jest.mock("@/hooks/useBackendReady", () => ({
+  useBackendReady: () => ({ ready: true }),
+}));
+
 jest.mock("@/hooks/usePermissions", () => ({
   usePermissions: () => ({
     canAccess: (...args: unknown[]) => mockCanAccess(...args),


### PR DESCRIPTION
## Summary

- When GKE provisioning exceeds the 30-minute Terraform timeout (e.g., during GCP service delays), the app now detects orphaned clusters and guides users through recovery instead of leaving them stuck
- On the Components page, a recovery modal auto-opens when orphaned clusters are detected: if the cluster came online, users can resume; if still provisioning, they're told to check back; if dead, it's cleaned up silently
- The deploy button is blocked when orphaned clusters exist to prevent spawning duplicates
- Three new backend endpoints: `recovery-check` (queries GKE API for live cluster status), `adopt` (recovers a running orphaned cluster), `cleanup-all` (batch-cleans dead orphans)
- Version bump to 0.3.12

## Test plan

- [x] 18 new backend tests for recovery-check, adopt, cleanup-all service methods and API endpoints
- [x] 8 new frontend tests for DeployRecoveryModal (loading, recoverable, provisioning, adopt, start-fresh, auto-clean, error states)
- [x] All 1560 backend tests pass
- [x] All 392 frontend tests pass
- [x] ruff format, ruff check, mypy, tsc, markdownlint all clean