### PR TITLE
Usability: real backups, service health, version checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A turnkey computational biology platform for small biotech companies (5-50 resea
 - **SSH Access** - One-click kubectl exec into running pipeline jobs and notebook sessions
 - **Notifications** - Event-driven alerts via in-app, email (SMTP), and Slack (OAuth integration)
 - **Cost Center** - GCP billing integration, budget alerts, component cost breakdown, projections
-- **Backup & Recovery** - Tiered backups (Cloud SQL PITR, GCS versioning, config exports), one-click restore
+- **Backup & Recovery** - 4-tier GCS backups (pg_dump, GCS versioning, platform config, terraform state), restore with review period
 - **Session Credentials** - Per-user RStudio credentials with PAM authentication, auto-generated usernames
 - **Role-Based Access** - Permission-based RBAC with four built-in roles, custom role creation, and per-resource/action grants
 - **Upgrade System** - GitHub-based version checking, managed upgrade flow with rollback

--- a/backend/app/api/backups.py
+++ b/backend/app/api/backups.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
@@ -9,6 +9,8 @@ from app.schemas.backup import (
     ConfigSnapshotListResponse,
     ConfigSnapshot,
     ConfigSnapshotDiff,
+    PostgresSnapshotListResponse,
+    PostgresSnapshot,
     RestoreRequest,
     RestoreResponse,
     BackupSettingsUpdate,
@@ -73,28 +75,25 @@ async def restore_config(
     return RestoreResponse(**result)
 
 
-@router.post("/restore/cloudsql", response_model=RestoreResponse)
-async def restore_cloudsql(
-    body: RestoreRequest,
-    current_user: dict = require_permission("backups", "restore"),
+@router.get("/postgres-snapshots", response_model=PostgresSnapshotListResponse)
+async def list_postgres_snapshots(
+    current_user: dict = require_permission("backups", "view"),
     session: AsyncSession = Depends(get_session),
 ):
-    return RestoreResponse(
-        status="initiated",
-        message=f"Cloud SQL PITR restore to {body.restore_point or 'latest'} initiated",
+    snapshots, total = await BackupService.get_postgres_snapshots(current_user["org_id"])
+    return PostgresSnapshotListResponse(
+        snapshots=[PostgresSnapshot(**s) for s in snapshots],
+        total=total,
     )
 
 
-@router.post("/restore/filestore", response_model=RestoreResponse)
-async def restore_filestore(
-    body: RestoreRequest,
-    current_user: dict = require_permission("backups", "restore"),
+@router.post("/trigger/postgres", status_code=501)
+async def trigger_postgres_backup(
+    current_user: dict = require_permission("backups", "create"),
     session: AsyncSession = Depends(get_session),
 ):
-    return RestoreResponse(
-        status="initiated",
-        message=f"Filestore snapshot restore to {body.restore_point or 'latest'} initiated",
-    )
+    """Trigger a manual PostgreSQL backup. Wired up in Commit 5."""
+    raise HTTPException(501, detail="PostgreSQL backup not yet implemented")
 
 
 @router.put("/settings")
@@ -103,15 +102,12 @@ async def update_backup_settings(
     current_user: dict = require_permission("backups", "create"),
     session: AsyncSession = Depends(get_session),
 ):
-    # Enforce minimums
     errors = []
-    if body.cloud_sql_pitr_days is not None and body.cloud_sql_pitr_days < 7:
-        errors.append("Cloud SQL PITR retention must be at least 7 days")
-    if body.cloud_sql_retention_days is not None and body.cloud_sql_retention_days < 30:
-        errors.append("Cloud SQL snapshot retention must be at least 30 days")
+    if body.postgres_retention_days is not None and body.postgres_retention_days < 1:
+        errors.append("PostgreSQL backup retention must be at least 1 day")
+    if body.config_retention_days is not None and body.config_retention_days < 1:
+        errors.append("Config backup retention must be at least 1 day")
     if errors:
-        from fastapi import HTTPException
-
         raise HTTPException(400, detail="; ".join(errors))
 
     return {"status": "updated", "settings": body.model_dump(exclude_unset=True)}

--- a/backend/app/api/backups.py
+++ b/backend/app/api/backups.py
@@ -87,13 +87,16 @@ async def list_postgres_snapshots(
     )
 
 
-@router.post("/trigger/postgres", status_code=501)
+@router.post("/trigger/postgres")
 async def trigger_postgres_backup(
     current_user: dict = require_permission("backups", "create"),
     session: AsyncSession = Depends(get_session),
 ):
-    """Trigger a manual PostgreSQL backup. Wired up in Commit 5."""
-    raise HTTPException(501, detail="PostgreSQL backup not yet implemented")
+    """Trigger a manual PostgreSQL backup."""
+    result = await BackupService.run_postgres_backup(current_user["org_id"])
+    if result["status"] == "error":
+        raise HTTPException(500, detail=result.get("message", "Backup failed"))
+    return result
 
 
 @router.put("/settings")

--- a/backend/app/api/backups.py
+++ b/backend/app/api/backups.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_permission
@@ -111,6 +112,33 @@ async def trigger_config_backup(
     if result["status"] == "error":
         raise HTTPException(500, detail=result.get("message", "Backup failed"))
     return result
+
+
+@router.get("/tfstate-files")
+async def list_tfstate_files(
+    current_user: dict = require_permission("backups", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    """List terraform state files available for download."""
+    files = await BackupService.list_tfstate_files(session)
+    return {"files": files}
+
+
+@router.get("/tfstate-download/{filename:path}")
+async def download_tfstate(
+    filename: str,
+    current_user: dict = require_permission("backups", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Download a terraform state file."""
+    data = await BackupService.download_tfstate(session, filename)
+    if data is None:
+        raise HTTPException(404, detail="Terraform state file not found")
+    return Response(
+        content=data,
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename.split("/")[-1]}"'},
+    )
 
 
 @router.get("/settings", response_model=BackupSettingsResponse)

--- a/backend/app/api/backups.py
+++ b/backend/app/api/backups.py
@@ -16,8 +16,10 @@ from app.schemas.backup import (
     PostgresSnapshotListResponse,
     RestoreRequest,
     RestoreResponse,
+    RestoreStatusResponse,
+    StartPostgresRestoreRequest,
 )
-from app.services.backup_service import BackupService
+from app.services.backup_service import BackupService, RestoreService
 
 router = APIRouter(prefix="/api/backups", tags=["backups"])
 
@@ -169,3 +171,49 @@ async def update_backup_settings(
 
     updated = await BackupService.update_backup_settings(session, body.model_dump(exclude_unset=True))
     return {"status": "updated", "settings": updated}
+
+
+# --- Database Restore ---
+
+
+@router.get("/restore/status", response_model=RestoreStatusResponse)
+async def get_restore_status(
+    current_user: dict = require_permission("backups", "view"),
+):
+    return RestoreService.get_status()
+
+
+@router.post("/restore/postgres")
+async def start_postgres_restore(
+    body: StartPostgresRestoreRequest,
+    current_user: dict = require_permission("backups", "restore"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Start a database restore from a pg_dump backup. Enters review mode."""
+    result = await RestoreService.start(session, current_user["org_id"], body.filename)
+    if result["status"] == "error":
+        status_code = 409 if "already active" in result["message"] else 500
+        raise HTTPException(status_code, detail=result["message"])
+    return result
+
+
+@router.post("/restore/accept")
+async def accept_restore(
+    current_user: dict = require_permission("backups", "restore"),
+):
+    """Accept the restored database, making it permanent."""
+    result = await RestoreService.accept()
+    if result["status"] == "error":
+        raise HTTPException(400, detail=result["message"])
+    return result
+
+
+@router.post("/restore/reject")
+async def reject_restore(
+    current_user: dict = require_permission("backups", "restore"),
+):
+    """Reject the restored database and revert to the original."""
+    result = await RestoreService.reject()
+    if result["status"] == "error":
+        raise HTTPException(400, detail=result["message"])
+    return result

--- a/backend/app/api/backups.py
+++ b/backend/app/api/backups.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import require_permission
 from app.database import get_session
 from app.schemas.backup import (
+    BackupSettingsResponse,
     BackupSettingsUpdate,
     BackupStatusResponse,
     BackupTierStatus,
@@ -100,6 +101,26 @@ async def trigger_postgres_backup(
     return result
 
 
+@router.post("/trigger/config")
+async def trigger_config_backup(
+    current_user: dict = require_permission("backups", "create"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Trigger a manual platform config backup to GCS."""
+    result = await BackupService.run_config_backup(session, current_user["org_id"])
+    if result["status"] == "error":
+        raise HTTPException(500, detail=result.get("message", "Backup failed"))
+    return result
+
+
+@router.get("/settings", response_model=BackupSettingsResponse)
+async def get_backup_settings(
+    current_user: dict = require_permission("backups", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    return await BackupService.get_backup_settings(session)
+
+
 @router.put("/settings")
 async def update_backup_settings(
     body: BackupSettingsUpdate,
@@ -109,9 +130,14 @@ async def update_backup_settings(
     errors = []
     if body.postgres_retention_days is not None and body.postgres_retention_days < 1:
         errors.append("PostgreSQL backup retention must be at least 1 day")
+    if body.postgres_schedule_hours is not None and body.postgres_schedule_hours < 1:
+        errors.append("PostgreSQL backup schedule must be at least 1 hour")
     if body.config_retention_days is not None and body.config_retention_days < 1:
         errors.append("Config backup retention must be at least 1 day")
+    if body.config_schedule_hours is not None and body.config_schedule_hours < 1:
+        errors.append("Config backup schedule must be at least 1 hour")
     if errors:
         raise HTTPException(400, detail="; ".join(errors))
 
-    return {"status": "updated", "settings": body.model_dump(exclude_unset=True)}
+    updated = await BackupService.update_backup_settings(session, body.model_dump(exclude_unset=True))
+    return {"status": "updated", "settings": updated}

--- a/backend/app/api/backups.py
+++ b/backend/app/api/backups.py
@@ -1,19 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import get_session
 from app.api.dependencies import require_permission
+from app.database import get_session
 from app.schemas.backup import (
+    BackupSettingsUpdate,
     BackupStatusResponse,
     BackupTierStatus,
-    ConfigSnapshotListResponse,
     ConfigSnapshot,
     ConfigSnapshotDiff,
-    PostgresSnapshotListResponse,
+    ConfigSnapshotListResponse,
     PostgresSnapshot,
+    PostgresSnapshotListResponse,
     RestoreRequest,
     RestoreResponse,
-    BackupSettingsUpdate,
 )
 from app.services.backup_service import BackupService
 
@@ -25,7 +25,7 @@ async def get_backup_status(
     current_user: dict = require_permission("backups", "view"),
     session: AsyncSession = Depends(get_session),
 ):
-    status = await BackupService.get_backup_status(current_user["org_id"])
+    status = await BackupService.get_backup_status(session, current_user["org_id"])
     return BackupStatusResponse(
         tiers=[BackupTierStatus(**t) for t in status["tiers"]],
         overall_status=status["overall_status"],
@@ -40,6 +40,7 @@ async def list_config_snapshots(
     session: AsyncSession = Depends(get_session),
 ):
     snapshots, total = await BackupService.get_config_snapshots(
+        session,
         current_user["org_id"],
         page,
         page_size,
@@ -80,7 +81,7 @@ async def list_postgres_snapshots(
     current_user: dict = require_permission("backups", "view"),
     session: AsyncSession = Depends(get_session),
 ):
-    snapshots, total = await BackupService.get_postgres_snapshots(current_user["org_id"])
+    snapshots, total = await BackupService.get_postgres_snapshots(session, current_user["org_id"])
     return PostgresSnapshotListResponse(
         snapshots=[PostgresSnapshot(**s) for s in snapshots],
         total=total,
@@ -92,8 +93,8 @@ async def trigger_postgres_backup(
     current_user: dict = require_permission("backups", "create"),
     session: AsyncSession = Depends(get_session),
 ):
-    """Trigger a manual PostgreSQL backup."""
-    result = await BackupService.run_postgres_backup(current_user["org_id"])
+    """Trigger a manual PostgreSQL backup to GCS."""
+    result = await BackupService.run_postgres_backup(session, current_user["org_id"])
     if result["status"] == "error":
         raise HTTPException(500, detail=result.get("message", "Backup failed"))
     return result

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -38,3 +38,17 @@ async def system_status(session: AsyncSession = Depends(get_session)):
         "status": "healthy" if all_healthy else "degraded",
         "services": checks,
     }
+
+
+@router.get("/services")
+async def service_health():
+    """Return per-service health based on request success rates over the last 5 minutes.
+
+    Services with >75% success are healthy, 50-74% are degraded,
+    <50% are unhealthy. Services with no recent traffic are unknown.
+    """
+    from app.services.request_health import get_service_health
+
+    health = get_service_health()
+    services = [{"name": name, "status": status} for name, status in sorted(health.items())]
+    return {"services": services}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,7 +67,6 @@ class Settings(BaseSettings):
     backup_postgres_interval_hours: int = 24
     backup_postgres_retention_days: int = 14
     backup_config_retention_days: int = 30
-    backups_bucket_name: str = ""
 
     # Bcrypt
     bcrypt_rounds: int = 12

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -63,6 +63,13 @@ class Settings(BaseSettings):
     ssl_certfile: str = ""
     ssl_keyfile: str = ""
 
+    # Backups
+    backup_postgres_interval_hours: int = 24
+    backup_postgres_retention_days: int = 14
+    backup_config_retention_days: int = 30
+    backup_local_dir: str = "/tmp/bioaf-backups"
+    backups_bucket_name: str = ""
+
     # Bcrypt
     bcrypt_rounds: int = 12
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,7 +67,6 @@ class Settings(BaseSettings):
     backup_postgres_interval_hours: int = 24
     backup_postgres_retention_days: int = 14
     backup_config_retention_days: int = 30
-    backup_local_dir: str = "/tmp/bioaf-backups"
     backups_bucket_name: str = ""
 
     # Bcrypt

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,9 +1,12 @@
+import logging
 from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from app.config import settings
+
+logger = logging.getLogger("bioaf.database")
 
 engine = create_async_engine(
     settings.database_url,
@@ -22,3 +25,24 @@ class Base(DeclarativeBase):
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_factory() as session:
         yield session
+
+
+async def swap_database(new_url: str) -> None:
+    """Swap the connection pool to a different database URL.
+
+    Disposes the old engine and creates a new one. All subsequent calls to
+    get_session() and background loop imports of async_session_factory will
+    use the new connection. In-flight requests on the old engine will complete
+    normally as dispose() waits for connections to be returned.
+    """
+    global engine, async_session_factory
+    old_engine = engine
+    logger.info("Swapping database connection to %s", new_url.split("@")[-1])
+    engine = create_async_engine(
+        new_url,
+        echo=settings.debug,
+        pool_size=5,
+        max_overflow=10,
+    )
+    async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    await old_engine.dispose()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -142,6 +142,7 @@ async def lifespan(app: FastAPI):
     background_tasks.append(asyncio.create_task(_reconciler_loop()))
     background_tasks.append(asyncio.create_task(_notification_cleanup_loop()))
     background_tasks.append(asyncio.create_task(_backup_health_check_loop()))
+    background_tasks.append(asyncio.create_task(_postgres_backup_loop()))
     background_tasks.append(asyncio.create_task(_cost_billing_sync_loop()))
     background_tasks.append(asyncio.create_task(_version_check_loop()))
     background_tasks.append(asyncio.create_task(_review_reminder_loop()))
@@ -337,6 +338,29 @@ async def _backup_health_check_loop():
             break
         except Exception as e:
             logger.error("Backup health check error: %s", e)
+
+
+async def _postgres_backup_loop():
+    """Run pg_dump backups on the configured interval (local mode only)."""
+    from app.config import settings
+    from app.services.backup_service import BackupService
+
+    if settings.compute_mode != "local":
+        return  # In production, CronJob handles this
+
+    interval = settings.backup_postgres_interval_hours * 3600
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            result = await BackupService.run_postgres_backup(org_id=1)
+            if result["status"] == "completed":
+                logger.info("Scheduled pg_dump completed: %s", result.get("filename"))
+            else:
+                logger.error("Scheduled pg_dump failed: %s", result.get("message"))
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error("Postgres backup loop error: %s", e)
 
 
 async def _cost_billing_sync_loop():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -331,7 +331,7 @@ async def _backup_health_check_loop():
                 orgs = list(result.scalars().all())
                 for org in orgs:
                     try:
-                        await BackupService.check_backup_health(org.id)
+                        await BackupService.check_backup_health(session, org.id)
                     except Exception as e:
                         logger.warning("Backup health check failed for org %d: %s", org.id, e)
         except asyncio.CancelledError:
@@ -341,18 +341,17 @@ async def _backup_health_check_loop():
 
 
 async def _postgres_backup_loop():
-    """Run pg_dump backups on the configured interval (local mode only)."""
+    """Run pg_dump backups on the configured interval."""
     from app.config import settings
+    from app.database import async_session_factory
     from app.services.backup_service import BackupService
-
-    if settings.compute_mode != "local":
-        return  # In production, CronJob handles this
 
     interval = settings.backup_postgres_interval_hours * 3600
     while True:
         try:
             await asyncio.sleep(interval)
-            result = await BackupService.run_postgres_backup(org_id=1)
+            async with async_session_factory() as session:
+                result = await BackupService.run_postgres_backup(session, org_id=1)
             if result["status"] == "completed":
                 logger.info("Scheduled pg_dump completed: %s", result.get("filename"))
             else:

--- a/backend/app/middleware/logging_middleware.py
+++ b/backend/app/middleware/logging_middleware.py
@@ -39,4 +39,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             duration_ms,
         )
 
+        # Feed request health counters
+        from app.services.request_health import record
+
+        record(request.url.path, response.status_code)
+
         return response

--- a/backend/app/schemas/backup.py
+++ b/backend/app/schemas/backup.py
@@ -62,6 +62,18 @@ class RestoreResponse(BaseModel):
     message: str
 
 
+class StartPostgresRestoreRequest(BaseModel):
+    filename: str
+
+
+class RestoreStatusResponse(BaseModel):
+    active: bool
+    backup_filename: str | None = None
+    started_at: datetime | None = None
+    expires_at: datetime | None = None
+    seconds_remaining: int | None = None
+
+
 class BackupSettingsResponse(BaseModel):
     postgres_retention_days: int
     postgres_schedule_hours: int

--- a/backend/app/schemas/backup.py
+++ b/backend/app/schemas/backup.py
@@ -62,6 +62,15 @@ class RestoreResponse(BaseModel):
     message: str
 
 
+class BackupSettingsResponse(BaseModel):
+    postgres_retention_days: int
+    postgres_schedule_hours: int
+    config_retention_days: int
+    config_schedule_hours: int
+
+
 class BackupSettingsUpdate(BaseModel):
     postgres_retention_days: int | None = None
+    postgres_schedule_hours: int | None = None
     config_retention_days: int | None = None
+    config_schedule_hours: int | None = None

--- a/backend/app/schemas/backup.py
+++ b/backend/app/schemas/backup.py
@@ -11,8 +11,8 @@ class BackupTierStatus(BaseModel):
     next_scheduled: datetime | None = None
     retention_days: int | None = None
     status: str = "unknown"
-    pitr_window_hours: int | None = None
     versioning_enabled: bool | None = None
+    backup_count: int | None = None
 
 
 class BackupStatusResponse(BaseModel):
@@ -41,6 +41,17 @@ class ConfigSnapshotDiff(BaseModel):
     changes: list[dict] = []
 
 
+class PostgresSnapshot(BaseModel):
+    filename: str
+    date: str
+    size_bytes: int | None = None
+
+
+class PostgresSnapshotListResponse(BaseModel):
+    snapshots: list[PostgresSnapshot]
+    total: int
+
+
 class RestoreRequest(BaseModel):
     confirmation_token: str
     restore_point: str | None = None
@@ -52,9 +63,5 @@ class RestoreResponse(BaseModel):
 
 
 class BackupSettingsUpdate(BaseModel):
-    cloud_sql_retention_days: int | None = None
-    cloud_sql_pitr_days: int | None = None
-    filestore_retention_days: int | None = None
-    config_nightly_retention_days: int | None = None
-    config_weekly_retention_weeks: int | None = None
-    config_monthly_retention_months: int | None = None
+    postgres_retention_days: int | None = None
+    config_retention_days: int | None = None

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -56,13 +56,30 @@ def _tier_status_from_age(last_backup: datetime | None, interval_hours: int) -> 
 
 
 async def _get_backups_bucket(session: AsyncSession) -> str:
-    """Read backups_bucket_name from platform_config, fall back to settings."""
-    result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'backups_bucket_name'"))
-    row = result.fetchone()
-    bucket = row[0] if row else ""
+    """Read backup bucket from platform_config.
+
+    Checks backups_bucket_name first (persistent bucket from foundation module),
+    then falls back to config_backups_bucket_name (existing bucket from storage
+    deployment). Returns empty string if neither is configured.
+    """
+    result = await session.execute(
+        text(
+            "SELECT key, value FROM platform_config WHERE key IN ('backups_bucket_name', 'config_backups_bucket_name')"
+        )
+    )
+    config = {r[0]: r[1] for r in result.fetchall()}
+
+    # Prefer the persistent backups bucket from foundation module
+    bucket = config.get("backups_bucket_name", "")
     if bucket and bucket != "null":
         return bucket
-    return settings.backups_bucket_name
+
+    # Fall back to the existing config backups bucket from storage module
+    bucket = config.get("config_backups_bucket_name", "")
+    if bucket and bucket != "null":
+        return bucket
+
+    return ""
 
 
 def _get_gcs_client(credentials=None):

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -104,7 +104,6 @@ class BackupService:
     def _local_status() -> list[dict]:
         """Build tier status by scanning the local backup directory."""
         tiers = []
-        now = datetime.now(timezone.utc)
 
         # PostgreSQL
         pg_dir = os.path.join(settings.backup_local_dir, "postgres")
@@ -275,12 +274,17 @@ class BackupService:
         try:
             process = await asyncio.create_subprocess_exec(
                 "pg_dump",
-                "-h", host,
-                "-p", port,
-                "-U", user,
-                "-d", dbname,
+                "-h",
+                host,
+                "-p",
+                port,
+                "-U",
+                user,
+                "-d",
+                dbname,
                 "-Fc",
-                "-f", output_path,
+                "-f",
+                output_path,
                 env=env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -299,9 +303,7 @@ class BackupService:
 
             # Rotate old backups
             if settings.compute_mode == "local":
-                BackupService.rotate_local_backups(
-                    pg_dir, _PG_FILENAME_RE, settings.backup_postgres_retention_days
-                )
+                BackupService.rotate_local_backups(pg_dir, _PG_FILENAME_RE, settings.backup_postgres_retention_days)
 
             logger.info("pg_dump completed: %s (%d bytes, %.1fs)", filename, size, duration)
             return {

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -1,6 +1,12 @@
-"""Backup monitoring service with status checks and restore operations."""
+"""Backup monitoring service with real status checks.
+
+Local mode: checks filesystem at {backup_local_dir}/{type}/.
+Production mode: checks GCS blobs at {backups_bucket}/{prefix}/.
+"""
 
 import logging
+import os
+import re
 from datetime import datetime, timedelta, timezone
 
 from app.config import settings
@@ -9,74 +15,76 @@ from app.services.event_types import BACKUP_FAILURE
 
 logger = logging.getLogger("bioaf.backup_service")
 
+_PG_FILENAME_RE = re.compile(r"^pgdump-(\d{8}-\d{6})\.dump$")
+_CONFIG_FILENAME_RE = re.compile(r"^config-(\d{8}-\d{6})\.json$")
+_TIMESTAMP_FMT = "%Y%m%d-%H%M%S"
+
+
+def _parse_timestamp(filename: str, pattern: re.Pattern) -> datetime | None:
+    """Extract UTC timestamp from a backup filename."""
+    m = pattern.match(filename)
+    if not m:
+        return None
+    try:
+        return datetime.strptime(m.group(1), _TIMESTAMP_FMT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _scan_local_backups(directory: str, pattern: re.Pattern) -> list[dict]:
+    """Scan a local directory for backup files matching the pattern.
+    Returns list of dicts sorted newest-first with filename, timestamp, size_bytes.
+    """
+    if not os.path.isdir(directory):
+        return []
+
+    results = []
+    for name in os.listdir(directory):
+        ts = _parse_timestamp(name, pattern)
+        if ts is None:
+            continue
+        path = os.path.join(directory, name)
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            size = 0
+        results.append({"filename": name, "timestamp": ts, "size_bytes": size})
+
+    results.sort(key=lambda x: x["timestamp"], reverse=True)
+    return results
+
+
+def _tier_status_from_age(
+    last_backup: datetime | None,
+    interval_hours: int,
+) -> str:
+    """Determine tier health from the age of the most recent backup.
+    healthy: age < 2x interval
+    warning: age < 3x interval
+    error: age >= 3x interval
+    unknown: no backup exists
+    """
+    if last_backup is None:
+        return "unknown"
+    age_hours = (datetime.now(timezone.utc) - last_backup).total_seconds() / 3600
+    if age_hours < interval_hours * 2:
+        return "healthy"
+    if age_hours < interval_hours * 3:
+        return "warning"
+    return "error"
+
 
 class BackupService:
     @staticmethod
     async def get_backup_status(org_id: int) -> dict:
-        """Get backup status for each tier. Returns local/mock data for now;
-        Commit 4 wires this to real GCS checks."""
-        now = datetime.now(timezone.utc)
+        """Get backup status for each tier using real filesystem/GCS checks."""
         tiers = []
 
-        # PostgreSQL (pg_dump)
-        tiers.append(
-            {
-                "tier": "postgres",
-                "name": "PostgreSQL (pg_dump)",
-                "last_backup": None,
-                "size_bytes": None,
-                "next_scheduled": None,
-                "retention_days": settings.backup_postgres_retention_days,
-                "status": "unknown",
-                "versioning_enabled": None,
-                "backup_count": 0,
-            }
-        )
-
-        # GCS Object Versioning
-        tiers.append(
-            {
-                "tier": "gcs",
-                "name": "GCS Object Versioning",
-                "last_backup": None,
-                "size_bytes": None,
-                "next_scheduled": None,
-                "retention_days": None,
-                "status": "unknown",
-                "versioning_enabled": None,
-                "backup_count": None,
-            }
-        )
-
-        # Platform Config
-        tiers.append(
-            {
-                "tier": "platform_config",
-                "name": "Platform Configuration",
-                "last_backup": None,
-                "size_bytes": None,
-                "next_scheduled": None,
-                "retention_days": settings.backup_config_retention_days,
-                "status": "unknown",
-                "versioning_enabled": None,
-                "backup_count": 0,
-            }
-        )
-
-        # Terraform State
-        tiers.append(
-            {
-                "tier": "terraform_state",
-                "name": "Terraform State",
-                "last_backup": None,
-                "size_bytes": None,
-                "next_scheduled": None,
-                "retention_days": None,
-                "status": "unknown",
-                "versioning_enabled": None,
-                "backup_count": None,
-            }
-        )
+        if settings.compute_mode == "local":
+            tiers.extend(BackupService._local_status())
+        else:
+            # GCS mode will be wired in when session parameter is added
+            tiers.extend(BackupService._local_status())
 
         all_healthy = all(t["status"] == "healthy" for t in tiers)
         any_error = any(t["status"] == "error" for t in tiers)
@@ -87,15 +95,111 @@ class BackupService:
         else:
             overall = "unknown"
 
-        return {
-            "tiers": tiers,
-            "overall_status": overall,
-        }
+        return {"tiers": tiers, "overall_status": overall}
+
+    @staticmethod
+    def _local_status() -> list[dict]:
+        """Build tier status by scanning the local backup directory."""
+        tiers = []
+        now = datetime.now(timezone.utc)
+
+        # PostgreSQL
+        pg_dir = os.path.join(settings.backup_local_dir, "postgres")
+        pg_files = _scan_local_backups(pg_dir, _PG_FILENAME_RE)
+        pg_last = pg_files[0]["timestamp"] if pg_files else None
+        pg_size = pg_files[0]["size_bytes"] if pg_files else None
+        pg_status = _tier_status_from_age(pg_last, settings.backup_postgres_interval_hours)
+        interval_delta = timedelta(hours=settings.backup_postgres_interval_hours)
+        tiers.append(
+            {
+                "tier": "postgres",
+                "name": "PostgreSQL (pg_dump)",
+                "last_backup": pg_last.isoformat() if pg_last else None,
+                "size_bytes": pg_size,
+                "next_scheduled": (pg_last + interval_delta).isoformat() if pg_last else None,
+                "retention_days": settings.backup_postgres_retention_days,
+                "status": pg_status,
+                "versioning_enabled": None,
+                "backup_count": len(pg_files),
+            }
+        )
+
+        # GCS Object Versioning (in local mode, report as healthy since there are no
+        # real GCS buckets to check)
+        tiers.append(
+            {
+                "tier": "gcs",
+                "name": "GCS Object Versioning",
+                "last_backup": None,
+                "size_bytes": None,
+                "next_scheduled": None,
+                "retention_days": None,
+                "status": "healthy" if settings.compute_mode == "local" else "unknown",
+                "versioning_enabled": True if settings.compute_mode == "local" else None,
+                "backup_count": None,
+            }
+        )
+
+        # Platform Config
+        config_dir = os.path.join(settings.backup_local_dir, "config")
+        config_files = _scan_local_backups(config_dir, _CONFIG_FILENAME_RE)
+        config_last = config_files[0]["timestamp"] if config_files else None
+        config_size = config_files[0]["size_bytes"] if config_files else None
+        config_status = _tier_status_from_age(config_last, 24)  # daily cadence
+        tiers.append(
+            {
+                "tier": "platform_config",
+                "name": "Platform Configuration",
+                "last_backup": config_last.isoformat() if config_last else None,
+                "size_bytes": config_size,
+                "next_scheduled": (config_last + timedelta(hours=24)).isoformat() if config_last else None,
+                "retention_days": settings.backup_config_retention_days,
+                "status": config_status,
+                "versioning_enabled": None,
+                "backup_count": len(config_files),
+            }
+        )
+
+        # Terraform State (in local mode, terraform state is local files, always healthy)
+        tiers.append(
+            {
+                "tier": "terraform_state",
+                "name": "Terraform State",
+                "last_backup": None,
+                "size_bytes": None,
+                "next_scheduled": None,
+                "retention_days": None,
+                "status": "healthy" if settings.compute_mode == "local" else "unknown",
+                "versioning_enabled": True if settings.compute_mode == "local" else None,
+                "backup_count": None,
+            }
+        )
+
+        return tiers
 
     @staticmethod
     async def get_config_snapshots(org_id: int, page: int = 1, page_size: int = 20) -> tuple[list[dict], int]:
-        """List config backup snapshots. Wired to real GCS in Commit 4."""
+        """List config backup snapshots from local directory or GCS."""
+        if settings.compute_mode == "local":
+            return BackupService._local_config_snapshots(page, page_size)
         return [], 0
+
+    @staticmethod
+    def _local_config_snapshots(page: int = 1, page_size: int = 20) -> tuple[list[dict], int]:
+        config_dir = os.path.join(settings.backup_local_dir, "config")
+        files = _scan_local_backups(config_dir, _CONFIG_FILENAME_RE)
+        total = len(files)
+        start = (page - 1) * page_size
+        page_files = files[start : start + page_size]
+        snapshots = [
+            {
+                "date": f["timestamp"].strftime("%Y-%m-%d"),
+                "size_bytes": f["size_bytes"],
+                "tier": "nightly",
+            }
+            for f in page_files
+        ]
+        return snapshots, total
 
     @staticmethod
     async def get_config_snapshot_diff(org_id: int, snapshot_date: str) -> dict:
@@ -116,32 +220,49 @@ class BackupService:
 
     @staticmethod
     async def get_postgres_snapshots(org_id: int) -> tuple[list[dict], int]:
-        """List postgres backup snapshots. Wired to real storage in Commit 5."""
+        """List postgres backup snapshots from local directory or GCS."""
+        if settings.compute_mode == "local":
+            return BackupService._local_postgres_snapshots()
         return [], 0
 
     @staticmethod
+    def _local_postgres_snapshots() -> tuple[list[dict], int]:
+        pg_dir = os.path.join(settings.backup_local_dir, "postgres")
+        files = _scan_local_backups(pg_dir, _PG_FILENAME_RE)
+        total = len(files)
+        snapshots = [
+            {
+                "filename": f["filename"],
+                "date": f["timestamp"].strftime("%Y-%m-%d %H:%M:%S"),
+                "size_bytes": f["size_bytes"],
+            }
+            for f in files
+        ]
+        return snapshots, total
+
+    @staticmethod
     async def check_backup_health(org_id: int) -> None:
-        """Background health check: emit event if any backup is overdue >24h."""
+        """Background health check: emit event if any backup is overdue."""
         import asyncio
 
         status = await BackupService.get_backup_status(org_id)
         now = datetime.now(timezone.utc)
 
         for tier in status["tiers"]:
-            if tier["last_backup"] and tier["status"] == "healthy":
+            if tier["last_backup"] and tier["status"] in ("warning", "error"):
                 last = datetime.fromisoformat(tier["last_backup"])
-                if (now - last).total_seconds() > 86400:
-                    asyncio.create_task(
-                        event_bus.emit(
-                            BACKUP_FAILURE,
-                            {
-                                "event_type": BACKUP_FAILURE,
-                                "org_id": org_id,
-                                "entity_type": "backup",
-                                "title": f"Backup overdue: {tier['name']}",
-                                "message": f"Last backup was {(now - last).total_seconds() / 3600:.1f} hours ago",
-                                "severity": "critical",
-                                "summary": f"Backup overdue for {tier['name']}",
-                            },
-                        )
+                hours_ago = (now - last).total_seconds() / 3600
+                asyncio.create_task(
+                    event_bus.emit(
+                        BACKUP_FAILURE,
+                        {
+                            "event_type": BACKUP_FAILURE,
+                            "org_id": org_id,
+                            "entity_type": "backup",
+                            "title": f"Backup overdue: {tier['name']}",
+                            "message": f"Last backup was {hours_ago:.1f} hours ago",
+                            "severity": "critical" if tier["status"] == "error" else "warning",
+                            "summary": f"Backup overdue for {tier['name']}",
+                        },
                     )
+                )

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -4,10 +4,13 @@ Local mode: checks filesystem at {backup_local_dir}/{type}/.
 Production mode: checks GCS blobs at {backups_bucket}/{prefix}/.
 """
 
+import asyncio
 import logging
 import os
 import re
+import time
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
 
 from app.config import settings
 from app.services.event_bus import event_bus
@@ -241,10 +244,100 @@ class BackupService:
         return snapshots, total
 
     @staticmethod
+    async def run_postgres_backup(org_id: int) -> dict:
+        """Run pg_dump and save the result to local dir or GCS.
+
+        Parses DATABASE_URL to extract connection parameters, runs pg_dump
+        in custom format (-Fc), and rotates old backups afterward.
+        """
+        start = time.monotonic()
+        now = datetime.now(timezone.utc)
+        filename = f"pgdump-{now.strftime(_TIMESTAMP_FMT)}.dump"
+
+        # Parse connection params from DATABASE_URL
+        # Format: postgresql+asyncpg://user:pass@host:port/dbname
+        url = settings.database_url.replace("+asyncpg", "")
+        parsed = urlparse(url)
+        host = parsed.hostname or "localhost"
+        port = str(parsed.port or 5432)
+        user = parsed.username or "bioaf_app"
+        password = parsed.password or ""
+        dbname = parsed.path.lstrip("/") or "bioaf"
+
+        if settings.compute_mode == "local":
+            pg_dir = os.path.join(settings.backup_local_dir, "postgres")
+            os.makedirs(pg_dir, exist_ok=True)
+            output_path = os.path.join(pg_dir, filename)
+        else:
+            output_path = f"/tmp/{filename}"
+
+        env = {**os.environ, "PGPASSWORD": password}
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "pg_dump",
+                "-h", host,
+                "-p", port,
+                "-U", user,
+                "-d", dbname,
+                "-Fc",
+                "-f", output_path,
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await process.communicate()
+
+            if process.returncode != 0:
+                logger.error("pg_dump failed (exit %d): %s", process.returncode, stderr.decode())
+                # Clean up failed dump
+                if os.path.exists(output_path):
+                    os.remove(output_path)
+                return {"status": "error", "message": stderr.decode()[:500]}
+
+            size = os.path.getsize(output_path) if os.path.exists(output_path) else 0
+            duration = time.monotonic() - start
+
+            # Rotate old backups
+            if settings.compute_mode == "local":
+                BackupService.rotate_local_backups(
+                    pg_dir, _PG_FILENAME_RE, settings.backup_postgres_retention_days
+                )
+
+            logger.info("pg_dump completed: %s (%d bytes, %.1fs)", filename, size, duration)
+            return {
+                "status": "completed",
+                "filename": filename,
+                "size_bytes": size,
+                "duration_seconds": round(duration, 1),
+            }
+
+        except FileNotFoundError:
+            logger.error("pg_dump not found. Install postgresql-client in the container.")
+            return {"status": "error", "message": "pg_dump binary not found"}
+        except Exception as e:
+            logger.error("pg_dump backup failed: %s", e)
+            return {"status": "error", "message": str(e)[:500]}
+
+    @staticmethod
+    def rotate_local_backups(directory: str, pattern: re.Pattern, retention_days: int) -> int:
+        """Delete local backup files older than retention_days. Returns count deleted."""
+        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+        deleted = 0
+        if not os.path.isdir(directory):
+            return 0
+        for name in os.listdir(directory):
+            ts = _parse_timestamp(name, pattern)
+            if ts and ts < cutoff:
+                try:
+                    os.remove(os.path.join(directory, name))
+                    deleted += 1
+                except OSError as e:
+                    logger.warning("Failed to delete old backup %s: %s", name, e)
+        return deleted
+
+    @staticmethod
     async def check_backup_health(org_id: int) -> None:
         """Background health check: emit event if any backup is overdue."""
-        import asyncio
-
         status = await BackupService.get_backup_status(org_id)
         now = datetime.now(timezone.utc)
 

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
+from app.config import settings
 from app.services.event_bus import event_bus
 from app.services.event_types import BACKUP_FAILURE
 
@@ -12,41 +13,27 @@ logger = logging.getLogger("bioaf.backup_service")
 class BackupService:
     @staticmethod
     async def get_backup_status(org_id: int) -> dict:
-        """Get backup status for each tier. Uses mock data when GCP is unavailable."""
+        """Get backup status for each tier. Returns local/mock data for now;
+        Commit 4 wires this to real GCS checks."""
         now = datetime.now(timezone.utc)
         tiers = []
 
-        # Cloud SQL
+        # PostgreSQL (pg_dump)
         tiers.append(
             {
-                "tier": "cloud_sql",
-                "name": "Cloud SQL (PostgreSQL)",
-                "last_backup": (now - timedelta(hours=6)).isoformat(),
-                "size_bytes": 524288000,
-                "next_scheduled": (now + timedelta(hours=18)).isoformat(),
-                "retention_days": 30,
-                "status": "healthy",
-                "pitr_window_hours": 168,
-                "versioning_enabled": None,
-            }
-        )
-
-        # Filestore
-        tiers.append(
-            {
-                "tier": "filestore",
-                "name": "Filestore NFS Snapshots",
-                "last_backup": (now - timedelta(hours=12)).isoformat(),
+                "tier": "postgres",
+                "name": "PostgreSQL (pg_dump)",
+                "last_backup": None,
                 "size_bytes": None,
-                "next_scheduled": (now + timedelta(hours=12)).isoformat(),
-                "retention_days": 14,
-                "status": "healthy",
-                "pitr_window_hours": None,
+                "next_scheduled": None,
+                "retention_days": settings.backup_postgres_retention_days,
+                "status": "unknown",
                 "versioning_enabled": None,
+                "backup_count": 0,
             }
         )
 
-        # GCS
+        # GCS Object Versioning
         tiers.append(
             {
                 "tier": "gcs",
@@ -55,9 +42,9 @@ class BackupService:
                 "size_bytes": None,
                 "next_scheduled": None,
                 "retention_days": None,
-                "status": "healthy",
-                "pitr_window_hours": None,
-                "versioning_enabled": True,
+                "status": "unknown",
+                "versioning_enabled": None,
+                "backup_count": None,
             }
         )
 
@@ -66,13 +53,13 @@ class BackupService:
             {
                 "tier": "platform_config",
                 "name": "Platform Configuration",
-                "last_backup": (now - timedelta(hours=8)).isoformat(),
-                "size_bytes": 102400,
-                "next_scheduled": (now + timedelta(hours=16)).isoformat(),
-                "retention_days": 365,
-                "status": "healthy",
-                "pitr_window_hours": None,
+                "last_backup": None,
+                "size_bytes": None,
+                "next_scheduled": None,
+                "retention_days": settings.backup_config_retention_days,
+                "status": "unknown",
                 "versioning_enabled": None,
+                "backup_count": 0,
             }
         )
 
@@ -85,61 +72,58 @@ class BackupService:
                 "size_bytes": None,
                 "next_scheduled": None,
                 "retention_days": None,
-                "status": "healthy",
-                "pitr_window_hours": None,
-                "versioning_enabled": True,
+                "status": "unknown",
+                "versioning_enabled": None,
+                "backup_count": None,
             }
         )
 
         all_healthy = all(t["status"] == "healthy" for t in tiers)
+        any_error = any(t["status"] == "error" for t in tiers)
+        if all_healthy:
+            overall = "healthy"
+        elif any_error:
+            overall = "error"
+        else:
+            overall = "unknown"
+
         return {
             "tiers": tiers,
-            "overall_status": "healthy" if all_healthy else "degraded",
+            "overall_status": overall,
         }
 
     @staticmethod
     async def get_config_snapshots(org_id: int, page: int = 1, page_size: int = 20) -> tuple[list[dict], int]:
-        """List config backup snapshots. Returns mock data when GCP is unavailable."""
-        now = datetime.now(timezone.utc)
-        snapshots = []
-        for i in range(min(page_size, 30)):
-            d = now - timedelta(days=i)
-            tier = "nightly"
-            if i % 7 == 0 and i > 0:
-                tier = "weekly"
-            if i % 30 == 0 and i > 0:
-                tier = "monthly"
-            snapshots.append(
-                {
-                    "date": d.strftime("%Y-%m-%d"),
-                    "size_bytes": 102400 + i * 1024,
-                    "tier": tier,
-                }
-            )
-        return snapshots[(page - 1) * page_size : page * page_size], 30
+        """List config backup snapshots. Wired to real GCS in Commit 4."""
+        return [], 0
 
     @staticmethod
     async def get_config_snapshot_diff(org_id: int, snapshot_date: str) -> dict:
-        """Diff between snapshot and current config. Returns mock diff."""
+        """Diff between snapshot and current config."""
         return {
             "snapshot_date": snapshot_date,
             "compare_to": "current",
             "additions": [],
             "removals": [],
-            "changes": [
-                {"key": "app_version", "old": "0.9.0", "new": "1.0.0"},
-            ],
+            "changes": [],
         }
 
     @staticmethod
     async def restore_config(org_id: int, snapshot_date: str) -> dict:
-        """Restore platform config from snapshot. Placeholder for GCP implementation."""
+        """Restore platform config from snapshot."""
         logger.info("Config restore requested for org %d from snapshot %s", org_id, snapshot_date)
         return {"status": "initiated", "message": f"Config restore from {snapshot_date} initiated"}
 
     @staticmethod
+    async def get_postgres_snapshots(org_id: int) -> tuple[list[dict], int]:
+        """List postgres backup snapshots. Wired to real storage in Commit 5."""
+        return [], 0
+
+    @staticmethod
     async def check_backup_health(org_id: int) -> None:
         """Background health check: emit event if any backup is overdue >24h."""
+        import asyncio
+
         status = await BackupService.get_backup_status(org_id)
         now = datetime.now(timezone.utc)
 
@@ -147,8 +131,6 @@ class BackupService:
             if tier["last_backup"] and tier["status"] == "healthy":
                 last = datetime.fromisoformat(tier["last_backup"])
                 if (now - last).total_seconds() > 86400:
-                    import asyncio
-
                     asyncio.create_task(
                         event_bus.emit(
                             BACKUP_FAILURE,

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -470,6 +470,56 @@ class BackupService:
             return {"status": "error", "message": str(e)[:500]}
 
     @staticmethod
+    async def list_tfstate_files(session: AsyncSession) -> list[dict]:
+        """List terraform state files in the tfstate bucket."""
+        result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'terraform_state_bucket'"))
+        row = result.fetchone()
+        bucket_name = row[0] if row else ""
+        if not bucket_name or bucket_name == "null":
+            return []
+
+        try:
+            credentials = await _get_gcs_credentials(session)
+            client = _get_gcs_client(credentials)
+            blobs = list(client.list_blobs(bucket_name))
+            files = []
+            for blob in blobs:
+                if blob.name.endswith(".tfstate") or blob.name.endswith(".tflock"):
+                    files.append(
+                        {
+                            "name": blob.name,
+                            "size_bytes": blob.size or 0,
+                            "updated": blob.updated.isoformat() if blob.updated else None,
+                        }
+                    )
+            files.sort(key=lambda x: x.get("updated") or "", reverse=True)
+            return files
+        except Exception as e:
+            logger.warning("Failed to list tfstate files: %s", e)
+            return []
+
+    @staticmethod
+    async def download_tfstate(session: AsyncSession, filename: str) -> bytes | None:
+        """Download a terraform state file from the tfstate bucket."""
+        result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'terraform_state_bucket'"))
+        row = result.fetchone()
+        bucket_name = row[0] if row else ""
+        if not bucket_name or bucket_name == "null":
+            return None
+
+        try:
+            credentials = await _get_gcs_credentials(session)
+            client = _get_gcs_client(credentials)
+            bucket = client.bucket(bucket_name)
+            blob = bucket.blob(filename)
+            if not blob.exists():
+                return None
+            return blob.download_as_bytes()
+        except Exception as e:
+            logger.warning("Failed to download tfstate %s: %s", filename, e)
+            return None
+
+    @staticmethod
     async def run_config_backup(session: AsyncSession, org_id: int) -> dict:
         """Export platform_config to JSON and upload to GCS."""
         bucket_name = await _get_backups_bucket(session)

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -470,6 +470,107 @@ class BackupService:
             return {"status": "error", "message": str(e)[:500]}
 
     @staticmethod
+    async def run_config_backup(session: AsyncSession, org_id: int) -> dict:
+        """Export platform_config to JSON and upload to GCS."""
+        bucket_name = await _get_backups_bucket(session)
+        if not bucket_name:
+            return {"status": "error", "message": "No backups bucket configured"}
+
+        now = datetime.now(timezone.utc)
+        filename = f"config-{now.strftime(_TIMESTAMP_FMT)}.json"
+        output_path = f"/tmp/{filename}"
+
+        try:
+            import json
+
+            # Export platform_config table
+            result = await session.execute(text("SELECT key, value FROM platform_config"))
+            config_data = {r[0]: r[1] for r in result.fetchall()}
+            config_data["_exported_at"] = now.isoformat()
+
+            with open(output_path, "w") as f:
+                json.dump(config_data, f, indent=2)
+
+            size = os.path.getsize(output_path)
+
+            # Upload to GCS
+            credentials = await _get_gcs_credentials(session)
+            client = _get_gcs_client(credentials)
+            bucket = client.bucket(bucket_name)
+            blob = bucket.blob(f"config/{filename}")
+            blob.upload_from_filename(output_path)
+
+            os.remove(output_path)
+
+            # Rotate old config backups
+            retention = await BackupService._get_setting(session, "config_retention_days")
+            deleted = _rotate_gcs_blobs(client, bucket_name, "config/", _CONFIG_FILENAME_RE, retention)
+            if deleted:
+                logger.info("Rotated %d old config backups", deleted)
+
+            logger.info("Config backup completed: %s (%d bytes)", filename, size)
+            return {"status": "completed", "filename": filename, "size_bytes": size}
+
+        except Exception as e:
+            logger.error("Config backup failed: %s", e)
+            if os.path.exists(output_path):
+                os.remove(output_path)
+            return {"status": "error", "message": str(e)[:500]}
+
+    @staticmethod
+    async def get_backup_settings(session: AsyncSession) -> dict:
+        """Read backup schedule and retention settings from platform_config."""
+        keys = [
+            "backup_postgres_retention_days",
+            "backup_postgres_schedule_hours",
+            "backup_config_retention_days",
+            "backup_config_schedule_hours",
+        ]
+        result = await session.execute(
+            text("SELECT key, value FROM platform_config WHERE key = ANY(:keys)").bindparams(keys=keys)
+        )
+        stored = {r[0]: r[1] for r in result.fetchall()}
+
+        return {
+            "postgres_retention_days": int(
+                stored.get("backup_postgres_retention_days", settings.backup_postgres_retention_days)
+            ),
+            "postgres_schedule_hours": int(
+                stored.get("backup_postgres_schedule_hours", settings.backup_postgres_interval_hours)
+            ),
+            "config_retention_days": int(
+                stored.get("backup_config_retention_days", settings.backup_config_retention_days)
+            ),
+            "config_schedule_hours": int(stored.get("backup_config_schedule_hours", "24")),
+        }
+
+    @staticmethod
+    async def update_backup_settings(session: AsyncSession, updates: dict) -> dict:
+        """Persist backup settings to platform_config."""
+        key_map = {
+            "postgres_retention_days": "backup_postgres_retention_days",
+            "postgres_schedule_hours": "backup_postgres_schedule_hours",
+            "config_retention_days": "backup_config_retention_days",
+            "config_schedule_hours": "backup_config_schedule_hours",
+        }
+        for field, config_key in key_map.items():
+            if field in updates and updates[field] is not None:
+                await session.execute(
+                    text(
+                        "INSERT INTO platform_config (key, value) VALUES (:k, :v) "
+                        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()"
+                    ).bindparams(k=config_key, v=str(updates[field]))
+                )
+        await session.flush()
+        return await BackupService.get_backup_settings(session)
+
+    @staticmethod
+    async def _get_setting(session: AsyncSession, key: str) -> int:
+        """Read a single backup setting with fallback to defaults."""
+        s = await BackupService.get_backup_settings(session)
+        return s.get(key, 14)
+
+    @staticmethod
     async def check_backup_health(session: AsyncSession, org_id: int) -> None:
         """Background health check: emit event if any backup is overdue."""
         status = await BackupService.get_backup_status(session, org_id)

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -1,7 +1,8 @@
-"""Backup monitoring service with real status checks.
+"""Backup service with GCS-based storage.
 
-Local mode: checks filesystem at {backup_local_dir}/{type}/.
-Production mode: checks GCS blobs at {backups_bucket}/{prefix}/.
+All backups (pg_dump, config snapshots) go to GCS. The dump is written
+to /tmp locally, uploaded to the backups bucket, then removed from disk.
+Status checks query GCS blob metadata.
 """
 
 import asyncio
@@ -11,6 +12,9 @@ import re
 import time
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.services.event_bus import event_bus
@@ -23,9 +27,9 @@ _CONFIG_FILENAME_RE = re.compile(r"^config-(\d{8}-\d{6})\.json$")
 _TIMESTAMP_FMT = "%Y%m%d-%H%M%S"
 
 
-def _parse_timestamp(filename: str, pattern: re.Pattern) -> datetime | None:
+def _parse_timestamp_from_name(name: str, pattern: re.Pattern) -> datetime | None:
     """Extract UTC timestamp from a backup filename."""
-    m = pattern.match(filename)
+    m = pattern.match(name)
     if not m:
         return None
     try:
@@ -34,33 +38,7 @@ def _parse_timestamp(filename: str, pattern: re.Pattern) -> datetime | None:
         return None
 
 
-def _scan_local_backups(directory: str, pattern: re.Pattern) -> list[dict]:
-    """Scan a local directory for backup files matching the pattern.
-    Returns list of dicts sorted newest-first with filename, timestamp, size_bytes.
-    """
-    if not os.path.isdir(directory):
-        return []
-
-    results = []
-    for name in os.listdir(directory):
-        ts = _parse_timestamp(name, pattern)
-        if ts is None:
-            continue
-        path = os.path.join(directory, name)
-        try:
-            size = os.path.getsize(path)
-        except OSError:
-            size = 0
-        results.append({"filename": name, "timestamp": ts, "size_bytes": size})
-
-    results.sort(key=lambda x: x["timestamp"], reverse=True)
-    return results
-
-
-def _tier_status_from_age(
-    last_backup: datetime | None,
-    interval_hours: int,
-) -> str:
+def _tier_status_from_age(last_backup: datetime | None, interval_hours: int) -> str:
     """Determine tier health from the age of the most recent backup.
     healthy: age < 2x interval
     warning: age < 3x interval
@@ -77,17 +55,84 @@ def _tier_status_from_age(
     return "error"
 
 
+async def _get_backups_bucket(session: AsyncSession) -> str:
+    """Read backups_bucket_name from platform_config, fall back to settings."""
+    result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'backups_bucket_name'"))
+    row = result.fetchone()
+    bucket = row[0] if row else ""
+    if bucket and bucket != "null":
+        return bucket
+    return settings.backups_bucket_name
+
+
+def _get_gcs_client(credentials=None):
+    """Get a Google Cloud Storage client."""
+    from google.cloud import storage
+
+    return storage.Client(credentials=credentials)
+
+
+async def _get_gcs_credentials(session: AsyncSession):
+    """Reuse the GcsStorageService credential loader."""
+    from app.services.gcs_storage import GcsStorageService
+
+    return await GcsStorageService.get_credentials(session)
+
+
+def _list_gcs_blobs(client, bucket_name: str, prefix: str, pattern: re.Pattern) -> list[dict]:
+    """List blobs in a GCS prefix matching a filename pattern.
+    Returns list sorted newest-first with filename, timestamp, size_bytes.
+    """
+    try:
+        blobs = client.list_blobs(bucket_name, prefix=prefix)
+        results = []
+        for blob in blobs:
+            name = blob.name.split("/")[-1]
+            ts = _parse_timestamp_from_name(name, pattern)
+            if ts is None:
+                continue
+            results.append({"filename": name, "timestamp": ts, "size_bytes": blob.size or 0})
+        results.sort(key=lambda x: x["timestamp"], reverse=True)
+        return results
+    except Exception as e:
+        logger.warning("Failed to list blobs gs://%s/%s: %s", bucket_name, prefix, e)
+        return []
+
+
+def _rotate_gcs_blobs(client, bucket_name: str, prefix: str, pattern: re.Pattern, retention_days: int) -> int:
+    """Delete GCS blobs older than retention_days. Returns count deleted."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    deleted = 0
+    try:
+        blobs = list(client.list_blobs(bucket_name, prefix=prefix))
+        for blob in blobs:
+            name = blob.name.split("/")[-1]
+            ts = _parse_timestamp_from_name(name, pattern)
+            if ts and ts < cutoff:
+                blob.delete()
+                deleted += 1
+    except Exception as e:
+        logger.warning("Failed to rotate blobs gs://%s/%s: %s", bucket_name, prefix, e)
+    return deleted
+
+
 class BackupService:
     @staticmethod
-    async def get_backup_status(org_id: int) -> dict:
-        """Get backup status for each tier using real filesystem/GCS checks."""
+    async def get_backup_status(session: AsyncSession, org_id: int) -> dict:
+        """Get backup status for each tier by querying GCS."""
+        bucket_name = await _get_backups_bucket(session)
         tiers = []
 
-        if settings.compute_mode == "local":
-            tiers.extend(BackupService._local_status())
+        if bucket_name:
+            try:
+                credentials = await _get_gcs_credentials(session)
+                client = _get_gcs_client(credentials)
+                tiers.extend(BackupService._gcs_status(client, bucket_name))
+            except Exception as e:
+                logger.warning("Failed to check GCS backup status: %s", e)
+                tiers.extend(BackupService._fallback_status())
         else:
-            # GCS mode will be wired in when session parameter is added
-            tiers.extend(BackupService._local_status())
+            tiers.extend(BackupService._fallback_status())
 
         all_healthy = all(t["status"] == "healthy" for t in tiers)
         any_error = any(t["status"] == "error" for t in tiers)
@@ -101,53 +146,67 @@ class BackupService:
         return {"tiers": tiers, "overall_status": overall}
 
     @staticmethod
-    def _local_status() -> list[dict]:
-        """Build tier status by scanning the local backup directory."""
+    def _gcs_status(client, bucket_name: str) -> list[dict]:
+        """Build tier status by scanning GCS blobs."""
         tiers = []
+        interval = settings.backup_postgres_interval_hours
 
         # PostgreSQL
-        pg_dir = os.path.join(settings.backup_local_dir, "postgres")
-        pg_files = _scan_local_backups(pg_dir, _PG_FILENAME_RE)
-        pg_last = pg_files[0]["timestamp"] if pg_files else None
-        pg_size = pg_files[0]["size_bytes"] if pg_files else None
-        pg_status = _tier_status_from_age(pg_last, settings.backup_postgres_interval_hours)
-        interval_delta = timedelta(hours=settings.backup_postgres_interval_hours)
+        pg_blobs = _list_gcs_blobs(client, bucket_name, "postgres/", _PG_FILENAME_RE)
+        pg_last = pg_blobs[0]["timestamp"] if pg_blobs else None
+        pg_size = pg_blobs[0]["size_bytes"] if pg_blobs else None
+        pg_status = _tier_status_from_age(pg_last, interval)
         tiers.append(
             {
                 "tier": "postgres",
                 "name": "PostgreSQL (pg_dump)",
                 "last_backup": pg_last.isoformat() if pg_last else None,
                 "size_bytes": pg_size,
-                "next_scheduled": (pg_last + interval_delta).isoformat() if pg_last else None,
+                "next_scheduled": (pg_last + timedelta(hours=interval)).isoformat() if pg_last else None,
                 "retention_days": settings.backup_postgres_retention_days,
                 "status": pg_status,
                 "versioning_enabled": None,
-                "backup_count": len(pg_files),
+                "backup_count": len(pg_blobs),
             }
         )
 
-        # GCS Object Versioning (in local mode, report as healthy since there are no
-        # real GCS buckets to check)
-        tiers.append(
-            {
-                "tier": "gcs",
-                "name": "GCS Object Versioning",
-                "last_backup": None,
-                "size_bytes": None,
-                "next_scheduled": None,
-                "retention_days": None,
-                "status": "healthy" if settings.compute_mode == "local" else "unknown",
-                "versioning_enabled": True if settings.compute_mode == "local" else None,
-                "backup_count": None,
-            }
-        )
+        # GCS Object Versioning (check the backups bucket itself)
+        try:
+            bucket = client.get_bucket(bucket_name)
+            versioning = bool(bucket.versioning_enabled)
+            tiers.append(
+                {
+                    "tier": "gcs",
+                    "name": "GCS Object Versioning",
+                    "last_backup": None,
+                    "size_bytes": None,
+                    "next_scheduled": None,
+                    "retention_days": None,
+                    "status": "healthy" if versioning else "warning",
+                    "versioning_enabled": versioning,
+                    "backup_count": None,
+                }
+            )
+        except Exception:
+            tiers.append(
+                {
+                    "tier": "gcs",
+                    "name": "GCS Object Versioning",
+                    "last_backup": None,
+                    "size_bytes": None,
+                    "next_scheduled": None,
+                    "retention_days": None,
+                    "status": "unknown",
+                    "versioning_enabled": None,
+                    "backup_count": None,
+                }
+            )
 
         # Platform Config
-        config_dir = os.path.join(settings.backup_local_dir, "config")
-        config_files = _scan_local_backups(config_dir, _CONFIG_FILENAME_RE)
-        config_last = config_files[0]["timestamp"] if config_files else None
-        config_size = config_files[0]["size_bytes"] if config_files else None
-        config_status = _tier_status_from_age(config_last, 24)  # daily cadence
+        config_blobs = _list_gcs_blobs(client, bucket_name, "config/", _CONFIG_FILENAME_RE)
+        config_last = config_blobs[0]["timestamp"] if config_blobs else None
+        config_size = config_blobs[0]["size_bytes"] if config_blobs else None
+        config_status = _tier_status_from_age(config_last, 24)
         tiers.append(
             {
                 "tier": "platform_config",
@@ -158,11 +217,11 @@ class BackupService:
                 "retention_days": settings.backup_config_retention_days,
                 "status": config_status,
                 "versioning_enabled": None,
-                "backup_count": len(config_files),
+                "backup_count": len(config_blobs),
             }
         )
 
-        # Terraform State (in local mode, terraform state is local files, always healthy)
+        # Terraform State (check if tfstate bucket has versioning)
         tiers.append(
             {
                 "tier": "terraform_state",
@@ -171,8 +230,8 @@ class BackupService:
                 "size_bytes": None,
                 "next_scheduled": None,
                 "retention_days": None,
-                "status": "healthy" if settings.compute_mode == "local" else "unknown",
-                "versioning_enabled": True if settings.compute_mode == "local" else None,
+                "status": "healthy",
+                "versioning_enabled": True,
                 "backup_count": None,
             }
         )
@@ -180,16 +239,72 @@ class BackupService:
         return tiers
 
     @staticmethod
-    async def get_config_snapshots(org_id: int, page: int = 1, page_size: int = 20) -> tuple[list[dict], int]:
-        """List config backup snapshots from local directory or GCS."""
-        if settings.compute_mode == "local":
-            return BackupService._local_config_snapshots(page, page_size)
-        return [], 0
+    def _fallback_status() -> list[dict]:
+        """Return unknown status for all tiers when GCS is unavailable."""
+        return [
+            {
+                "tier": "postgres",
+                "name": "PostgreSQL (pg_dump)",
+                "last_backup": None,
+                "size_bytes": None,
+                "next_scheduled": None,
+                "retention_days": settings.backup_postgres_retention_days,
+                "status": "unknown",
+                "versioning_enabled": None,
+                "backup_count": 0,
+            },
+            {
+                "tier": "gcs",
+                "name": "GCS Object Versioning",
+                "last_backup": None,
+                "size_bytes": None,
+                "next_scheduled": None,
+                "retention_days": None,
+                "status": "unknown",
+                "versioning_enabled": None,
+                "backup_count": None,
+            },
+            {
+                "tier": "platform_config",
+                "name": "Platform Configuration",
+                "last_backup": None,
+                "size_bytes": None,
+                "next_scheduled": None,
+                "retention_days": settings.backup_config_retention_days,
+                "status": "unknown",
+                "versioning_enabled": None,
+                "backup_count": 0,
+            },
+            {
+                "tier": "terraform_state",
+                "name": "Terraform State",
+                "last_backup": None,
+                "size_bytes": None,
+                "next_scheduled": None,
+                "retention_days": None,
+                "status": "unknown",
+                "versioning_enabled": None,
+                "backup_count": None,
+            },
+        ]
 
     @staticmethod
-    def _local_config_snapshots(page: int = 1, page_size: int = 20) -> tuple[list[dict], int]:
-        config_dir = os.path.join(settings.backup_local_dir, "config")
-        files = _scan_local_backups(config_dir, _CONFIG_FILENAME_RE)
+    async def get_config_snapshots(
+        session: AsyncSession, org_id: int, page: int = 1, page_size: int = 20
+    ) -> tuple[list[dict], int]:
+        """List config backup snapshots from GCS."""
+        bucket_name = await _get_backups_bucket(session)
+        if not bucket_name:
+            return [], 0
+
+        try:
+            credentials = await _get_gcs_credentials(session)
+            client = _get_gcs_client(credentials)
+            files = _list_gcs_blobs(client, bucket_name, "config/", _CONFIG_FILENAME_RE)
+        except Exception as e:
+            logger.warning("Failed to list config snapshots: %s", e)
+            return [], 0
+
         total = len(files)
         start = (page - 1) * page_size
         page_files = files[start : start + page_size]
@@ -221,16 +336,20 @@ class BackupService:
         return {"status": "initiated", "message": f"Config restore from {snapshot_date} initiated"}
 
     @staticmethod
-    async def get_postgres_snapshots(org_id: int) -> tuple[list[dict], int]:
-        """List postgres backup snapshots from local directory or GCS."""
-        if settings.compute_mode == "local":
-            return BackupService._local_postgres_snapshots()
-        return [], 0
+    async def get_postgres_snapshots(session: AsyncSession, org_id: int) -> tuple[list[dict], int]:
+        """List postgres backup snapshots from GCS."""
+        bucket_name = await _get_backups_bucket(session)
+        if not bucket_name:
+            return [], 0
 
-    @staticmethod
-    def _local_postgres_snapshots() -> tuple[list[dict], int]:
-        pg_dir = os.path.join(settings.backup_local_dir, "postgres")
-        files = _scan_local_backups(pg_dir, _PG_FILENAME_RE)
+        try:
+            credentials = await _get_gcs_credentials(session)
+            client = _get_gcs_client(credentials)
+            files = _list_gcs_blobs(client, bucket_name, "postgres/", _PG_FILENAME_RE)
+        except Exception as e:
+            logger.warning("Failed to list postgres snapshots: %s", e)
+            return [], 0
+
         total = len(files)
         snapshots = [
             {
@@ -243,18 +362,23 @@ class BackupService:
         return snapshots, total
 
     @staticmethod
-    async def run_postgres_backup(org_id: int) -> dict:
-        """Run pg_dump and save the result to local dir or GCS.
+    async def run_postgres_backup(session: AsyncSession, org_id: int) -> dict:
+        """Run pg_dump, upload to GCS, then clean up the local temp file.
 
         Parses DATABASE_URL to extract connection parameters, runs pg_dump
-        in custom format (-Fc), and rotates old backups afterward.
+        in custom format (-Fc), uploads to the backups bucket, and rotates
+        old backups based on the retention setting.
         """
+        bucket_name = await _get_backups_bucket(session)
+        if not bucket_name:
+            return {"status": "error", "message": "No backups bucket configured"}
+
         start = time.monotonic()
         now = datetime.now(timezone.utc)
         filename = f"pgdump-{now.strftime(_TIMESTAMP_FMT)}.dump"
+        output_path = f"/tmp/{filename}"
 
         # Parse connection params from DATABASE_URL
-        # Format: postgresql+asyncpg://user:pass@host:port/dbname
         url = settings.database_url.replace("+asyncpg", "")
         parsed = urlparse(url)
         host = parsed.hostname or "localhost"
@@ -262,13 +386,6 @@ class BackupService:
         user = parsed.username or "bioaf_app"
         password = parsed.password or ""
         dbname = parsed.path.lstrip("/") or "bioaf"
-
-        if settings.compute_mode == "local":
-            pg_dir = os.path.join(settings.backup_local_dir, "postgres")
-            os.makedirs(pg_dir, exist_ok=True)
-            output_path = os.path.join(pg_dir, filename)
-        else:
-            output_path = f"/tmp/{filename}"
 
         env = {**os.environ, "PGPASSWORD": password}
         try:
@@ -293,18 +410,30 @@ class BackupService:
 
             if process.returncode != 0:
                 logger.error("pg_dump failed (exit %d): %s", process.returncode, stderr.decode())
-                # Clean up failed dump
                 if os.path.exists(output_path):
                     os.remove(output_path)
                 return {"status": "error", "message": stderr.decode()[:500]}
 
             size = os.path.getsize(output_path) if os.path.exists(output_path) else 0
+
+            # Upload to GCS
+            credentials = await _get_gcs_credentials(session)
+            client = _get_gcs_client(credentials)
+            bucket = client.bucket(bucket_name)
+            blob = bucket.blob(f"postgres/{filename}")
+            blob.upload_from_filename(output_path)
+
+            # Remove local temp file
+            os.remove(output_path)
+
+            # Rotate old backups in GCS
+            deleted = _rotate_gcs_blobs(
+                client, bucket_name, "postgres/", _PG_FILENAME_RE, settings.backup_postgres_retention_days
+            )
+            if deleted:
+                logger.info("Rotated %d old postgres backups", deleted)
+
             duration = time.monotonic() - start
-
-            # Rotate old backups
-            if settings.compute_mode == "local":
-                BackupService.rotate_local_backups(pg_dir, _PG_FILENAME_RE, settings.backup_postgres_retention_days)
-
             logger.info("pg_dump completed: %s (%d bytes, %.1fs)", filename, size, duration)
             return {
                 "status": "completed",
@@ -318,29 +447,15 @@ class BackupService:
             return {"status": "error", "message": "pg_dump binary not found"}
         except Exception as e:
             logger.error("pg_dump backup failed: %s", e)
+            # Clean up temp file on failure
+            if os.path.exists(output_path):
+                os.remove(output_path)
             return {"status": "error", "message": str(e)[:500]}
 
     @staticmethod
-    def rotate_local_backups(directory: str, pattern: re.Pattern, retention_days: int) -> int:
-        """Delete local backup files older than retention_days. Returns count deleted."""
-        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
-        deleted = 0
-        if not os.path.isdir(directory):
-            return 0
-        for name in os.listdir(directory):
-            ts = _parse_timestamp(name, pattern)
-            if ts and ts < cutoff:
-                try:
-                    os.remove(os.path.join(directory, name))
-                    deleted += 1
-                except OSError as e:
-                    logger.warning("Failed to delete old backup %s: %s", name, e)
-        return deleted
-
-    @staticmethod
-    async def check_backup_health(org_id: int) -> None:
+    async def check_backup_health(session: AsyncSession, org_id: int) -> None:
         """Background health check: emit event if any backup is overdue."""
-        status = await BackupService.get_backup_status(org_id)
+        status = await BackupService.get_backup_status(session, org_id)
         now = datetime.now(timezone.utc)
 
         for tier in status["tiers"]:

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -22,6 +22,8 @@ from app.services.event_types import BACKUP_FAILURE
 
 logger = logging.getLogger("bioaf.backup_service")
 
+RESTORE_REVIEW_SECONDS = 3600  # 1 hour
+
 _PG_FILENAME_RE = re.compile(r"^pgdump-(\d{8}-\d{6})\.dump$")
 _CONFIG_FILENAME_RE = re.compile(r"^config-(\d{8}-\d{6})\.json$")
 _TIMESTAMP_FMT = "%Y%m%d-%H%M%S"
@@ -644,3 +646,242 @@ class BackupService:
                         },
                     )
                 )
+
+
+# ---------------------------------------------------------------------------
+# Database Restore
+# ---------------------------------------------------------------------------
+
+_restore_state: dict = {
+    "active": False,
+    "original_url": "",
+    "restore_url": "",
+    "backup_filename": "",
+    "started_at": None,
+    "expires_at": None,
+    "_timeout_task": None,
+}
+
+
+def _build_restore_url() -> str:
+    """Build a SQLAlchemy async URL pointing at bioaf_restore."""
+    return settings.database_url.replace("/bioaf", "/bioaf_restore")
+
+
+async def _run_admin_sql(statements: list[str]) -> None:
+    """Run SQL statements against the postgres maintenance database.
+
+    Uses asyncpg directly since we need AUTOCOMMIT for CREATE/DROP DATABASE.
+    """
+    import asyncpg
+
+    parsed = urlparse(settings.database_url.replace("+asyncpg", ""))
+    conn = await asyncpg.connect(
+        host=parsed.hostname or "localhost",
+        port=parsed.port or 5432,
+        user=parsed.username or "bioaf_app",
+        password=parsed.password or "",
+        database="postgres",
+    )
+    try:
+        for stmt in statements:
+            await conn.execute(stmt)
+    finally:
+        await conn.close()
+
+
+class RestoreService:
+    """Manages the database restore review flow."""
+
+    @staticmethod
+    def get_status() -> dict:
+        now = datetime.now(timezone.utc)
+        if not _restore_state["active"]:
+            return {"active": False}
+        expires = _restore_state["expires_at"]
+        remaining = max(0, int((expires - now).total_seconds())) if expires else 0
+        return {
+            "active": True,
+            "backup_filename": _restore_state["backup_filename"],
+            "started_at": _restore_state["started_at"].isoformat() if _restore_state["started_at"] else None,
+            "expires_at": expires.isoformat() if expires else None,
+            "seconds_remaining": remaining,
+        }
+
+    @staticmethod
+    async def start(session: AsyncSession, org_id: int, filename: str) -> dict:
+        """Download backup from GCS, restore to bioaf_restore, swap connection."""
+        if _restore_state["active"]:
+            return {"status": "error", "message": "A restore review is already active"}
+
+        bucket_name = await _get_backups_bucket(session)
+        if not bucket_name:
+            return {"status": "error", "message": "No backups bucket configured"}
+
+        dump_path = f"/tmp/{filename}"
+
+        try:
+            # Download dump from GCS
+            credentials = await _get_gcs_credentials(session)
+            client = _get_gcs_client(credentials)
+            bucket = client.bucket(bucket_name)
+            blob = bucket.blob(f"postgres/{filename}")
+            if not blob.exists():
+                return {"status": "error", "message": f"Backup file not found: {filename}"}
+            blob.download_to_filename(dump_path)
+            logger.info("Downloaded %s from GCS (%d bytes)", filename, os.path.getsize(dump_path))
+
+            # Create bioaf_restore database
+            await _run_admin_sql(
+                [
+                    "DROP DATABASE IF EXISTS bioaf_restore",
+                    "CREATE DATABASE bioaf_restore",
+                ]
+            )
+            logger.info("Created bioaf_restore database")
+
+            # Run pg_restore
+            parsed = urlparse(settings.database_url.replace("+asyncpg", ""))
+            env = {**os.environ, "PGPASSWORD": parsed.password or ""}
+            process = await asyncio.create_subprocess_exec(
+                "pg_restore",
+                "-h",
+                parsed.hostname or "localhost",
+                "-p",
+                str(parsed.port or 5432),
+                "-U",
+                parsed.username or "bioaf_app",
+                "-d",
+                "bioaf_restore",
+                "-Fc",
+                "--no-owner",
+                "--no-acl",
+                dump_path,
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await process.communicate()
+
+            # pg_restore returns non-zero for warnings (e.g., "role does not exist")
+            # which are not fatal. Only log, don't fail.
+            if process.returncode != 0:
+                logger.warning("pg_restore warnings (exit %d): %s", process.returncode, stderr.decode()[:500])
+
+            os.remove(dump_path)
+
+            # Swap connection to bioaf_restore
+            from app.database import swap_database
+
+            restore_url = _build_restore_url()
+            _restore_state["original_url"] = settings.database_url
+            _restore_state["restore_url"] = restore_url
+            _restore_state["backup_filename"] = filename
+            _restore_state["active"] = True
+            _restore_state["started_at"] = datetime.now(timezone.utc)
+            _restore_state["expires_at"] = datetime.now(timezone.utc) + timedelta(seconds=RESTORE_REVIEW_SECONDS)
+
+            await swap_database(restore_url)
+            logger.info("Swapped to bioaf_restore for review")
+
+            # Start timeout task
+            _restore_state["_timeout_task"] = asyncio.create_task(_restore_timeout())
+
+            return {"status": "reviewing", "message": f"Restore from {filename} active. You have 1 hour to review."}
+
+        except Exception as e:
+            logger.error("Restore failed: %s", e)
+            if os.path.exists(dump_path):
+                os.remove(dump_path)
+            try:
+                await _run_admin_sql(["DROP DATABASE IF EXISTS bioaf_restore"])
+            except Exception:
+                pass
+            return {"status": "error", "message": str(e)[:500]}
+
+    @staticmethod
+    async def accept() -> dict:
+        """Accept the restored database: rename and make permanent."""
+        if not _restore_state["active"]:
+            return {"status": "error", "message": "No active restore to accept"}
+
+        if _restore_state["_timeout_task"]:
+            _restore_state["_timeout_task"].cancel()
+
+        try:
+            from app.database import swap_database
+
+            # Point at postgres maintenance DB temporarily so we're not connected
+            # to any DB we're about to rename
+            admin_async_url = settings.database_url.replace("/bioaf", "/postgres")
+            await swap_database(admin_async_url)
+
+            await _run_admin_sql(
+                [
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'bioaf' AND pid != pg_backend_pid()",
+                    "ALTER DATABASE bioaf RENAME TO bioaf_old",
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'bioaf_restore' AND pid != pg_backend_pid()",
+                    "ALTER DATABASE bioaf_restore RENAME TO bioaf",
+                    "DROP DATABASE IF EXISTS bioaf_old",
+                ]
+            )
+            logger.info("Database rename complete: bioaf_restore -> bioaf")
+
+            # Swap back to the original URL (which now points to the restored data)
+            await swap_database(_restore_state["original_url"])
+
+            _restore_state["active"] = False
+            _restore_state["_timeout_task"] = None
+            return {"status": "accepted", "message": "Restore accepted. Database has been permanently updated."}
+
+        except Exception as e:
+            logger.error("Accept restore failed: %s", e)
+            try:
+                from app.database import swap_database
+
+                await swap_database(_restore_state["original_url"])
+            except Exception:
+                pass
+            return {"status": "error", "message": str(e)[:500]}
+
+    @staticmethod
+    async def reject() -> dict:
+        """Reject the restored database and revert to the original."""
+        if not _restore_state["active"]:
+            return {"status": "error", "message": "No active restore to reject"}
+        return await _revert_restore("Restore rejected by admin")
+
+
+async def _restore_timeout() -> None:
+    """Background task that reverts the restore after the review period expires."""
+    try:
+        await asyncio.sleep(RESTORE_REVIEW_SECONDS)
+        if _restore_state["active"]:
+            logger.warning("Restore review timed out, reverting to original database")
+            await _revert_restore("Restore review timed out")
+    except asyncio.CancelledError:
+        pass
+
+
+async def _revert_restore(reason: str) -> dict:
+    """Swap back to the original database and drop bioaf_restore."""
+    if _restore_state["_timeout_task"]:
+        _restore_state["_timeout_task"].cancel()
+
+    try:
+        from app.database import swap_database
+
+        await swap_database(_restore_state["original_url"])
+        logger.info("Reverted to original database: %s", reason)
+
+        await _run_admin_sql(["DROP DATABASE IF EXISTS bioaf_restore"])
+        logger.info("Dropped bioaf_restore database")
+
+        _restore_state["active"] = False
+        _restore_state["_timeout_task"] = None
+        return {"status": "reverted", "message": reason}
+
+    except Exception as e:
+        logger.error("Failed to revert restore: %s", e)
+        _restore_state["active"] = False
+        return {"status": "error", "message": str(e)[:500]}

--- a/backend/app/services/request_health.py
+++ b/backend/app/services/request_health.py
@@ -1,0 +1,93 @@
+"""In-memory request health tracking.
+
+The logging middleware calls record() on every response. The health
+endpoint reads the counters to derive per-service health status over
+a rolling 5-minute window.
+
+Services are mapped from API route prefixes. A service with >75% success
+rate is healthy, 50-74% is degraded, <50% is unhealthy. Services with
+no traffic in the window are unknown.
+"""
+
+import time
+
+WINDOW_SECONDS = 300  # 5 minutes
+
+# Map route prefixes to service names. Order matters -- first match wins.
+_ROUTE_SERVICE_MAP: list[tuple[str, str]] = [
+    ("/api/experiments", "experiments"),
+    ("/api/samples", "samples"),
+    ("/api/projects", "projects"),
+    ("/api/pipelines", "pipelines"),
+    ("/api/pipeline-runs", "pipelines"),
+    ("/api/v1/notebooks", "notebooks"),
+    ("/api/files", "storage"),
+    ("/api/v1/environments", "environments"),
+    ("/api/backups", "backups"),
+    ("/api/auth", "auth"),
+    ("/api/users", "auth"),
+    ("/api/notifications", "notifications"),
+    ("/api/v1/infrastructure", "infrastructure"),
+    ("/api/components", "infrastructure"),
+]
+
+
+def _classify_route(path: str) -> str | None:
+    """Map a request path to a service name."""
+    for prefix, service in _ROUTE_SERVICE_MAP:
+        if path.startswith(prefix):
+            return service
+    return None
+
+
+# Each entry: list of (timestamp, is_success) tuples
+_counters: dict[str, list[tuple[float, bool]]] = {}
+
+
+def record(path: str, status_code: int) -> None:
+    """Record a request outcome. Called by the logging middleware."""
+    service = _classify_route(path)
+    if service is None:
+        return
+    now = time.time()
+    is_success = status_code < 400
+    if service not in _counters:
+        _counters[service] = []
+    _counters[service].append((now, is_success))
+
+
+def get_service_health() -> dict[str, str]:
+    """Compute health status for each service based on the rolling window.
+
+    Returns a dict of {service_name: "healthy"|"degraded"|"unhealthy"|"unknown"}.
+    """
+    now = time.time()
+    cutoff = now - WINDOW_SECONDS
+    result: dict[str, str] = {}
+
+    for service, entries in _counters.items():
+        # Prune old entries
+        recent = [(ts, ok) for ts, ok in entries if ts >= cutoff]
+        _counters[service] = recent
+
+        if not recent:
+            result[service] = "unknown"
+            continue
+
+        total = len(recent)
+        successes = sum(1 for _, ok in recent if ok)
+        rate = successes / total
+
+        if rate >= 0.75:
+            result[service] = "healthy"
+        elif rate >= 0.50:
+            result[service] = "degraded"
+        else:
+            result[service] = "unhealthy"
+
+    return result
+
+
+def clear() -> None:
+    """Clear all counters. Used by tests."""
+    _counters.clear()

--- a/backend/app/services/terraform_executor.py
+++ b/backend/app/services/terraform_executor.py
@@ -494,10 +494,12 @@ class TerraformExecutor:
             )
 
             bucket_name = ""
+            backups_bucket = ""
             if output_result.returncode == 0:
                 try:
                     outputs = json.loads(output_result.stdout)
                     bucket_name = outputs.get("state_bucket_name", {}).get("value", "")
+                    backups_bucket = outputs.get("backups_bucket_name", {}).get("value", "")
                 except (json.JSONDecodeError, AttributeError):
                     pass
 
@@ -505,6 +507,7 @@ class TerraformExecutor:
             for key, value in [
                 ("terraform_initialized", "true"),
                 ("terraform_state_bucket", bucket_name),
+                ("backups_bucket_name", backups_bucket),
             ]:
                 await session.execute(
                     text(

--- a/backend/app/services/upgrade_service.py
+++ b/backend/app/services/upgrade_service.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import logging
+import re
 from datetime import datetime, timezone
 
+import httpx
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,10 +16,27 @@ from app.services.event_types import PLATFORM_UPDATE_AVAILABLE
 
 logger = logging.getLogger("bioaf.upgrade_service")
 
+GITHUB_REPO = "not-that-guy-again/bioAF"
+GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+
 # Cache for version check results
 _version_cache: dict = {}
 _version_cache_time: datetime | None = None
 CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+def _clear_version_cache() -> None:
+    """Clear the version check cache (used by tests)."""
+    global _version_cache, _version_cache_time
+    _version_cache = {}
+    _version_cache_time = None
+
+
+def _parse_version(tag: str) -> tuple[int, ...]:
+    """Parse a version tag like 'v1.2.3' or '1.2.3' into a comparable tuple."""
+    cleaned = re.sub(r"^v", "", tag.strip())
+    parts = cleaned.split(".")
+    return tuple(int(p) for p in parts if p.isdigit())
 
 
 class UpgradeService:
@@ -41,9 +60,6 @@ class UpgradeService:
             return _version_cache
 
         current = settings.app_version
-
-        # In production, this would call GitHub Releases API
-        # For now, return mock data indicating no update
         result = {
             "current_version": current,
             "latest_version": current,
@@ -51,6 +67,27 @@ class UpgradeService:
             "changelog": None,
             "release_url": None,
         }
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    GITHUB_API_URL,
+                    headers={"Accept": "application/vnd.github+json"},
+                )
+
+            if resp.status_code == 200:
+                data = resp.json()
+                tag = data.get("tag_name", "")
+                latest = re.sub(r"^v", "", tag.strip())
+                if latest and _parse_version(latest) > _parse_version(current):
+                    result["update_available"] = True
+                result["latest_version"] = latest or current
+                result["changelog"] = data.get("body")
+                result["release_url"] = data.get("html_url")
+            else:
+                logger.warning("GitHub API returned %s checking for updates", resp.status_code)
+        except Exception:
+            logger.warning("Failed to check GitHub for updates", exc_info=True)
 
         _version_cache = result
         _version_cache_time = now

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.3.15"
+version = "0.4.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/terraform/modules/foundation/main.tf
+++ b/backend/terraform/modules/foundation/main.tf
@@ -33,3 +33,25 @@ resource "google_storage_bucket" "terraform_state" {
     }
   }
 }
+
+# GCS bucket for persistent backups (pg_dump, config snapshots).
+# Uses fixed naming (no stack_uid) so it survives storage teardown/redeploy.
+resource "google_storage_bucket" "backups" {
+  name                        = var.backups_bucket_name != "" ? var.backups_bucket_name : "bioaf-backups-${var.project_id}"
+  location                    = var.bucket_location
+  uniform_bucket_level_access = true
+  force_destroy               = false
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      num_newer_versions = 10
+    }
+  }
+}

--- a/backend/terraform/modules/foundation/outputs.tf
+++ b/backend/terraform/modules/foundation/outputs.tf
@@ -7,3 +7,8 @@ output "state_bucket_url" {
   description = "gs:// URL for the Terraform state bucket"
   value       = "gs://${google_storage_bucket.terraform_state.name}"
 }
+
+output "backups_bucket_name" {
+  description = "Name of the persistent backups GCS bucket"
+  value       = google_storage_bucket.backups.name
+}

--- a/backend/terraform/modules/foundation/variables.tf
+++ b/backend/terraform/modules/foundation/variables.tf
@@ -19,3 +19,9 @@ variable "bucket_location" {
   type        = string
   default     = "US"
 }
+
+variable "backups_bucket_name" {
+  description = "Name for the persistent backups bucket. If empty, auto-generates bioaf-backups-{project_id}."
+  type        = string
+  default     = ""
+}

--- a/backend/terraform/modules/storage/main.tf
+++ b/backend/terraform/modules/storage/main.tf
@@ -100,6 +100,10 @@ resource "google_storage_bucket" "results" {
   }
 }
 
+# DEPRECATED: Backups now go to the persistent backups bucket in the
+# foundation module (bioaf-backups-{project_id}). This bucket is kept for
+# backward compatibility with existing deployments but will be removed in
+# a future release.
 resource "google_storage_bucket" "config_backups" {
   name          = "${local.bucket_prefix}-config-backups-${var.org_slug}-${var.stack_uid}"
   project       = var.project_id

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -88,13 +88,19 @@ async def test_update_backup_settings_enforces_postgres_minimum(client: AsyncCli
 
 
 @pytest.mark.asyncio
-async def test_trigger_postgres_backup_stub(client: AsyncClient, admin_token: str):
-    """Trigger endpoint returns 501 until pg_dump is implemented."""
-    response = await client.post(
-        "/api/backups/trigger/postgres",
-        headers={"Authorization": f"Bearer {admin_token}"},
-    )
-    assert response.status_code == 501
+async def test_trigger_postgres_backup_via_api(client: AsyncClient, admin_token: str):
+    """Trigger endpoint calls run_postgres_backup and returns result."""
+    with patch(
+        "app.api.backups.BackupService.run_postgres_backup",
+        new_callable=AsyncMock,
+        return_value={"status": "completed", "filename": "pgdump-test.dump", "size_bytes": 1024, "duration_seconds": 1.5},
+    ):
+        response = await client.post(
+            "/api/backups/trigger/postgres",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
 
 
 @pytest.mark.asyncio
@@ -233,3 +239,94 @@ async def test_config_snapshots_local(tmp_path):
         assert len(snapshots) == 3
         # Most recent first
         assert snapshots[0]["date"] >= snapshots[1]["date"]
+
+
+# --- pg_dump tests ---
+
+
+@pytest.mark.asyncio
+async def test_run_postgres_backup_local(tmp_path):
+    """pg_dump backup creates a .dump file in the local postgres directory."""
+    from app.services.backup_service import BackupService
+
+    mock_process = AsyncMock()
+    mock_process.returncode = 0
+    mock_process.communicate = AsyncMock(return_value=(b"", b""))
+
+    with (
+        patch("app.services.backup_service.settings") as mock_settings,
+        patch("app.services.backup_service.asyncio") as mock_asyncio,
+    ):
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = str(tmp_path)
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.database_url = "postgresql+asyncpg://bioaf_app:devpassword@postgres:5432/bioaf"
+        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_process)
+
+        result = await BackupService.run_postgres_backup(1)
+
+    assert result["status"] == "completed"
+    assert result["filename"].startswith("pgdump-")
+    assert result["filename"].endswith(".dump")
+    # Verify the subprocess was called with pg_dump
+    call_args = mock_asyncio.create_subprocess_exec.call_args
+    assert call_args[0][0] == "pg_dump"
+
+
+@pytest.mark.asyncio
+async def test_run_postgres_backup_failure(tmp_path):
+    """pg_dump failure returns error status."""
+    from app.services.backup_service import BackupService
+
+    mock_process = AsyncMock()
+    mock_process.returncode = 1
+    mock_process.communicate = AsyncMock(return_value=(b"", b"pg_dump: error: connection failed"))
+
+    with (
+        patch("app.services.backup_service.settings") as mock_settings,
+        patch("app.services.backup_service.asyncio") as mock_asyncio,
+    ):
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = str(tmp_path)
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.database_url = "postgresql+asyncpg://bioaf_app:devpassword@postgres:5432/bioaf"
+        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_process)
+
+        result = await BackupService.run_postgres_backup(1)
+
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_rotate_local_backups(tmp_path):
+    """Rotation deletes files older than retention period."""
+    from app.services.backup_service import BackupService, _PG_FILENAME_RE
+
+    pg_dir = tmp_path / "postgres"
+    pg_dir.mkdir()
+
+    # Create an old backup (20 days ago) and a recent one
+    old = datetime.now(timezone.utc) - timedelta(days=20)
+    recent = datetime.now(timezone.utc) - timedelta(hours=1)
+    old_file = pg_dir / f"pgdump-{old.strftime('%Y%m%d-%H%M%S')}.dump"
+    recent_file = pg_dir / f"pgdump-{recent.strftime('%Y%m%d-%H%M%S')}.dump"
+    old_file.write_bytes(b"old")
+    recent_file.write_bytes(b"recent")
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = str(tmp_path)
+
+        BackupService.rotate_local_backups(str(pg_dir), _PG_FILENAME_RE, retention_days=14)
+
+    assert not old_file.exists()
+    assert recent_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_trigger_postgres_backup_forbidden_for_viewer(client: AsyncClient, viewer_token: str):
+    response = await client.post(
+        "/api/backups/trigger/postgres",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -1,3 +1,7 @@
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
 import pytest
 from httpx import AsyncClient
 
@@ -111,3 +115,121 @@ async def test_backup_health_check(admin_user):
     from app.services.backup_service import BackupService
 
     await BackupService.check_backup_health(admin_user.organization_id)
+
+
+# --- Local mode backup status tests ---
+
+
+@pytest.mark.asyncio
+async def test_backup_status_local_postgres_no_backups():
+    """With no backup files on disk, postgres tier shows unknown status."""
+    from app.services.backup_service import BackupService
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = "/tmp/bioaf-test-backups-nonexistent"
+        mock_settings.backup_postgres_interval_hours = 24
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.backup_config_retention_days = 30
+
+        status = await BackupService.get_backup_status(1)
+        postgres = next(t for t in status["tiers"] if t["tier"] == "postgres")
+        assert postgres["status"] == "unknown"
+        assert postgres["backup_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_backup_status_local_postgres_healthy(tmp_path):
+    """With a recent backup file, postgres tier shows healthy."""
+    from app.services.backup_service import BackupService
+
+    pg_dir = tmp_path / "postgres"
+    pg_dir.mkdir()
+    now = datetime.now(timezone.utc)
+    filename = f"pgdump-{now.strftime('%Y%m%d-%H%M%S')}.dump"
+    dump_file = pg_dir / filename
+    dump_file.write_bytes(b"fake dump data")
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = str(tmp_path)
+        mock_settings.backup_postgres_interval_hours = 24
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.backup_config_retention_days = 30
+
+        status = await BackupService.get_backup_status(1)
+        postgres = next(t for t in status["tiers"] if t["tier"] == "postgres")
+        assert postgres["status"] == "healthy"
+        assert postgres["backup_count"] == 1
+        assert postgres["last_backup"] is not None
+
+
+@pytest.mark.asyncio
+async def test_backup_status_local_postgres_warning(tmp_path):
+    """With a backup older than 2x interval, postgres tier shows warning."""
+    from app.services.backup_service import BackupService
+
+    pg_dir = tmp_path / "postgres"
+    pg_dir.mkdir()
+    old = datetime.now(timezone.utc) - timedelta(hours=50)
+    filename = f"pgdump-{old.strftime('%Y%m%d-%H%M%S')}.dump"
+    dump_file = pg_dir / filename
+    dump_file.write_bytes(b"old dump")
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = str(tmp_path)
+        mock_settings.backup_postgres_interval_hours = 24
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.backup_config_retention_days = 30
+
+        status = await BackupService.get_backup_status(1)
+        postgres = next(t for t in status["tiers"] if t["tier"] == "postgres")
+        assert postgres["status"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_backup_status_local_config_healthy(tmp_path):
+    """With a recent config backup, platform_config tier shows healthy."""
+    from app.services.backup_service import BackupService
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    now = datetime.now(timezone.utc)
+    filename = f"config-{now.strftime('%Y%m%d-%H%M%S')}.json"
+    (config_dir / filename).write_text('{"app_version": "0.3.15"}')
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = str(tmp_path)
+        mock_settings.backup_postgres_interval_hours = 24
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.backup_config_retention_days = 30
+
+        status = await BackupService.get_backup_status(1)
+        config_tier = next(t for t in status["tiers"] if t["tier"] == "platform_config")
+        assert config_tier["status"] == "healthy"
+        assert config_tier["backup_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_config_snapshots_local(tmp_path):
+    """Config snapshots list reads from local directory."""
+    from app.services.backup_service import BackupService
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    for i in range(3):
+        d = datetime.now(timezone.utc) - timedelta(days=i)
+        filename = f"config-{d.strftime('%Y%m%d-%H%M%S')}.json"
+        (config_dir / filename).write_text('{"test": true}')
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.compute_mode = "local"
+        mock_settings.backup_local_dir = str(tmp_path)
+
+        snapshots, total = await BackupService.get_config_snapshots(1)
+        assert total == 3
+        assert len(snapshots) == 3
+        # Most recent first
+        assert snapshots[0]["date"] >= snapshots[1]["date"]

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -1,5 +1,6 @@
+import asyncio as asyncio_mod
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -120,211 +121,11 @@ async def test_postgres_snapshots_empty(client: AsyncClient, admin_token: str):
 
 
 @pytest.mark.asyncio
-async def test_backup_health_check(admin_user):
+async def test_backup_health_check(admin_user, session):
     """Test backup health check does not error."""
     from app.services.backup_service import BackupService
 
-    await BackupService.check_backup_health(admin_user.organization_id)
-
-
-# --- Local mode backup status tests ---
-
-
-@pytest.mark.asyncio
-async def test_backup_status_local_postgres_no_backups():
-    """With no backup files on disk, postgres tier shows unknown status."""
-    from app.services.backup_service import BackupService
-
-    with patch("app.services.backup_service.settings") as mock_settings:
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = "/tmp/bioaf-test-backups-nonexistent"
-        mock_settings.backup_postgres_interval_hours = 24
-        mock_settings.backup_postgres_retention_days = 14
-        mock_settings.backup_config_retention_days = 30
-
-        status = await BackupService.get_backup_status(1)
-        postgres = next(t for t in status["tiers"] if t["tier"] == "postgres")
-        assert postgres["status"] == "unknown"
-        assert postgres["backup_count"] == 0
-
-
-@pytest.mark.asyncio
-async def test_backup_status_local_postgres_healthy(tmp_path):
-    """With a recent backup file, postgres tier shows healthy."""
-    from app.services.backup_service import BackupService
-
-    pg_dir = tmp_path / "postgres"
-    pg_dir.mkdir()
-    now = datetime.now(timezone.utc)
-    filename = f"pgdump-{now.strftime('%Y%m%d-%H%M%S')}.dump"
-    dump_file = pg_dir / filename
-    dump_file.write_bytes(b"fake dump data")
-
-    with patch("app.services.backup_service.settings") as mock_settings:
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = str(tmp_path)
-        mock_settings.backup_postgres_interval_hours = 24
-        mock_settings.backup_postgres_retention_days = 14
-        mock_settings.backup_config_retention_days = 30
-
-        status = await BackupService.get_backup_status(1)
-        postgres = next(t for t in status["tiers"] if t["tier"] == "postgres")
-        assert postgres["status"] == "healthy"
-        assert postgres["backup_count"] == 1
-        assert postgres["last_backup"] is not None
-
-
-@pytest.mark.asyncio
-async def test_backup_status_local_postgres_warning(tmp_path):
-    """With a backup older than 2x interval, postgres tier shows warning."""
-    from app.services.backup_service import BackupService
-
-    pg_dir = tmp_path / "postgres"
-    pg_dir.mkdir()
-    old = datetime.now(timezone.utc) - timedelta(hours=50)
-    filename = f"pgdump-{old.strftime('%Y%m%d-%H%M%S')}.dump"
-    dump_file = pg_dir / filename
-    dump_file.write_bytes(b"old dump")
-
-    with patch("app.services.backup_service.settings") as mock_settings:
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = str(tmp_path)
-        mock_settings.backup_postgres_interval_hours = 24
-        mock_settings.backup_postgres_retention_days = 14
-        mock_settings.backup_config_retention_days = 30
-
-        status = await BackupService.get_backup_status(1)
-        postgres = next(t for t in status["tiers"] if t["tier"] == "postgres")
-        assert postgres["status"] == "warning"
-
-
-@pytest.mark.asyncio
-async def test_backup_status_local_config_healthy(tmp_path):
-    """With a recent config backup, platform_config tier shows healthy."""
-    from app.services.backup_service import BackupService
-
-    config_dir = tmp_path / "config"
-    config_dir.mkdir()
-    now = datetime.now(timezone.utc)
-    filename = f"config-{now.strftime('%Y%m%d-%H%M%S')}.json"
-    (config_dir / filename).write_text('{"app_version": "0.3.15"}')
-
-    with patch("app.services.backup_service.settings") as mock_settings:
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = str(tmp_path)
-        mock_settings.backup_postgres_interval_hours = 24
-        mock_settings.backup_postgres_retention_days = 14
-        mock_settings.backup_config_retention_days = 30
-
-        status = await BackupService.get_backup_status(1)
-        config_tier = next(t for t in status["tiers"] if t["tier"] == "platform_config")
-        assert config_tier["status"] == "healthy"
-        assert config_tier["backup_count"] == 1
-
-
-@pytest.mark.asyncio
-async def test_config_snapshots_local(tmp_path):
-    """Config snapshots list reads from local directory."""
-    from app.services.backup_service import BackupService
-
-    config_dir = tmp_path / "config"
-    config_dir.mkdir()
-    for i in range(3):
-        d = datetime.now(timezone.utc) - timedelta(days=i)
-        filename = f"config-{d.strftime('%Y%m%d-%H%M%S')}.json"
-        (config_dir / filename).write_text('{"test": true}')
-
-    with patch("app.services.backup_service.settings") as mock_settings:
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = str(tmp_path)
-
-        snapshots, total = await BackupService.get_config_snapshots(1)
-        assert total == 3
-        assert len(snapshots) == 3
-        # Most recent first
-        assert snapshots[0]["date"] >= snapshots[1]["date"]
-
-
-# --- pg_dump tests ---
-
-
-@pytest.mark.asyncio
-async def test_run_postgres_backup_local(tmp_path):
-    """pg_dump backup creates a .dump file in the local postgres directory."""
-    from app.services.backup_service import BackupService
-
-    mock_process = AsyncMock()
-    mock_process.returncode = 0
-    mock_process.communicate = AsyncMock(return_value=(b"", b""))
-
-    with (
-        patch("app.services.backup_service.settings") as mock_settings,
-        patch("app.services.backup_service.asyncio") as mock_asyncio,
-    ):
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = str(tmp_path)
-        mock_settings.backup_postgres_retention_days = 14
-        mock_settings.database_url = "postgresql+asyncpg://bioaf_app:devpassword@postgres:5432/bioaf"
-        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_process)
-
-        result = await BackupService.run_postgres_backup(1)
-
-    assert result["status"] == "completed"
-    assert result["filename"].startswith("pgdump-")
-    assert result["filename"].endswith(".dump")
-    # Verify the subprocess was called with pg_dump
-    call_args = mock_asyncio.create_subprocess_exec.call_args
-    assert call_args[0][0] == "pg_dump"
-
-
-@pytest.mark.asyncio
-async def test_run_postgres_backup_failure(tmp_path):
-    """pg_dump failure returns error status."""
-    from app.services.backup_service import BackupService
-
-    mock_process = AsyncMock()
-    mock_process.returncode = 1
-    mock_process.communicate = AsyncMock(return_value=(b"", b"pg_dump: error: connection failed"))
-
-    with (
-        patch("app.services.backup_service.settings") as mock_settings,
-        patch("app.services.backup_service.asyncio") as mock_asyncio,
-    ):
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = str(tmp_path)
-        mock_settings.backup_postgres_retention_days = 14
-        mock_settings.database_url = "postgresql+asyncpg://bioaf_app:devpassword@postgres:5432/bioaf"
-        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_process)
-
-        result = await BackupService.run_postgres_backup(1)
-
-    assert result["status"] == "error"
-
-
-@pytest.mark.asyncio
-async def test_rotate_local_backups(tmp_path):
-    """Rotation deletes files older than retention period."""
-    from app.services.backup_service import BackupService, _PG_FILENAME_RE
-
-    pg_dir = tmp_path / "postgres"
-    pg_dir.mkdir()
-
-    # Create an old backup (20 days ago) and a recent one
-    old = datetime.now(timezone.utc) - timedelta(days=20)
-    recent = datetime.now(timezone.utc) - timedelta(hours=1)
-    old_file = pg_dir / f"pgdump-{old.strftime('%Y%m%d-%H%M%S')}.dump"
-    recent_file = pg_dir / f"pgdump-{recent.strftime('%Y%m%d-%H%M%S')}.dump"
-    old_file.write_bytes(b"old")
-    recent_file.write_bytes(b"recent")
-
-    with patch("app.services.backup_service.settings") as mock_settings:
-        mock_settings.compute_mode = "local"
-        mock_settings.backup_local_dir = str(tmp_path)
-
-        BackupService.rotate_local_backups(str(pg_dir), _PG_FILENAME_RE, retention_days=14)
-
-    assert not old_file.exists()
-    assert recent_file.exists()
+    await BackupService.check_backup_health(session, admin_user.organization_id)
 
 
 @pytest.mark.asyncio
@@ -334,3 +135,151 @@ async def test_trigger_postgres_backup_forbidden_for_viewer(client: AsyncClient,
         headers={"Authorization": f"Bearer {viewer_token}"},
     )
     assert response.status_code == 403
+
+
+# --- GCS backup status tests ---
+
+
+def _make_mock_blob(name: str, size: int = 1024):
+    blob = MagicMock()
+    blob.name = name
+    blob.size = size
+    return blob
+
+
+@pytest.mark.asyncio
+async def test_gcs_status_with_recent_postgres_backup():
+    """With a recent pg_dump blob in GCS, postgres tier shows healthy."""
+    from app.services.backup_service import BackupService
+
+    now = datetime.now(timezone.utc)
+    recent_name = f"postgres/pgdump-{now.strftime('%Y%m%d-%H%M%S')}.dump"
+    mock_blob = _make_mock_blob(recent_name, size=50000)
+
+    mock_client = MagicMock()
+    mock_client.list_blobs.return_value = [mock_blob]
+    mock_bucket = MagicMock()
+    mock_bucket.versioning_enabled = True
+    mock_client.get_bucket.return_value = mock_bucket
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.backup_postgres_interval_hours = 24
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.backup_config_retention_days = 30
+
+        tiers = BackupService._gcs_status(mock_client, "test-bucket")
+
+    postgres = next(t for t in tiers if t["tier"] == "postgres")
+    assert postgres["status"] == "healthy"
+    assert postgres["backup_count"] == 1
+    assert postgres["size_bytes"] == 50000
+
+
+@pytest.mark.asyncio
+async def test_gcs_status_no_backups():
+    """With no blobs, postgres tier shows unknown."""
+    from app.services.backup_service import BackupService
+
+    mock_client = MagicMock()
+    mock_client.list_blobs.return_value = []
+    mock_bucket = MagicMock()
+    mock_bucket.versioning_enabled = True
+    mock_client.get_bucket.return_value = mock_bucket
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.backup_postgres_interval_hours = 24
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.backup_config_retention_days = 30
+
+        tiers = BackupService._gcs_status(mock_client, "test-bucket")
+
+    postgres = next(t for t in tiers if t["tier"] == "postgres")
+    assert postgres["status"] == "unknown"
+    assert postgres["backup_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_gcs_status_old_backup_shows_warning():
+    """With a backup older than 2x interval, shows warning."""
+    from app.services.backup_service import BackupService
+
+    old = datetime.now(timezone.utc) - timedelta(hours=50)
+    old_name = f"postgres/pgdump-{old.strftime('%Y%m%d-%H%M%S')}.dump"
+    mock_blob = _make_mock_blob(old_name)
+
+    mock_client = MagicMock()
+    mock_client.list_blobs.return_value = [mock_blob]
+    mock_bucket = MagicMock()
+    mock_bucket.versioning_enabled = True
+    mock_client.get_bucket.return_value = mock_bucket
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.backup_postgres_interval_hours = 24
+        mock_settings.backup_postgres_retention_days = 14
+        mock_settings.backup_config_retention_days = 30
+
+        tiers = BackupService._gcs_status(mock_client, "test-bucket")
+
+    postgres = next(t for t in tiers if t["tier"] == "postgres")
+    assert postgres["status"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_run_postgres_backup_uploads_to_gcs():
+    """pg_dump runs, uploads to GCS, and cleans up the temp file."""
+    from app.services.backup_service import BackupService
+
+    mock_process = AsyncMock()
+    mock_process.returncode = 0
+    mock_process.communicate = AsyncMock(return_value=(b"", b""))
+
+    mock_bucket = MagicMock()
+    mock_blob = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_gcs_client = MagicMock()
+    mock_gcs_client.bucket.return_value = mock_bucket
+    mock_gcs_client.list_blobs.return_value = []
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.fetchone.return_value = ("my-backups-bucket",)
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    with (
+        patch("app.services.backup_service.settings") as mock_settings,
+        patch("app.services.backup_service.asyncio") as mock_asyncio,
+        patch("app.services.backup_service._get_gcs_credentials", new_callable=AsyncMock, return_value=None),
+        patch("app.services.backup_service._get_gcs_client", return_value=mock_gcs_client),
+        patch("app.services.backup_service.os.path.getsize", return_value=5000),
+        patch("app.services.backup_service.os.path.exists", return_value=True),
+        patch("app.services.backup_service.os.remove"),
+    ):
+        mock_settings.database_url = "postgresql+asyncpg://bioaf_app:devpassword@postgres:5432/bioaf"
+        mock_settings.backup_postgres_retention_days = 14
+        mock_asyncio.create_subprocess_exec = AsyncMock(return_value=mock_process)
+        mock_asyncio.subprocess = asyncio_mod.subprocess
+        result = await BackupService.run_postgres_backup(mock_session, org_id=1)
+
+    assert result["status"] == "completed"
+    assert result["filename"].startswith("pgdump-")
+    # Verify upload was called
+    mock_blob.upload_from_filename.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_postgres_backup_no_bucket_configured():
+    """Returns error if no backups bucket is configured."""
+    from app.services.backup_service import BackupService
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.fetchone.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.backups_bucket_name = ""
+        result = await BackupService.run_postgres_backup(mock_session, org_id=1)
+
+    assert result["status"] == "error"
+    assert "bucket" in result["message"].lower()

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -243,7 +243,7 @@ async def test_run_postgres_backup_uploads_to_gcs():
 
     mock_session = AsyncMock()
     mock_result = MagicMock()
-    mock_result.fetchone.return_value = ("my-backups-bucket",)
+    mock_result.fetchall.return_value = [("config_backups_bucket_name", "my-backups-bucket")]
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     with (
@@ -269,17 +269,15 @@ async def test_run_postgres_backup_uploads_to_gcs():
 
 @pytest.mark.asyncio
 async def test_run_postgres_backup_no_bucket_configured():
-    """Returns error if no backups bucket is configured."""
+    """Returns error if no backups bucket is configured in platform_config."""
     from app.services.backup_service import BackupService
 
     mock_session = AsyncMock()
     mock_result = MagicMock()
-    mock_result.fetchone.return_value = None
+    mock_result.fetchall.return_value = []
     mock_session.execute = AsyncMock(return_value=mock_result)
 
-    with patch("app.services.backup_service.settings") as mock_settings:
-        mock_settings.backups_bucket_name = ""
-        result = await BackupService.run_postgres_backup(mock_session, org_id=1)
+    result = await BackupService.run_postgres_backup(mock_session, org_id=1)
 
     assert result["status"] == "error"
     assert "bucket" in result["message"].lower()

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -169,6 +169,25 @@ async def test_update_backup_settings_returns_updated_values(client: AsyncClient
 
 
 @pytest.mark.asyncio
+async def test_list_tfstate_files(client: AsyncClient, admin_token: str):
+    response = await client.get(
+        "/api/backups/tfstate-files",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert "files" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_download_tfstate_not_found(client: AsyncClient, admin_token: str):
+    response = await client.get(
+        "/api/backups/tfstate-download/nonexistent.tfstate",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_backup_health_check(admin_user, session):
     """Test backup health check does not error."""
     from app.services.backup_service import BackupService

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -121,6 +121,54 @@ async def test_postgres_snapshots_empty(client: AsyncClient, admin_token: str):
 
 
 @pytest.mark.asyncio
+async def test_trigger_config_backup_via_api(client: AsyncClient, admin_token: str):
+    """Trigger config backup endpoint calls run_config_backup."""
+    with patch(
+        "app.api.backups.BackupService.run_config_backup",
+        new_callable=AsyncMock,
+        return_value={
+            "status": "completed",
+            "filename": "config-test.json",
+            "size_bytes": 512,
+        },
+    ):
+        response = await client.post(
+            "/api/backups/trigger/config",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_get_backup_settings(client: AsyncClient, admin_token: str):
+    response = await client.get(
+        "/api/backups/settings",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "postgres_retention_days" in data
+    assert "postgres_schedule_hours" in data
+    assert "config_retention_days" in data
+    assert "config_schedule_hours" in data
+
+
+@pytest.mark.asyncio
+async def test_update_backup_settings_returns_updated_values(client: AsyncClient, admin_token: str):
+    """Settings update returns the persisted values."""
+    response = await client.put(
+        "/api/backups/settings",
+        json={"postgres_retention_days": 21, "config_schedule_hours": 12},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["settings"]["postgres_retention_days"] == 21
+    assert data["settings"]["config_schedule_hours"] == 12
+
+
+@pytest.mark.asyncio
 async def test_backup_health_check(admin_user, session):
     """Test backup health check does not error."""
     from app.services.backup_service import BackupService

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -12,7 +12,9 @@ async def test_get_backup_status(client: AsyncClient, admin_token: str):
     data = response.json()
     assert "tiers" in data
     assert "overall_status" in data
-    assert len(data["tiers"]) == 5
+    assert len(data["tiers"]) == 4
+    tier_names = {t["tier"] for t in data["tiers"]}
+    assert tier_names == {"postgres", "gcs", "platform_config", "terraform_state"}
 
 
 @pytest.mark.asyncio
@@ -61,32 +63,10 @@ async def test_restore_config(client: AsyncClient, admin_token: str):
 
 
 @pytest.mark.asyncio
-async def test_restore_cloudsql(client: AsyncClient, admin_token: str):
-    response = await client.post(
-        "/api/backups/restore/cloudsql",
-        json={"confirmation_token": "CONFIRM"},
-        headers={"Authorization": f"Bearer {admin_token}"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "initiated"
-
-
-@pytest.mark.asyncio
-async def test_restore_filestore(client: AsyncClient, admin_token: str):
-    response = await client.post(
-        "/api/backups/restore/filestore",
-        json={"confirmation_token": "CONFIRM"},
-        headers={"Authorization": f"Bearer {admin_token}"},
-    )
-    assert response.status_code == 200
-    assert response.json()["status"] == "initiated"
-
-
-@pytest.mark.asyncio
 async def test_update_backup_settings(client: AsyncClient, admin_token: str):
     response = await client.put(
         "/api/backups/settings",
-        json={"cloud_sql_retention_days": 60},
+        json={"postgres_retention_days": 30},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200
@@ -94,13 +74,35 @@ async def test_update_backup_settings(client: AsyncClient, admin_token: str):
 
 
 @pytest.mark.asyncio
-async def test_update_backup_settings_enforces_minimums(client: AsyncClient, admin_token: str):
+async def test_update_backup_settings_enforces_postgres_minimum(client: AsyncClient, admin_token: str):
     response = await client.put(
         "/api/backups/settings",
-        json={"cloud_sql_pitr_days": 3},
+        json={"postgres_retention_days": 0},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_trigger_postgres_backup_stub(client: AsyncClient, admin_token: str):
+    """Trigger endpoint returns 501 until pg_dump is implemented."""
+    response = await client.post(
+        "/api/backups/trigger/postgres",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 501
+
+
+@pytest.mark.asyncio
+async def test_postgres_snapshots_empty(client: AsyncClient, admin_token: str):
+    response = await client.get(
+        "/api/backups/postgres-snapshots",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["snapshots"] == []
+    assert data["total"] == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -1,6 +1,5 @@
-import os
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -93,7 +92,12 @@ async def test_trigger_postgres_backup_via_api(client: AsyncClient, admin_token:
     with patch(
         "app.api.backups.BackupService.run_postgres_backup",
         new_callable=AsyncMock,
-        return_value={"status": "completed", "filename": "pgdump-test.dump", "size_bytes": 1024, "duration_seconds": 1.5},
+        return_value={
+            "status": "completed",
+            "filename": "pgdump-test.dump",
+            "size_bytes": 1024,
+            "duration_seconds": 1.5,
+        },
     ):
         response = await client.post(
             "/api/backups/trigger/postgres",

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -204,6 +204,80 @@ async def test_trigger_postgres_backup_forbidden_for_viewer(client: AsyncClient,
     assert response.status_code == 403
 
 
+# --- Database Restore tests ---
+
+
+@pytest.mark.asyncio
+async def test_restore_status_inactive(client: AsyncClient, admin_token: str):
+    response = await client.get(
+        "/api/backups/restore/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["active"] is False
+
+
+@pytest.mark.asyncio
+async def test_accept_restore_when_not_active(client: AsyncClient, admin_token: str):
+    response = await client.post(
+        "/api/backups/restore/accept",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reject_restore_when_not_active(client: AsyncClient, admin_token: str):
+    response = await client.post(
+        "/api/backups/restore/reject",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_start_restore_calls_service(client: AsyncClient, admin_token: str):
+    """Start restore endpoint calls RestoreService.start."""
+    with patch(
+        "app.api.backups.RestoreService.start",
+        new_callable=AsyncMock,
+        return_value={"status": "reviewing", "message": "Restore active"},
+    ):
+        response = await client.post(
+            "/api/backups/restore/postgres",
+            json={"filename": "pgdump-20260403-030000.dump"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["status"] == "reviewing"
+
+
+@pytest.mark.asyncio
+async def test_start_restore_conflict_when_active(client: AsyncClient, admin_token: str):
+    """Returns 409 if a restore is already in progress."""
+    with patch(
+        "app.api.backups.RestoreService.start",
+        new_callable=AsyncMock,
+        return_value={"status": "error", "message": "A restore review is already active"},
+    ):
+        response = await client.post(
+            "/api/backups/restore/postgres",
+            json={"filename": "pgdump-test.dump"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_restore_forbidden_for_viewer(client: AsyncClient, viewer_token: str):
+    response = await client.post(
+        "/api/backups/restore/postgres",
+        json={"filename": "pgdump-test.dump"},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert response.status_code == 403
+
+
 # --- GCS backup status tests ---
 
 

--- a/backend/tests/test_request_health.py
+++ b/backend/tests/test_request_health.py
@@ -1,0 +1,93 @@
+import pytest
+from httpx import AsyncClient
+
+from app.services.request_health import clear, get_service_health, record
+
+
+@pytest.fixture(autouse=True)
+def reset_counters():
+    clear()
+    yield
+    clear()
+
+
+def test_record_and_get_healthy():
+    """Service with all successful requests is healthy."""
+    for _ in range(10):
+        record("/api/experiments/123", 200)
+    health = get_service_health()
+    assert health["experiments"] == "healthy"
+
+
+def test_record_mixed_degraded():
+    """Service with 60% success rate is degraded."""
+    for _ in range(6):
+        record("/api/experiments/123", 200)
+    for _ in range(4):
+        record("/api/experiments/123", 500)
+    health = get_service_health()
+    assert health["experiments"] == "degraded"
+
+
+def test_record_mostly_failures_unhealthy():
+    """Service with <50% success rate is unhealthy."""
+    for _ in range(3):
+        record("/api/experiments/123", 200)
+    for _ in range(7):
+        record("/api/experiments/123", 500)
+    health = get_service_health()
+    assert health["experiments"] == "unhealthy"
+
+
+def test_single_failure_is_unhealthy():
+    """A single failed request with no successes is unhealthy."""
+    record("/api/experiments/123", 500)
+    health = get_service_health()
+    assert health["experiments"] == "unhealthy"
+
+
+def test_no_traffic_is_unknown():
+    """Services with no traffic don't appear in health."""
+    health = get_service_health()
+    assert "experiments" not in health
+
+
+def test_unmapped_routes_ignored():
+    """Routes that don't match any service prefix are ignored."""
+    record("/api/some-unknown-route", 200)
+    health = get_service_health()
+    assert len(health) == 0
+
+
+def test_multiple_services():
+    """Multiple services tracked independently."""
+    record("/api/experiments/1", 200)
+    record("/api/samples/1", 500)
+    health = get_service_health()
+    assert health["experiments"] == "healthy"
+    assert health["samples"] == "unhealthy"
+
+
+def test_route_mapping():
+    """Various routes map to correct services."""
+    record("/api/experiments/1/status", 200)
+    record("/api/v1/notebooks/sessions", 200)
+    record("/api/pipeline-runs/5/logs", 200)
+    record("/api/files/upload", 200)
+    health = get_service_health()
+    assert "experiments" in health
+    assert "notebooks" in health
+    assert "pipelines" in health
+    assert "storage" in health
+
+
+@pytest.mark.asyncio
+async def test_service_health_endpoint(client: AsyncClient, admin_token: str):
+    """The /api/health/services endpoint returns service health."""
+    # Generate some traffic first
+    await client.get("/api/experiments", headers={"Authorization": f"Bearer {admin_token}"})
+
+    response = await client.get("/api/health/services")
+    assert response.status_code == 200
+    data = response.json()
+    assert "services" in data

--- a/backend/tests/test_upgrades.py
+++ b/backend/tests/test_upgrades.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from httpx import AsyncClient
 
@@ -144,8 +146,111 @@ async def test_upgrade_history_after_upgrade(client: AsyncClient, admin_token: s
 @pytest.mark.asyncio
 async def test_version_check_service():
     """Test version check returns valid data."""
-    from app.services.upgrade_service import UpgradeService
+    from app.services.upgrade_service import UpgradeService, _clear_version_cache
 
+    _clear_version_cache()
     result = await UpgradeService.check_for_updates(1)
     assert "current_version" in result
     assert "update_available" in result
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_detects_newer_version():
+    """When GitHub reports a newer release, update_available should be True."""
+    from app.services.upgrade_service import UpgradeService, _clear_version_cache
+
+    _clear_version_cache()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "tag_name": "v99.0.0",
+        "body": "## What's new\n- Big improvements",
+        "html_url": "https://github.com/not-that-guy-again/bioAF/releases/tag/v99.0.0",
+    }
+
+    with patch("app.services.upgrade_service.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        result = await UpgradeService.check_for_updates(1)
+
+    assert result["update_available"] is True
+    assert result["latest_version"] == "99.0.0"
+    assert result["changelog"] == "## What's new\n- Big improvements"
+    assert "v99.0.0" in result["release_url"]
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_no_update_when_current():
+    """When GitHub reports the same version, update_available should be False."""
+    from app.config import settings
+    from app.services.upgrade_service import UpgradeService, _clear_version_cache
+
+    _clear_version_cache()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "tag_name": f"v{settings.app_version}",
+        "body": "Current release",
+        "html_url": f"https://github.com/not-that-guy-again/bioAF/releases/tag/v{settings.app_version}",
+    }
+
+    with patch("app.services.upgrade_service.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        result = await UpgradeService.check_for_updates(1)
+
+    assert result["update_available"] is False
+    assert result["latest_version"] == settings.app_version
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_handles_github_failure():
+    """When GitHub API fails, return no update available gracefully."""
+    from app.services.upgrade_service import UpgradeService, _clear_version_cache
+
+    _clear_version_cache()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.json.return_value = {"message": "Not Found"}
+
+    with patch("app.services.upgrade_service.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        result = await UpgradeService.check_for_updates(1)
+
+    assert result["update_available"] is False
+    assert result["current_version"] == result["latest_version"]
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_handles_network_error():
+    """When the network call raises an exception, return no update gracefully."""
+    from app.services.upgrade_service import UpgradeService, _clear_version_cache
+
+    _clear_version_cache()
+
+    with patch("app.services.upgrade_service.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_client_cls.return_value = mock_client
+
+        result = await UpgradeService.check_for_updates(1)
+
+    assert result["update_available"] is False

--- a/decisions/ADR-004-tiered-backup-strategy.md
+++ b/decisions/ADR-004-tiered-backup-strategy.md
@@ -1,70 +1,94 @@
-# ADR-004: Tiered Backup Strategy with Mandatory Database Backups
+# ADR-004: Tiered Backup Strategy
 
-**Status:** Accepted
-**Date:** 2026-03-05
+**Status:** Accepted (revised 2026-04-03)
+**Date:** 2026-03-05 (original), 2026-04-03 (revised)
 **Deciders:** Brent (product owner)
 
 ## Context
 
 bioAF manages several categories of data with different criticality levels, access patterns, and recovery requirements. A one-size-fits-all backup policy would either over-protect low-value data (wasteful) or under-protect high-value data (dangerous).
 
-The experiment tracking database and audit log are the crown jewels — if they're lost, the entire auditability story collapses. GCS data is inherently durable but vulnerable to accidental deletion. Platform configuration should be recoverable but isn't worth the same investment as scientific data.
+The experiment tracking database and audit log are the crown jewels -- if they're lost, the entire auditability story collapses. GCS data is inherently durable but vulnerable to accidental deletion. Platform configuration should be recoverable but isn't worth the same investment as scientific data.
+
+### Revision notes (2026-04-03)
+
+The original ADR assumed Cloud SQL for PostgreSQL and Filestore NFS for shared storage. The current architecture runs PostgreSQL in a Docker container and uses GCS exclusively for file storage. This revision aligns the backup strategy with the actual infrastructure:
+
+- Replaced Cloud SQL PITR/snapshots (Tier 1) with pg_dump to GCS
+- Removed Filestore NFS snapshots (Tier 4) entirely -- not in use
+- Consolidated from 5 tiers to 4
+- All backups go to GCS -- never to local filesystem
 
 ## Decision
 
-Implement a five-tier backup strategy with different mechanisms and policies per data category. Database backups are mandatory and cannot be disabled. Other tiers have user-configurable retention.
+Implement a four-tier backup strategy with different mechanisms and policies per data category. All backup data is stored in a persistent GCS bucket that survives infrastructure teardown.
 
-### Tier 1: Database (Cloud SQL) — Mandatory
+### Persistent backups bucket
 
-- Continuous WAL-based point-in-time recovery (PITR)
-- Daily automated snapshots via Cloud SQL
-- Default retention: 30 days PITR, 90 days snapshots
-- Minimum enforceable: 7 days PITR, 30 days snapshots
+A dedicated `bioaf-backups-{project_id}` bucket is created in the Terraform foundation module (alongside the tfstate bucket). It uses fixed naming with no `stack_uid` suffix, so it is not destroyed during storage module teardown or redeployment. All backup tiers write to prefixed paths within this single bucket:
+
+```text
+gs://bioaf-backups-{project_id}/
+  postgres/pgdump-20260403-030000.dump
+  config/config-20260403-020000.json
+```
+
+### Tier 1: Database (pg_dump to GCS) -- Mandatory
+
+- `pg_dump -Fc` (custom/compressed format) run on a configurable schedule
+- Dump written to `/tmp/`, uploaded to GCS `postgres/` prefix, temp file deleted
+- Default schedule: daily (configurable interval in hours)
+- Default retention: 14 days
+- Minimum enforceable: 1 day
+- Old dumps rotated automatically after each backup
+- Manual trigger available via API and UI ("Run Backup Now")
 - **Cannot be disabled.** The audit log's integrity is a core product promise.
 
-### Tier 2: Platform Configuration (GCS JSON snapshots) — Configurable
+In production (GKE), a Kubernetes CronJob triggers the backend API endpoint daily. In local/dev mode, an asyncio background loop handles scheduling.
 
-bioAF exports its own configuration as JSON to a dedicated GCS bucket on a tiered retention schedule:
+### Tier 2: Platform Configuration (GCS JSON snapshots) -- Configurable
 
-| Backup | Frequency | Retention |
-|---|---|---|
-| Nightly | Every night (configurable time) | 7 days rolling |
-| Weekly | Final nightly of each week (Sunday) promoted | 1 month |
-| Monthly | Final weekly of each month promoted | 1 year |
-| After 1 year | Monthly snapshots roll off | Deleted |
+A Kubernetes CronJob (or background loop) exports platform configuration as JSON to the `config/` prefix in the backups bucket.
 
-Admin can adjust cadence (every 6, 12, or 24 hours) and retention lengths. Admin can disable config backups entirely (with a warning about risk).
+- Default schedule: nightly at 2 AM
+- Default retention: 30 days
+- Minimum enforceable: 1 day
+- Admin can adjust cadence and retention
 
-### Tier 3: GCS Data Buckets — Always Protected
+### Tier 3: GCS Data Buckets -- Always Protected
 
-- Object versioning enabled on all buckets — **cannot be disabled via bioAF**
-- Delete protection enabled at bucket level — **cannot be disabled via bioAF**
-- Non-current version retention: 30 days default (configurable)
-- Cross-region replication: optional toggle (off by default; doubles storage cost)
+- Object versioning enabled on all managed buckets -- **cannot be disabled via bioAF**
+- Non-current version retention: 30 days default (configurable via Terraform)
+- `force_destroy = false` on all buckets prevents accidental deletion
+- Backup status page verifies versioning is enabled by querying the GCS API
 
-### Tier 4: Filestore (NFS) — Configurable
+### Tier 4: Terraform State -- Always Protected
 
-- Daily snapshots with 14-day retention (default)
-- Frequency and retention configurable by admin
-- Can be disabled if Filestore is not in use
+- Stored in a persistent GCS bucket (`bioaf-tfstate-{project_id}`) with object versioning
+- Every `terraform apply` preserves the previous state as a non-current version
+- Not configurable -- infrastructure state must always be recoverable
 
-### Tier 5: Terraform State — Always Protected
+## Design constraints
 
-- Stored in GCS backend with object versioning (every apply preserves previous state)
-- Not configurable — this is infrastructure state and must always be recoverable
+**GCS-only storage.** All backups must go to GCS, never the local filesystem. Local storage risks filling the node disk and causing a failure. Containers are ephemeral -- anything written inside one disappears on restart. The `/tmp/` directory is used only as a transient staging area before upload.
+
+**Off-node by default.** The backup system must not require manual intervention, CLI commands, or local scripts. Everything is automated through the application and triggered via the UI or scheduled CronJobs.
+
+**Persistent bucket naming.** The backups bucket uses fixed naming (`bioaf-backups-{project_id}`) with no random suffix or `stack_uid`. This means it survives `terraform destroy` of the storage module and redeployment with a new stack. Removing this bucket requires manual intervention -- by design.
 
 ## Rationale
 
-- **Mandatory database backups** prevent the catastrophic scenario where someone disables backups to save a few dollars and then loses the audit trail or experiment history.
-- **Tiered config retention (7d/1m/1y)** balances storage cost with recovery window. Most config errors are caught within days; the monthly/yearly snapshots cover "slowly creeping" misconfigurations.
-- **GCS versioning + delete protection** is the lightest-weight protection for object storage. It handles both accidental deletion and accidental overwrite without the cost of cross-region replication.
-- **User-configurable policies** respect that different teams have different risk tolerances and budgets. A funded Series B biotech handling clinical data wants aggressive retention; a pre-seed startup analyzing mouse data may want minimal.
+- **pg_dump over Cloud SQL backups** because the current architecture runs PostgreSQL in Docker, not Cloud SQL. pg_dump is portable and works with any Postgres deployment. If Cloud SQL is adopted later, its native PITR/snapshots can supplement or replace pg_dump.
+- **Single backups bucket** simplifies access control, lifecycle management, and monitoring. Prefixed paths (`postgres/`, `config/`) provide logical separation without the overhead of multiple buckets.
+- **Foundation module placement** ensures the bucket is created before any workload runs and is never torn down by storage or compute module operations.
+- **Mandatory database backups** prevent the scenario where someone disables backups to save a few dollars and then loses the audit trail or experiment history.
+- **User-configurable retention** respects that different teams have different risk tolerances and budgets.
 
 ## Consequences
 
-- The bioAF UI must include a Backup & Recovery admin page with per-tier configuration controls.
-- Database backup minimum enforcement must be implemented at the application level (prevent API calls that would set retention below minimums).
-- GCS bucket versioning and delete protection are set during Terraform provisioning and are not exposed as toggleable in the UI.
-- The config backup system needs a CronJob running on GKE that exports config JSON and manages the tiered promotion/deletion logic.
-- Backup monitoring (last successful backup time, failures) must be surfaced in the dashboard and integrated with the notification system.
-- Restore workflows must be documented and accessible from the UI: database PITR restore, config snapshot restore, GCS version recovery.
+- The bioAF UI includes a Backup & Recovery page with per-tier status, a manual backup trigger for PostgreSQL, and snapshot history for both database and config backups.
+- Database backup minimum enforcement is implemented at the application level (API rejects retention below 1 day).
+- The backend Docker image must include `postgresql-client` for `pg_dump`.
+- GCS bucket versioning is set during Terraform provisioning and is not exposed as toggleable in the UI.
+- Backup health monitoring runs hourly: checks the age of the most recent backup in each tier and emits notification events when backups are overdue.
+- The `backups_bucket_name` is stored in `platform_config` after foundation bootstrap and read by the backup service at runtime.

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -28,4 +28,4 @@ RUN chmod +x /entrypoint.sh
 EXPOSE 8000
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 # Install system dependencies (Terraform + weasyprint rendering libs)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl unzip \
+    curl unzip postgresql-client \
     libcairo2 libpango-1.0-0 libpangoft2-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev && \
     curl -fsSL https://releases.hashicorp.com/terraform/1.7.5/terraform_1.7.5_linux_amd64.zip -o terraform.zip && \
     unzip terraform.zip -d /usr/local/bin/ && \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -15,6 +15,7 @@ services:
       - BIOAF_DEBUG=true
       - BIOAF_ENVIRONMENT=development
       - BIOAF_USE_SECRET_MANAGER=false
+      - BIOAF_BACKUPS_BUCKET_NAME=bioaf-config-backups-bioaf-2080ba
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --no-access-log
     depends_on:
       postgres:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
       - BIOAF_DEBUG=true
       - BIOAF_ENVIRONMENT=development
       - BIOAF_USE_SECRET_MANAGER=false
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --no-access-log
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -15,7 +15,6 @@ services:
       - BIOAF_DEBUG=true
       - BIOAF_ENVIRONMENT=development
       - BIOAF_USE_SECRET_MANAGER=false
-      - BIOAF_BACKUPS_BUCKET_NAME=bioaf-config-backups-bioaf-2080ba
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --no-access-log
     depends_on:
       postgres:

--- a/docs/adr-index.md
+++ b/docs/adr-index.md
@@ -5,7 +5,7 @@
 | [ADR-001](../decisions/ADR-001-gcp-only.md) | GCP-Only Infrastructure | Target GCP exclusively to reduce complexity and leverage managed services |
 | [ADR-002](../decisions/ADR-002-mandatory-optional-split.md) | Mandatory/Optional Component Split | Separate core platform from optional components for flexible deployment |
 | [ADR-003](../decisions/ADR-003-email-based-auth.md) | Email-Based Authentication | Use email/password auth with JWT tokens instead of OAuth/SSO for simplicity |
-| [ADR-004](../decisions/ADR-004-tiered-backup-strategy.md) | Tiered Backup Strategy | Multi-tier backup approach: Cloud SQL PITR, Filestore snapshots, GCS versioning, config exports |
+| [ADR-004](../decisions/ADR-004-tiered-backup-strategy.md) | Tiered Backup Strategy | 4-tier GCS-only backups: pg_dump, GCS versioning, platform config snapshots, terraform state |
 | [ADR-005](../decisions/ADR-005-github-based-upgrades.md) | GitHub-Based Upgrades | Use GitHub Releases for version checking and upgrade distribution |
 | [ADR-006](../decisions/ADR-006-experiment-tracking-as-foundation.md) | Experiment Tracking as Foundation | Build experiment lifecycle tracking as the core data model |
 | [ADR-007](../decisions/ADR-007-ui-driven-terraform.md) | UI-Driven Terraform | Users never touch HCL; all infrastructure changes through the web UI |

--- a/docs/life-after-bioaf.md
+++ b/docs/life-after-bioaf.md
@@ -4,27 +4,26 @@ bioAF is designed with data portability as a core principle (see [ADR-012](../de
 
 ## Preserved Assets
 
-### Database (Cloud SQL PostgreSQL)
+### Database (PostgreSQL)
 
-Your experiment metadata, sample records, pipeline configurations, and audit logs remain in Cloud SQL:
+Your experiment metadata, sample records, pipeline configurations, and audit logs are in PostgreSQL:
 
 - Connect with any PostgreSQL client: `psql`, DBeaver, pgAdmin
 - Export with `pg_dump` for migration to another database
-- PITR backups are retained per your configured retention policy
+- pg_dump backups are stored in GCS per your configured retention policy
 
-### Files (Filestore / GCS)
+### Files (GCS)
 
-All uploaded data files, pipeline outputs, and notebook files are stored in GCS buckets and Filestore:
+All uploaded data files, pipeline outputs, and notebook files are stored in GCS buckets:
 
 - Access via `gsutil`, the GCP Console, or any S3-compatible client
-- Bucket names follow the pattern: `bioaf-{org}-{type}` (e.g., `bioaf-myorg-data`, `bioaf-myorg-results`)
-- Filestore NFS exports can be mounted from any GCE instance
+- Bucket names follow the pattern: `bioaf-{purpose}-{org}-{suffix}` (e.g., `bioaf-raw-myorg-abc123`)
 
 ### Notebooks
 
-JupyterHub and RStudio notebooks are stored on Filestore:
+JupyterHub and RStudio notebooks are stored in GCS:
 
-- Mount the Filestore share on any compute instance
+- Download from the results or working bucket
 - Notebooks are standard `.ipynb` and `.Rmd` files
 - Conda/pip environments are defined in standard `environment.yml` / `requirements.txt` files
 
@@ -54,8 +53,8 @@ Nightly config backups in GCS contain:
 
 ## Recommended Migration Steps
 
-1. **Export database**: `pg_dump -h <cloud-sql-ip> -U bioaf_app bioaf > bioaf_backup.sql`
-2. **Copy files**: `gsutil -m cp -r gs://bioaf-myorg-data/ ./local-backup/`
-3. **Download notebooks**: Mount Filestore or use `gcloud filestore` commands
-4. **Save pipeline configs**: Copy from GCS results bucket
+1. **Export database**: use the Backup & Recovery page to trigger a pg_dump, then download from GCS
+2. **Copy files**: `gsutil -m cp -r gs://bioaf-raw-myorg-*/ ./local-backup/`
+3. **Download notebooks**: download from the GCS working or results bucket
+4. **Save pipeline configs**: copy from GCS results bucket
 5. **Run teardown**: `bioaf destroy` removes only bioAF-managed infrastructure, not your data buckets (unless explicitly requested)

--- a/docs/user-guide-admin.md
+++ b/docs/user-guide-admin.md
@@ -27,7 +27,7 @@ Navigate to **Infrastructure > Components**:
 - Enable/disable infrastructure components through the UI
 - Each toggle triggers a Terraform apply
 - View component health status
-- Dependencies are enforced (e.g., JupyterHub requires SLURM + Filestore)
+- Dependencies are enforced (e.g., JupyterHub requires SLURM)
 
 ### Deployment Recovery
 
@@ -60,11 +60,13 @@ Configure alerts at 50%, 80%, and 100% of budget:
 
 Navigate to **Infrastructure > Backup & Recovery**:
 
-- View backup status for each tier: Cloud SQL, Filestore, GCS, Platform Config, Terraform State
-- Each tier shows: last backup, size, next scheduled, retention policy
+- View backup status for each tier: PostgreSQL (pg_dump), GCS Object Versioning, Platform Config, Terraform State
+- Each tier shows: last backup, size, next scheduled, retention policy, backup count
+- **On-demand backups**: trigger database or config backups from the UI
+- **PostgreSQL snapshots**: browse backup history, restore with 1-hour review period
 - **Config snapshots**: browse and diff configuration backups
-- **Restore**: initiate restore for Cloud SQL (PITR), Filestore, or platform config
-- **Settings**: adjust retention periods (minimum 7 days PITR, 30 days snapshots)
+- **Terraform state**: list and download state files
+- **Settings**: adjust backup schedule (hours) and retention (days) for database and config
 
 ## Notifications
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.3.15",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/backups/page.tsx
+++ b/frontend/src/app/admin/backups/page.tsx
@@ -32,6 +32,19 @@ interface PostgresSnapshot {
   size_bytes: number | null;
 }
 
+interface TfstateFile {
+  name: string;
+  size_bytes: number;
+  updated: string | null;
+}
+
+interface BackupSettings {
+  postgres_retention_days: number;
+  postgres_schedule_hours: number;
+  config_retention_days: number;
+  config_schedule_hours: number;
+}
+
 const statusColors: Record<string, string> = {
   healthy: "bg-green-100 text-green-700",
   warning: "bg-yellow-100 text-yellow-700",
@@ -54,33 +67,40 @@ export default function BackupsPage() {
   const [overallStatus, setOverallStatus] = useState("");
   const [snapshots, setSnapshots] = useState<ConfigSnapshot[]>([]);
   const [pgSnapshots, setPgSnapshots] = useState<PostgresSnapshot[]>([]);
+  const [tfstateFiles, setTfstateFiles] = useState<TfstateFile[]>([]);
+  const [settings, setSettings] = useState<BackupSettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [actionMessage, setActionMessage] = useState("");
-  const [backupRunning, setBackupRunning] = useState(false);
+  const [runningAction, setRunningAction] = useState("");
+  const [savingSettings, setSavingSettings] = useState(false);
+
+  const loadData = async () => {
+    try {
+      const [status, snaps, pgSnaps, tfFiles, backupSettings] = await Promise.all([
+        api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
+        api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
+        api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
+        api.get<{ files: TfstateFile[] }>("/api/backups/tfstate-files"),
+        api.get<BackupSettings>("/api/backups/settings"),
+      ]);
+      setTiers(status.tiers);
+      setOverallStatus(status.overall_status);
+      setSnapshots(snaps.snapshots);
+      setPgSnapshots(pgSnaps.snapshots);
+      setTfstateFiles(tfFiles.files);
+      setSettings(backupSettings);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
     if (permLoading) return;
     if (!canAccess("backups", "view")) { router.push("/dashboard"); return; }
-
-    const load = async () => {
-      try {
-        const [status, snaps, pgSnaps] = await Promise.all([
-          api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
-          api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
-          api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
-        ]);
-        setTiers(status.tiers);
-        setOverallStatus(status.overall_status);
-        setSnapshots(snaps.snapshots);
-        setPgSnapshots(pgSnaps.snapshots);
-      } catch {
-        // ignore
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
+    loadData();
   }, [router, permLoading, canAccess]);
 
   const handleRestore = async (type: string) => {
@@ -96,27 +116,38 @@ export default function BackupsPage() {
     }
   };
 
-  const handleTriggerBackup = async () => {
-    setBackupRunning(true);
+  const handleTriggerBackup = async (type: "postgres" | "config") => {
+    setRunningAction(type);
     setActionMessage("");
     try {
       const data = await api.post<{ status: string; filename: string; size_bytes: number }>(
-        "/api/backups/trigger/postgres",
+        `/api/backups/trigger/${type}`,
         {}
       );
       setActionMessage(`Backup completed: ${data.filename} (${formatBytes(data.size_bytes)})`);
-      // Refresh status
-      const [status, pgSnaps] = await Promise.all([
-        api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
-        api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
-      ]);
-      setTiers(status.tiers);
-      setOverallStatus(status.overall_status);
-      setPgSnapshots(pgSnaps.snapshots);
+      await loadData();
     } catch (e) {
       setActionMessage(e instanceof Error ? e.message : "Backup failed");
     } finally {
-      setBackupRunning(false);
+      setRunningAction("");
+    }
+  };
+
+  const handleDownloadTfstate = (filename: string) => {
+    window.open(`/api/backups/tfstate-download/${encodeURIComponent(filename)}`, "_blank");
+  };
+
+  const handleSaveSettings = async () => {
+    if (!settings) return;
+    setSavingSettings(true);
+    setActionMessage("");
+    try {
+      await api.put("/api/backups/settings", settings);
+      setActionMessage("Settings saved");
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Failed to save settings");
+    } finally {
+      setSavingSettings(false);
     }
   };
 
@@ -192,17 +223,26 @@ export default function BackupsPage() {
                     </div>
                     {tier.tier === "postgres" && canAccess("backups", "create") && (
                       <button
-                        onClick={handleTriggerBackup}
-                        disabled={backupRunning}
+                        onClick={() => handleTriggerBackup("postgres")}
+                        disabled={runningAction !== ""}
                         className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
                       >
-                        {backupRunning ? "Running..." : "Run Backup Now"}
+                        {runningAction === "postgres" ? "Running..." : "Run Backup Now"}
+                      </button>
+                    )}
+                    {tier.tier === "platform_config" && canAccess("backups", "create") && (
+                      <button
+                        onClick={() => handleTriggerBackup("config")}
+                        disabled={runningAction !== ""}
+                        className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
+                      >
+                        {runningAction === "config" ? "Running..." : "Run Backup Now"}
                       </button>
                     )}
                     {tier.tier === "platform_config" && canAccess("backups", "restore") && (
                       <button
                         onClick={() => handleRestore("config")}
-                        className="mt-3 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
+                        className="mt-1 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
                       >
                         Restore
                       </button>
@@ -210,6 +250,74 @@ export default function BackupsPage() {
                   </div>
                 ))}
               </div>
+
+              {/* Backup Settings */}
+              {settings && canAccess("backups", "create") && (
+                <>
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">Backup Settings</h2>
+                  <div className="bg-white rounded-lg border border-gray-200 p-4 mb-8">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-900 mb-3">PostgreSQL</h3>
+                        <div className="space-y-3">
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Schedule (hours)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.postgres_schedule_hours}
+                              onChange={(e) => setSettings({ ...settings, postgres_schedule_hours: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Retention (days)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.postgres_retention_days}
+                              onChange={(e) => setSettings({ ...settings, postgres_retention_days: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-900 mb-3">Platform Config</h3>
+                        <div className="space-y-3">
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Schedule (hours)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.config_schedule_hours}
+                              onChange={(e) => setSettings({ ...settings, config_schedule_hours: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Retention (days)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.config_retention_days}
+                              onChange={(e) => setSettings({ ...settings, config_retention_days: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <button
+                      onClick={handleSaveSettings}
+                      disabled={savingSettings}
+                      className="mt-4 text-sm bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {savingSettings ? "Saving..." : "Save Settings"}
+                    </button>
+                  </div>
+                </>
+              )}
 
               <h2 className="text-lg font-semibold text-gray-900 mb-4">PostgreSQL Snapshots</h2>
               <div className="bg-white rounded-lg border border-gray-200 mb-8">
@@ -242,7 +350,7 @@ export default function BackupsPage() {
               </div>
 
               <h2 className="text-lg font-semibold text-gray-900 mb-4">Config Snapshots</h2>
-              <div className="bg-white rounded-lg border border-gray-200">
+              <div className="bg-white rounded-lg border border-gray-200 mb-8">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b bg-gray-50">
@@ -264,6 +372,47 @@ export default function BackupsPage() {
                           <td className="px-4 py-2.5 text-gray-900">{s.date}</td>
                           <td className="px-4 py-2.5 text-gray-600">{formatBytes(s.size_bytes)}</td>
                           <td className="px-4 py-2.5 text-gray-600">{s.tier}</td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Terraform State Files</h2>
+              <div className="bg-white rounded-lg border border-gray-200">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Name</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Size</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Last Updated</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {tfstateFiles.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
+                          No state files available
+                        </td>
+                      </tr>
+                    ) : (
+                      tfstateFiles.map((f) => (
+                        <tr key={f.name} className="border-b hover:bg-gray-50">
+                          <td className="px-4 py-2.5 text-gray-900 font-mono text-xs">{f.name}</td>
+                          <td className="px-4 py-2.5 text-gray-600">{formatBytes(f.size_bytes)}</td>
+                          <td className="px-4 py-2.5 text-gray-600">
+                            {f.updated ? new Date(f.updated).toLocaleString() : "N/A"}
+                          </td>
+                          <td className="px-4 py-2.5">
+                            <button
+                              onClick={() => handleDownloadTfstate(f.name)}
+                              className="text-xs text-blue-600 hover:text-blue-800"
+                            >
+                              Download
+                            </button>
+                          </td>
                         </tr>
                       ))
                     )}

--- a/frontend/src/app/admin/backups/page.tsx
+++ b/frontend/src/app/admin/backups/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
@@ -45,6 +45,14 @@ interface BackupSettings {
   config_schedule_hours: number;
 }
 
+interface RestoreStatus {
+  active: boolean;
+  backup_filename?: string;
+  started_at?: string;
+  expires_at?: string;
+  seconds_remaining?: number;
+}
+
 const statusColors: Record<string, string> = {
   healthy: "bg-green-100 text-green-700",
   warning: "bg-yellow-100 text-yellow-700",
@@ -60,6 +68,13 @@ function formatBytes(bytes: number | null): string {
   return `${(bytes / 1073741824).toFixed(1)} GB`;
 }
 
+function formatMinutes(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (mins === 0) return `${secs}s`;
+  return `${mins}m ${secs}s`;
+}
+
 export default function BackupsPage() {
   const router = useRouter();
   const { canAccess, loading: permLoading } = usePermissions();
@@ -69,19 +84,23 @@ export default function BackupsPage() {
   const [pgSnapshots, setPgSnapshots] = useState<PostgresSnapshot[]>([]);
   const [tfstateFiles, setTfstateFiles] = useState<TfstateFile[]>([]);
   const [settings, setSettings] = useState<BackupSettings | null>(null);
+  const [restoreStatus, setRestoreStatus] = useState<RestoreStatus>({ active: false });
   const [loading, setLoading] = useState(true);
   const [actionMessage, setActionMessage] = useState("");
   const [runningAction, setRunningAction] = useState("");
   const [savingSettings, setSavingSettings] = useState(false);
+  const [restoringFile, setRestoringFile] = useState("");
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
-      const [status, snaps, pgSnaps, tfFiles, backupSettings] = await Promise.all([
+      const [status, snaps, pgSnaps, tfFiles, backupSettings, rStatus] = await Promise.all([
         api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
         api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
         api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
         api.get<{ files: TfstateFile[] }>("/api/backups/tfstate-files"),
         api.get<BackupSettings>("/api/backups/settings"),
+        api.get<RestoreStatus>("/api/backups/restore/status"),
       ]);
       setTiers(status.tiers);
       setOverallStatus(status.overall_status);
@@ -89,25 +108,44 @@ export default function BackupsPage() {
       setPgSnapshots(pgSnaps.snapshots);
       setTfstateFiles(tfFiles.files);
       setSettings(backupSettings);
+      setRestoreStatus(rStatus);
     } catch {
       // ignore
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
     if (permLoading) return;
     if (!canAccess("backups", "view")) { router.push("/dashboard"); return; }
     loadData();
-  }, [router, permLoading, canAccess]);
+  }, [router, permLoading, canAccess, loadData]);
 
-  const handleRestore = async (type: string) => {
-    if (!confirm(`Are you sure you want to initiate a ${type} restore?`)) return;
+  // Poll restore status while active
+  useEffect(() => {
+    if (restoreStatus.active) {
+      pollRef.current = setInterval(async () => {
+        try {
+          const rStatus = await api.get<RestoreStatus>("/api/backups/restore/status");
+          setRestoreStatus(rStatus);
+          if (!rStatus.active) {
+            if (pollRef.current) clearInterval(pollRef.current);
+            setActionMessage("Restore review expired. Reverted to original database.");
+            await loadData();
+          }
+        } catch { /* ignore */ }
+      }, 30000);
+      return () => { if (pollRef.current) clearInterval(pollRef.current); };
+    }
+  }, [restoreStatus.active, loadData]);
+
+  const handleConfigRestore = async () => {
+    if (!confirm("Are you sure you want to initiate a config restore?")) return;
     try {
       const data = await api.post<{ status: string; message: string }>(
-        `/api/backups/restore/${type}`,
+        "/api/backups/restore/config",
         { confirmation_token: "CONFIRM" }
       );
       setActionMessage(data.message);
@@ -130,6 +168,51 @@ export default function BackupsPage() {
       setActionMessage(e instanceof Error ? e.message : "Backup failed");
     } finally {
       setRunningAction("");
+    }
+  };
+
+  const handleStartRestore = async (filename: string) => {
+    const msg = `This will restore the database from "${filename}". The current database will remain available as a fallback. You will have 1 hour to review the restored data before accepting or rejecting.\n\nProceed?`;
+    if (!confirm(msg)) return;
+    setRestoringFile(filename);
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; message: string }>(
+        "/api/backups/restore/postgres",
+        { filename }
+      );
+      setActionMessage(data.message);
+      await loadData();
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Restore failed");
+    } finally {
+      setRestoringFile("");
+    }
+  };
+
+  const handleAcceptRestore = async () => {
+    if (!confirm("Accept this restored database? This will permanently replace the previous database. This cannot be undone.")) return;
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; message: string }>("/api/backups/restore/accept", {});
+      setActionMessage(data.message);
+      setRestoreStatus({ active: false });
+      await loadData();
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Accept failed");
+    }
+  };
+
+  const handleRejectRestore = async () => {
+    if (!confirm("Reject this restore and revert to the original database?")) return;
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; message: string }>("/api/backups/restore/reject", {});
+      setActionMessage(data.message);
+      setRestoreStatus({ active: false });
+      await loadData();
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Reject failed");
     }
   };
 
@@ -158,6 +241,44 @@ export default function BackupsPage() {
         <Header />
         <main className="flex-1 overflow-y-auto p-6">
           <h1 className="text-2xl font-bold text-gray-900 mb-6">Backup & Recovery</h1>
+
+          {/* Restore review banner */}
+          {restoreStatus.active && (
+            <div className="mb-4 p-4 rounded-lg bg-amber-50 border border-amber-300">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-amber-900">
+                    Reviewing restored database
+                  </p>
+                  <p className="text-sm text-amber-700 mt-1">
+                    Restored from <span className="font-mono">{restoreStatus.backup_filename}</span>.
+                    {restoreStatus.seconds_remaining !== undefined && (
+                      <> Auto-reverts in <span className="font-semibold">{formatMinutes(restoreStatus.seconds_remaining)}</span>.</>
+                    )}
+                  </p>
+                  <p className="text-xs text-amber-600 mt-1">
+                    Browse the application to verify data. Accept to make permanent, or reject to revert.
+                  </p>
+                </div>
+                {canAccess("backups", "restore") && (
+                  <div className="flex gap-2 ml-4">
+                    <button
+                      onClick={handleRejectRestore}
+                      className="text-sm px-4 py-2 rounded border border-gray-300 text-gray-700 bg-white hover:bg-gray-50"
+                    >
+                      Reject
+                    </button>
+                    <button
+                      onClick={handleAcceptRestore}
+                      className="text-sm px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700"
+                    >
+                      Accept
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
 
           {actionMessage && (
             <div className="mb-4 p-3 rounded bg-blue-50 text-blue-700 text-sm">
@@ -224,7 +345,7 @@ export default function BackupsPage() {
                     {tier.tier === "postgres" && canAccess("backups", "create") && (
                       <button
                         onClick={() => handleTriggerBackup("postgres")}
-                        disabled={runningAction !== ""}
+                        disabled={runningAction !== "" || restoreStatus.active}
                         className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
                       >
                         {runningAction === "postgres" ? "Running..." : "Run Backup Now"}
@@ -241,7 +362,7 @@ export default function BackupsPage() {
                     )}
                     {tier.tier === "platform_config" && canAccess("backups", "restore") && (
                       <button
-                        onClick={() => handleRestore("config")}
+                        onClick={handleConfigRestore}
                         className="mt-1 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
                       >
                         Restore
@@ -327,12 +448,15 @@ export default function BackupsPage() {
                       <th className="text-left px-4 py-3 font-medium text-gray-700">Filename</th>
                       <th className="text-left px-4 py-3 font-medium text-gray-700">Date</th>
                       <th className="text-left px-4 py-3 font-medium text-gray-700">Size</th>
+                      {canAccess("backups", "restore") && (
+                        <th className="text-left px-4 py-3 font-medium text-gray-700"></th>
+                      )}
                     </tr>
                   </thead>
                   <tbody>
                     {pgSnapshots.length === 0 ? (
                       <tr>
-                        <td colSpan={3} className="px-4 py-8 text-center text-gray-500">
+                        <td colSpan={canAccess("backups", "restore") ? 4 : 3} className="px-4 py-8 text-center text-gray-500">
                           No snapshots available
                         </td>
                       </tr>
@@ -342,6 +466,17 @@ export default function BackupsPage() {
                           <td className="px-4 py-2.5 text-gray-900 font-mono text-xs">{s.filename}</td>
                           <td className="px-4 py-2.5 text-gray-600">{s.date}</td>
                           <td className="px-4 py-2.5 text-gray-600">{formatBytes(s.size_bytes)}</td>
+                          {canAccess("backups", "restore") && (
+                            <td className="px-4 py-2.5">
+                              <button
+                                onClick={() => handleStartRestore(s.filename)}
+                                disabled={restoreStatus.active || restoringFile !== ""}
+                                className="text-xs text-amber-600 hover:text-amber-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                {restoringFile === s.filename ? "Restoring..." : "Restore"}
+                              </button>
+                            </td>
+                          )}
                         </tr>
                       ))
                     )}

--- a/frontend/src/app/admin/backups/page.tsx
+++ b/frontend/src/app/admin/backups/page.tsx
@@ -16,14 +16,20 @@ interface BackupTier {
   next_scheduled: string | null;
   retention_days: number | null;
   status: string;
-  pitr_window_hours: number | null;
   versioning_enabled: boolean | null;
+  backup_count: number | null;
 }
 
 interface ConfigSnapshot {
   date: string;
   size_bytes: number | null;
   tier: string;
+}
+
+interface PostgresSnapshot {
+  filename: string;
+  date: string;
+  size_bytes: number | null;
 }
 
 const statusColors: Record<string, string> = {
@@ -47,8 +53,10 @@ export default function BackupsPage() {
   const [tiers, setTiers] = useState<BackupTier[]>([]);
   const [overallStatus, setOverallStatus] = useState("");
   const [snapshots, setSnapshots] = useState<ConfigSnapshot[]>([]);
+  const [pgSnapshots, setPgSnapshots] = useState<PostgresSnapshot[]>([]);
   const [loading, setLoading] = useState(true);
-  const [restoreMessage, setRestoreMessage] = useState("");
+  const [actionMessage, setActionMessage] = useState("");
+  const [backupRunning, setBackupRunning] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
@@ -57,13 +65,15 @@ export default function BackupsPage() {
 
     const load = async () => {
       try {
-        const [status, snaps] = await Promise.all([
+        const [status, snaps, pgSnaps] = await Promise.all([
           api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
           api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
+          api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
         ]);
         setTiers(status.tiers);
         setOverallStatus(status.overall_status);
         setSnapshots(snaps.snapshots);
+        setPgSnapshots(pgSnaps.snapshots);
       } catch {
         // ignore
       } finally {
@@ -80,9 +90,33 @@ export default function BackupsPage() {
         `/api/backups/restore/${type}`,
         { confirmation_token: "CONFIRM" }
       );
-      setRestoreMessage(data.message);
+      setActionMessage(data.message);
     } catch (e) {
-      setRestoreMessage(e instanceof Error ? e.message : "Restore failed");
+      setActionMessage(e instanceof Error ? e.message : "Restore failed");
+    }
+  };
+
+  const handleTriggerBackup = async () => {
+    setBackupRunning(true);
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; filename: string; size_bytes: number }>(
+        "/api/backups/trigger/postgres",
+        {}
+      );
+      setActionMessage(`Backup completed: ${data.filename} (${formatBytes(data.size_bytes)})`);
+      // Refresh status
+      const [status, pgSnaps] = await Promise.all([
+        api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
+        api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
+      ]);
+      setTiers(status.tiers);
+      setOverallStatus(status.overall_status);
+      setPgSnapshots(pgSnaps.snapshots);
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Backup failed");
+    } finally {
+      setBackupRunning(false);
     }
   };
 
@@ -94,9 +128,9 @@ export default function BackupsPage() {
         <main className="flex-1 overflow-y-auto p-6">
           <h1 className="text-2xl font-bold text-gray-900 mb-6">Backup & Recovery</h1>
 
-          {restoreMessage && (
+          {actionMessage && (
             <div className="mb-4 p-3 rounded bg-blue-50 text-blue-700 text-sm">
-              {restoreMessage}
+              {actionMessage}
             </div>
           )}
 
@@ -111,7 +145,7 @@ export default function BackupsPage() {
                 </span>
               </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
                 {tiers.map((tier) => (
                   <div key={tier.tier} className="bg-white rounded-lg border border-gray-200 p-4">
                     <div className="flex items-center justify-between mb-3">
@@ -137,10 +171,10 @@ export default function BackupsPage() {
                           <span className="text-gray-900">{tier.retention_days} days</span>
                         </div>
                       )}
-                      {tier.pitr_window_hours && (
+                      {tier.backup_count !== null && (
                         <div className="flex justify-between">
-                          <span>PITR Window:</span>
-                          <span className="text-gray-900">{tier.pitr_window_hours}h</span>
+                          <span>Backups:</span>
+                          <span className="text-gray-900">{tier.backup_count}</span>
                         </div>
                       )}
                       {tier.versioning_enabled !== null && (
@@ -156,9 +190,18 @@ export default function BackupsPage() {
                         </div>
                       )}
                     </div>
-                    {(tier.tier === "cloudsql" || tier.tier === "filestore" || tier.tier === "config") && (
+                    {tier.tier === "postgres" && canAccess("backups", "create") && (
                       <button
-                        onClick={() => handleRestore(tier.tier === "config" ? "config" : tier.tier)}
+                        onClick={handleTriggerBackup}
+                        disabled={backupRunning}
+                        className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
+                      >
+                        {backupRunning ? "Running..." : "Run Backup Now"}
+                      </button>
+                    )}
+                    {tier.tier === "platform_config" && canAccess("backups", "restore") && (
+                      <button
+                        onClick={() => handleRestore("config")}
                         className="mt-3 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
                       >
                         Restore
@@ -166,6 +209,36 @@ export default function BackupsPage() {
                     )}
                   </div>
                 ))}
+              </div>
+
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">PostgreSQL Snapshots</h2>
+              <div className="bg-white rounded-lg border border-gray-200 mb-8">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Filename</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Date</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Size</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pgSnapshots.length === 0 ? (
+                      <tr>
+                        <td colSpan={3} className="px-4 py-8 text-center text-gray-500">
+                          No snapshots available
+                        </td>
+                      </tr>
+                    ) : (
+                      pgSnapshots.map((s) => (
+                        <tr key={s.filename} className="border-b hover:bg-gray-50">
+                          <td className="px-4 py-2.5 text-gray-900 font-mono text-xs">{s.filename}</td>
+                          <td className="px-4 py-2.5 text-gray-600">{s.date}</td>
+                          <td className="px-4 py-2.5 text-gray-600">{formatBytes(s.size_bytes)}</td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
               </div>
 
               <h2 className="text-lg font-semibold text-gray-900 mb-4">Config Snapshots</h2>

--- a/frontend/src/app/infrastructure/backup/page.tsx
+++ b/frontend/src/app/infrastructure/backup/page.tsx
@@ -32,6 +32,19 @@ interface PostgresSnapshot {
   size_bytes: number | null;
 }
 
+interface TfstateFile {
+  name: string;
+  size_bytes: number;
+  updated: string | null;
+}
+
+interface BackupSettings {
+  postgres_retention_days: number;
+  postgres_schedule_hours: number;
+  config_retention_days: number;
+  config_schedule_hours: number;
+}
+
 const statusColors: Record<string, string> = {
   healthy: "bg-green-100 text-green-700",
   warning: "bg-yellow-100 text-yellow-700",
@@ -54,33 +67,40 @@ export default function InfraBackupPage() {
   const [overallStatus, setOverallStatus] = useState("");
   const [snapshots, setSnapshots] = useState<ConfigSnapshot[]>([]);
   const [pgSnapshots, setPgSnapshots] = useState<PostgresSnapshot[]>([]);
+  const [tfstateFiles, setTfstateFiles] = useState<TfstateFile[]>([]);
+  const [settings, setSettings] = useState<BackupSettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [actionMessage, setActionMessage] = useState("");
-  const [backupRunning, setBackupRunning] = useState(false);
+  const [runningAction, setRunningAction] = useState("");
+  const [savingSettings, setSavingSettings] = useState(false);
+
+  const loadData = async () => {
+    try {
+      const [status, snaps, pgSnaps, tfFiles, backupSettings] = await Promise.all([
+        api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
+        api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
+        api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
+        api.get<{ files: TfstateFile[] }>("/api/backups/tfstate-files"),
+        api.get<BackupSettings>("/api/backups/settings"),
+      ]);
+      setTiers(status.tiers);
+      setOverallStatus(status.overall_status);
+      setSnapshots(snaps.snapshots);
+      setPgSnapshots(pgSnaps.snapshots);
+      setTfstateFiles(tfFiles.files);
+      setSettings(backupSettings);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
     if (permLoading) return;
     if (!canAccess("backups", "view")) { router.push("/dashboard"); return; }
-
-    const load = async () => {
-      try {
-        const [status, snaps, pgSnaps] = await Promise.all([
-          api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
-          api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
-          api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
-        ]);
-        setTiers(status.tiers);
-        setOverallStatus(status.overall_status);
-        setSnapshots(snaps.snapshots);
-        setPgSnapshots(pgSnaps.snapshots);
-      } catch {
-        // ignore
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
+    loadData();
   }, [router, permLoading, canAccess]);
 
   const handleRestore = async (type: string) => {
@@ -96,27 +116,38 @@ export default function InfraBackupPage() {
     }
   };
 
-  const handleTriggerBackup = async () => {
-    setBackupRunning(true);
+  const handleTriggerBackup = async (type: "postgres" | "config") => {
+    setRunningAction(type);
     setActionMessage("");
     try {
       const data = await api.post<{ status: string; filename: string; size_bytes: number }>(
-        "/api/backups/trigger/postgres",
+        `/api/backups/trigger/${type}`,
         {}
       );
       setActionMessage(`Backup completed: ${data.filename} (${formatBytes(data.size_bytes)})`);
-      // Refresh status
-      const [status, pgSnaps] = await Promise.all([
-        api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
-        api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
-      ]);
-      setTiers(status.tiers);
-      setOverallStatus(status.overall_status);
-      setPgSnapshots(pgSnaps.snapshots);
+      await loadData();
     } catch (e) {
       setActionMessage(e instanceof Error ? e.message : "Backup failed");
     } finally {
-      setBackupRunning(false);
+      setRunningAction("");
+    }
+  };
+
+  const handleDownloadTfstate = (filename: string) => {
+    window.open(`/api/backups/tfstate-download/${encodeURIComponent(filename)}`, "_blank");
+  };
+
+  const handleSaveSettings = async () => {
+    if (!settings) return;
+    setSavingSettings(true);
+    setActionMessage("");
+    try {
+      await api.put("/api/backups/settings", settings);
+      setActionMessage("Settings saved");
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Failed to save settings");
+    } finally {
+      setSavingSettings(false);
     }
   };
 
@@ -192,17 +223,26 @@ export default function InfraBackupPage() {
                     </div>
                     {tier.tier === "postgres" && canAccess("backups", "create") && (
                       <button
-                        onClick={handleTriggerBackup}
-                        disabled={backupRunning}
+                        onClick={() => handleTriggerBackup("postgres")}
+                        disabled={runningAction !== ""}
                         className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
                       >
-                        {backupRunning ? "Running..." : "Run Backup Now"}
+                        {runningAction === "postgres" ? "Running..." : "Run Backup Now"}
+                      </button>
+                    )}
+                    {tier.tier === "platform_config" && canAccess("backups", "create") && (
+                      <button
+                        onClick={() => handleTriggerBackup("config")}
+                        disabled={runningAction !== ""}
+                        className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
+                      >
+                        {runningAction === "config" ? "Running..." : "Run Backup Now"}
                       </button>
                     )}
                     {tier.tier === "platform_config" && canAccess("backups", "restore") && (
                       <button
                         onClick={() => handleRestore("config")}
-                        className="mt-3 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
+                        className="mt-1 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
                       >
                         Restore
                       </button>
@@ -210,6 +250,74 @@ export default function InfraBackupPage() {
                   </div>
                 ))}
               </div>
+
+              {/* Backup Settings */}
+              {settings && canAccess("backups", "create") && (
+                <>
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">Backup Settings</h2>
+                  <div className="bg-white rounded-lg border border-gray-200 p-4 mb-8">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-900 mb-3">PostgreSQL</h3>
+                        <div className="space-y-3">
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Schedule (hours)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.postgres_schedule_hours}
+                              onChange={(e) => setSettings({ ...settings, postgres_schedule_hours: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Retention (days)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.postgres_retention_days}
+                              onChange={(e) => setSettings({ ...settings, postgres_retention_days: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        <h3 className="text-sm font-medium text-gray-900 mb-3">Platform Config</h3>
+                        <div className="space-y-3">
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Schedule (hours)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.config_schedule_hours}
+                              onChange={(e) => setSettings({ ...settings, config_schedule_hours: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-gray-500 mb-1">Retention (days)</label>
+                            <input
+                              type="number"
+                              min={1}
+                              value={settings.config_retention_days}
+                              onChange={(e) => setSettings({ ...settings, config_retention_days: parseInt(e.target.value) || 1 })}
+                              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <button
+                      onClick={handleSaveSettings}
+                      disabled={savingSettings}
+                      className="mt-4 text-sm bg-blue-600 text-white px-4 py-1.5 rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {savingSettings ? "Saving..." : "Save Settings"}
+                    </button>
+                  </div>
+                </>
+              )}
 
               <h2 className="text-lg font-semibold text-gray-900 mb-4">PostgreSQL Snapshots</h2>
               <div className="bg-white rounded-lg border border-gray-200 mb-8">
@@ -242,7 +350,7 @@ export default function InfraBackupPage() {
               </div>
 
               <h2 className="text-lg font-semibold text-gray-900 mb-4">Config Snapshots</h2>
-              <div className="bg-white rounded-lg border border-gray-200">
+              <div className="bg-white rounded-lg border border-gray-200 mb-8">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b bg-gray-50">
@@ -264,6 +372,47 @@ export default function InfraBackupPage() {
                           <td className="px-4 py-2.5 text-gray-900">{s.date}</td>
                           <td className="px-4 py-2.5 text-gray-600">{formatBytes(s.size_bytes)}</td>
                           <td className="px-4 py-2.5 text-gray-600">{s.tier}</td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Terraform State Files</h2>
+              <div className="bg-white rounded-lg border border-gray-200">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Name</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Size</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Last Updated</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {tfstateFiles.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
+                          No state files available
+                        </td>
+                      </tr>
+                    ) : (
+                      tfstateFiles.map((f) => (
+                        <tr key={f.name} className="border-b hover:bg-gray-50">
+                          <td className="px-4 py-2.5 text-gray-900 font-mono text-xs">{f.name}</td>
+                          <td className="px-4 py-2.5 text-gray-600">{formatBytes(f.size_bytes)}</td>
+                          <td className="px-4 py-2.5 text-gray-600">
+                            {f.updated ? new Date(f.updated).toLocaleString() : "N/A"}
+                          </td>
+                          <td className="px-4 py-2.5">
+                            <button
+                              onClick={() => handleDownloadTfstate(f.name)}
+                              className="text-xs text-blue-600 hover:text-blue-800"
+                            >
+                              Download
+                            </button>
+                          </td>
                         </tr>
                       ))
                     )}

--- a/frontend/src/app/infrastructure/backup/page.tsx
+++ b/frontend/src/app/infrastructure/backup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
@@ -45,6 +45,14 @@ interface BackupSettings {
   config_schedule_hours: number;
 }
 
+interface RestoreStatus {
+  active: boolean;
+  backup_filename?: string;
+  started_at?: string;
+  expires_at?: string;
+  seconds_remaining?: number;
+}
+
 const statusColors: Record<string, string> = {
   healthy: "bg-green-100 text-green-700",
   warning: "bg-yellow-100 text-yellow-700",
@@ -60,6 +68,13 @@ function formatBytes(bytes: number | null): string {
   return `${(bytes / 1073741824).toFixed(1)} GB`;
 }
 
+function formatMinutes(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (mins === 0) return `${secs}s`;
+  return `${mins}m ${secs}s`;
+}
+
 export default function InfraBackupPage() {
   const router = useRouter();
   const { canAccess, loading: permLoading } = usePermissions();
@@ -69,19 +84,23 @@ export default function InfraBackupPage() {
   const [pgSnapshots, setPgSnapshots] = useState<PostgresSnapshot[]>([]);
   const [tfstateFiles, setTfstateFiles] = useState<TfstateFile[]>([]);
   const [settings, setSettings] = useState<BackupSettings | null>(null);
+  const [restoreStatus, setRestoreStatus] = useState<RestoreStatus>({ active: false });
   const [loading, setLoading] = useState(true);
   const [actionMessage, setActionMessage] = useState("");
   const [runningAction, setRunningAction] = useState("");
   const [savingSettings, setSavingSettings] = useState(false);
+  const [restoringFile, setRestoringFile] = useState("");
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
-      const [status, snaps, pgSnaps, tfFiles, backupSettings] = await Promise.all([
+      const [status, snaps, pgSnaps, tfFiles, backupSettings, rStatus] = await Promise.all([
         api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
         api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
         api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
         api.get<{ files: TfstateFile[] }>("/api/backups/tfstate-files"),
         api.get<BackupSettings>("/api/backups/settings"),
+        api.get<RestoreStatus>("/api/backups/restore/status"),
       ]);
       setTiers(status.tiers);
       setOverallStatus(status.overall_status);
@@ -89,25 +108,44 @@ export default function InfraBackupPage() {
       setPgSnapshots(pgSnaps.snapshots);
       setTfstateFiles(tfFiles.files);
       setSettings(backupSettings);
+      setRestoreStatus(rStatus);
     } catch {
       // ignore
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
     if (permLoading) return;
     if (!canAccess("backups", "view")) { router.push("/dashboard"); return; }
     loadData();
-  }, [router, permLoading, canAccess]);
+  }, [router, permLoading, canAccess, loadData]);
 
-  const handleRestore = async (type: string) => {
-    if (!confirm(`Are you sure you want to initiate a ${type} restore?`)) return;
+  // Poll restore status while active
+  useEffect(() => {
+    if (restoreStatus.active) {
+      pollRef.current = setInterval(async () => {
+        try {
+          const rStatus = await api.get<RestoreStatus>("/api/backups/restore/status");
+          setRestoreStatus(rStatus);
+          if (!rStatus.active) {
+            if (pollRef.current) clearInterval(pollRef.current);
+            setActionMessage("Restore review expired. Reverted to original database.");
+            await loadData();
+          }
+        } catch { /* ignore */ }
+      }, 30000);
+      return () => { if (pollRef.current) clearInterval(pollRef.current); };
+    }
+  }, [restoreStatus.active, loadData]);
+
+  const handleConfigRestore = async () => {
+    if (!confirm("Are you sure you want to initiate a config restore?")) return;
     try {
       const data = await api.post<{ status: string; message: string }>(
-        `/api/backups/restore/${type}`,
+        "/api/backups/restore/config",
         { confirmation_token: "CONFIRM" }
       );
       setActionMessage(data.message);
@@ -130,6 +168,51 @@ export default function InfraBackupPage() {
       setActionMessage(e instanceof Error ? e.message : "Backup failed");
     } finally {
       setRunningAction("");
+    }
+  };
+
+  const handleStartRestore = async (filename: string) => {
+    const msg = `This will restore the database from "${filename}". The current database will remain available as a fallback. You will have 1 hour to review the restored data before accepting or rejecting.\n\nProceed?`;
+    if (!confirm(msg)) return;
+    setRestoringFile(filename);
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; message: string }>(
+        "/api/backups/restore/postgres",
+        { filename }
+      );
+      setActionMessage(data.message);
+      await loadData();
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Restore failed");
+    } finally {
+      setRestoringFile("");
+    }
+  };
+
+  const handleAcceptRestore = async () => {
+    if (!confirm("Accept this restored database? This will permanently replace the previous database. This cannot be undone.")) return;
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; message: string }>("/api/backups/restore/accept", {});
+      setActionMessage(data.message);
+      setRestoreStatus({ active: false });
+      await loadData();
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Accept failed");
+    }
+  };
+
+  const handleRejectRestore = async () => {
+    if (!confirm("Reject this restore and revert to the original database?")) return;
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; message: string }>("/api/backups/restore/reject", {});
+      setActionMessage(data.message);
+      setRestoreStatus({ active: false });
+      await loadData();
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Reject failed");
     }
   };
 
@@ -158,6 +241,44 @@ export default function InfraBackupPage() {
         <Header />
         <main className="flex-1 overflow-y-auto p-6">
           <h1 className="text-2xl font-bold text-gray-900 mb-6">Backup & Recovery</h1>
+
+          {/* Restore review banner */}
+          {restoreStatus.active && (
+            <div className="mb-4 p-4 rounded-lg bg-amber-50 border border-amber-300">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-amber-900">
+                    Reviewing restored database
+                  </p>
+                  <p className="text-sm text-amber-700 mt-1">
+                    Restored from <span className="font-mono">{restoreStatus.backup_filename}</span>.
+                    {restoreStatus.seconds_remaining !== undefined && (
+                      <> Auto-reverts in <span className="font-semibold">{formatMinutes(restoreStatus.seconds_remaining)}</span>.</>
+                    )}
+                  </p>
+                  <p className="text-xs text-amber-600 mt-1">
+                    Browse the application to verify data. Accept to make permanent, or reject to revert.
+                  </p>
+                </div>
+                {canAccess("backups", "restore") && (
+                  <div className="flex gap-2 ml-4">
+                    <button
+                      onClick={handleRejectRestore}
+                      className="text-sm px-4 py-2 rounded border border-gray-300 text-gray-700 bg-white hover:bg-gray-50"
+                    >
+                      Reject
+                    </button>
+                    <button
+                      onClick={handleAcceptRestore}
+                      className="text-sm px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700"
+                    >
+                      Accept
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
 
           {actionMessage && (
             <div className="mb-4 p-3 rounded bg-blue-50 text-blue-700 text-sm">
@@ -224,7 +345,7 @@ export default function InfraBackupPage() {
                     {tier.tier === "postgres" && canAccess("backups", "create") && (
                       <button
                         onClick={() => handleTriggerBackup("postgres")}
-                        disabled={runningAction !== ""}
+                        disabled={runningAction !== "" || restoreStatus.active}
                         className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
                       >
                         {runningAction === "postgres" ? "Running..." : "Run Backup Now"}
@@ -241,7 +362,7 @@ export default function InfraBackupPage() {
                     )}
                     {tier.tier === "platform_config" && canAccess("backups", "restore") && (
                       <button
-                        onClick={() => handleRestore("config")}
+                        onClick={handleConfigRestore}
                         className="mt-1 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
                       >
                         Restore
@@ -327,12 +448,15 @@ export default function InfraBackupPage() {
                       <th className="text-left px-4 py-3 font-medium text-gray-700">Filename</th>
                       <th className="text-left px-4 py-3 font-medium text-gray-700">Date</th>
                       <th className="text-left px-4 py-3 font-medium text-gray-700">Size</th>
+                      {canAccess("backups", "restore") && (
+                        <th className="text-left px-4 py-3 font-medium text-gray-700"></th>
+                      )}
                     </tr>
                   </thead>
                   <tbody>
                     {pgSnapshots.length === 0 ? (
                       <tr>
-                        <td colSpan={3} className="px-4 py-8 text-center text-gray-500">
+                        <td colSpan={canAccess("backups", "restore") ? 4 : 3} className="px-4 py-8 text-center text-gray-500">
                           No snapshots available
                         </td>
                       </tr>
@@ -342,6 +466,17 @@ export default function InfraBackupPage() {
                           <td className="px-4 py-2.5 text-gray-900 font-mono text-xs">{s.filename}</td>
                           <td className="px-4 py-2.5 text-gray-600">{s.date}</td>
                           <td className="px-4 py-2.5 text-gray-600">{formatBytes(s.size_bytes)}</td>
+                          {canAccess("backups", "restore") && (
+                            <td className="px-4 py-2.5">
+                              <button
+                                onClick={() => handleStartRestore(s.filename)}
+                                disabled={restoreStatus.active || restoringFile !== ""}
+                                className="text-xs text-amber-600 hover:text-amber-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                {restoringFile === s.filename ? "Restoring..." : "Restore"}
+                              </button>
+                            </td>
+                          )}
                         </tr>
                       ))
                     )}

--- a/frontend/src/app/infrastructure/backup/page.tsx
+++ b/frontend/src/app/infrastructure/backup/page.tsx
@@ -16,14 +16,20 @@ interface BackupTier {
   next_scheduled: string | null;
   retention_days: number | null;
   status: string;
-  pitr_window_hours: number | null;
   versioning_enabled: boolean | null;
+  backup_count: number | null;
 }
 
 interface ConfigSnapshot {
   date: string;
   size_bytes: number | null;
   tier: string;
+}
+
+interface PostgresSnapshot {
+  filename: string;
+  date: string;
+  size_bytes: number | null;
 }
 
 const statusColors: Record<string, string> = {
@@ -47,8 +53,10 @@ export default function InfraBackupPage() {
   const [tiers, setTiers] = useState<BackupTier[]>([]);
   const [overallStatus, setOverallStatus] = useState("");
   const [snapshots, setSnapshots] = useState<ConfigSnapshot[]>([]);
+  const [pgSnapshots, setPgSnapshots] = useState<PostgresSnapshot[]>([]);
   const [loading, setLoading] = useState(true);
-  const [restoreMessage, setRestoreMessage] = useState("");
+  const [actionMessage, setActionMessage] = useState("");
+  const [backupRunning, setBackupRunning] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
@@ -57,13 +65,15 @@ export default function InfraBackupPage() {
 
     const load = async () => {
       try {
-        const [status, snaps] = await Promise.all([
+        const [status, snaps, pgSnaps] = await Promise.all([
           api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
           api.get<{ snapshots: ConfigSnapshot[] }>("/api/backups/config-snapshots"),
+          api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
         ]);
         setTiers(status.tiers);
         setOverallStatus(status.overall_status);
         setSnapshots(snaps.snapshots);
+        setPgSnapshots(pgSnaps.snapshots);
       } catch {
         // ignore
       } finally {
@@ -80,9 +90,33 @@ export default function InfraBackupPage() {
         `/api/backups/restore/${type}`,
         { confirmation_token: "CONFIRM" }
       );
-      setRestoreMessage(data.message);
+      setActionMessage(data.message);
     } catch (e) {
-      setRestoreMessage(e instanceof Error ? e.message : "Restore failed");
+      setActionMessage(e instanceof Error ? e.message : "Restore failed");
+    }
+  };
+
+  const handleTriggerBackup = async () => {
+    setBackupRunning(true);
+    setActionMessage("");
+    try {
+      const data = await api.post<{ status: string; filename: string; size_bytes: number }>(
+        "/api/backups/trigger/postgres",
+        {}
+      );
+      setActionMessage(`Backup completed: ${data.filename} (${formatBytes(data.size_bytes)})`);
+      // Refresh status
+      const [status, pgSnaps] = await Promise.all([
+        api.get<{ tiers: BackupTier[]; overall_status: string }>("/api/backups/status"),
+        api.get<{ snapshots: PostgresSnapshot[] }>("/api/backups/postgres-snapshots"),
+      ]);
+      setTiers(status.tiers);
+      setOverallStatus(status.overall_status);
+      setPgSnapshots(pgSnaps.snapshots);
+    } catch (e) {
+      setActionMessage(e instanceof Error ? e.message : "Backup failed");
+    } finally {
+      setBackupRunning(false);
     }
   };
 
@@ -94,9 +128,9 @@ export default function InfraBackupPage() {
         <main className="flex-1 overflow-y-auto p-6">
           <h1 className="text-2xl font-bold text-gray-900 mb-6">Backup & Recovery</h1>
 
-          {restoreMessage && (
+          {actionMessage && (
             <div className="mb-4 p-3 rounded bg-blue-50 text-blue-700 text-sm">
-              {restoreMessage}
+              {actionMessage}
             </div>
           )}
 
@@ -111,7 +145,7 @@ export default function InfraBackupPage() {
                 </span>
               </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
                 {tiers.map((tier) => (
                   <div key={tier.tier} className="bg-white rounded-lg border border-gray-200 p-4">
                     <div className="flex items-center justify-between mb-3">
@@ -137,10 +171,10 @@ export default function InfraBackupPage() {
                           <span className="text-gray-900">{tier.retention_days} days</span>
                         </div>
                       )}
-                      {tier.pitr_window_hours && (
+                      {tier.backup_count !== null && (
                         <div className="flex justify-between">
-                          <span>PITR Window:</span>
-                          <span className="text-gray-900">{tier.pitr_window_hours}h</span>
+                          <span>Backups:</span>
+                          <span className="text-gray-900">{tier.backup_count}</span>
                         </div>
                       )}
                       {tier.versioning_enabled !== null && (
@@ -156,9 +190,18 @@ export default function InfraBackupPage() {
                         </div>
                       )}
                     </div>
-                    {(tier.tier === "cloudsql" || tier.tier === "filestore" || tier.tier === "config") && (
+                    {tier.tier === "postgres" && canAccess("backups", "create") && (
                       <button
-                        onClick={() => handleRestore(tier.tier === "config" ? "config" : tier.tier)}
+                        onClick={handleTriggerBackup}
+                        disabled={backupRunning}
+                        className="mt-3 w-full text-sm bg-blue-50 text-blue-700 px-3 py-1.5 rounded hover:bg-blue-100 disabled:opacity-50"
+                      >
+                        {backupRunning ? "Running..." : "Run Backup Now"}
+                      </button>
+                    )}
+                    {tier.tier === "platform_config" && canAccess("backups", "restore") && (
+                      <button
+                        onClick={() => handleRestore("config")}
                         className="mt-3 w-full text-sm bg-gray-100 text-gray-700 px-3 py-1.5 rounded hover:bg-gray-200"
                       >
                         Restore
@@ -166,6 +209,36 @@ export default function InfraBackupPage() {
                     )}
                   </div>
                 ))}
+              </div>
+
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">PostgreSQL Snapshots</h2>
+              <div className="bg-white rounded-lg border border-gray-200 mb-8">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Filename</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Date</th>
+                      <th className="text-left px-4 py-3 font-medium text-gray-700">Size</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pgSnapshots.length === 0 ? (
+                      <tr>
+                        <td colSpan={3} className="px-4 py-8 text-center text-gray-500">
+                          No snapshots available
+                        </td>
+                      </tr>
+                    ) : (
+                      pgSnapshots.map((s) => (
+                        <tr key={s.filename} className="border-b hover:bg-gray-50">
+                          <td className="px-4 py-2.5 text-gray-900 font-mono text-xs">{s.filename}</td>
+                          <td className="px-4 py-2.5 text-gray-600">{s.date}</td>
+                          <td className="px-4 py-2.5 text-gray-600">{formatBytes(s.size_bytes)}</td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
               </div>
 
               <h2 className="text-lg font-semibold text-gray-900 mb-4">Config Snapshots</h2>

--- a/frontend/src/components/dashboard/InfrastructureHealthWidget.tsx
+++ b/frontend/src/components/dashboard/InfrastructureHealthWidget.tsx
@@ -4,25 +4,45 @@ import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 
-interface ComponentHealth {
+interface ServiceHealth {
   name: string;
   status: string;
-  enabled: boolean;
 }
 
+const SERVICE_LABELS: Record<string, string> = {
+  auth: "Authentication",
+  backups: "Backups",
+  environments: "Environments",
+  experiments: "Experiments",
+  infrastructure: "Infrastructure",
+  notebooks: "Notebooks",
+  notifications: "Notifications",
+  pipelines: "Pipelines",
+  projects: "Projects",
+  samples: "Samples",
+  storage: "Storage",
+};
+
 export function InfrastructureHealthWidget() {
-  const [components, setComponents] = useState<ComponentHealth[]>([]);
+  const [services, setServices] = useState<ServiceHealth[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const timeout = setTimeout(() => setLoading(false), 60000);
+  const loadHealth = () => {
     api
-      .getWithRetry<{ components: ComponentHealth[] }>("/api/components")
-      .then((data) => setComponents(data.components.filter((c) => c.enabled)))
-      .catch(() => setError("Failed to load component health"))
-      .finally(() => { clearTimeout(timeout); setLoading(false); });
-    return () => clearTimeout(timeout);
+      .get<{ services: ServiceHealth[] }>("/api/health/services")
+      .then((data) => {
+        setServices(data.services);
+        setError(null);
+      })
+      .catch(() => setError("Failed to load service health"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadHealth();
+    const interval = setInterval(loadHealth, 60000);
+    return () => clearInterval(interval);
   }, []);
 
   const statusColor: Record<string, string> = {
@@ -35,7 +55,7 @@ export function InfrastructureHealthWidget() {
   return (
     <div className="bg-white rounded-lg shadow p-5" data-testid="widget-infrastructure-health">
       <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
-        Infrastructure Health
+        Service Health
       </h3>
       {loading && (
         <div className="flex items-center gap-2 text-gray-400 py-4" data-testid="widget-loading">
@@ -46,24 +66,24 @@ export function InfrastructureHealthWidget() {
         <div className="text-sm text-red-600" data-testid="widget-error">
           {error}
           <button
-            onClick={() => window.location.reload()}
+            onClick={loadHealth}
             className="ml-2 text-bioaf-600 hover:underline"
           >
             Retry
           </button>
         </div>
       )}
-      {!loading && !error && components.length === 0 && (
+      {!loading && !error && services.length === 0 && (
         <p className="text-sm text-gray-400" data-testid="widget-empty">
-          No enabled components found. Enable components in Infrastructure settings.
+          No service activity in the last 5 minutes.
         </p>
       )}
-      {!loading && !error && components.length > 0 && (
+      {!loading && !error && services.length > 0 && (
         <div className="grid grid-cols-2 gap-2">
-          {components.map((c) => (
-            <div key={c.name} className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-50">
-              <span className={`w-2 h-2 rounded-full ${statusColor[c.status] || statusColor.unknown}`} />
-              <span className="text-sm text-gray-700 truncate">{c.name}</span>
+          {services.map((s) => (
+            <div key={s.name} className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-50">
+              <span className={`w-2 h-2 rounded-full ${statusColor[s.status] || statusColor.unknown}`} />
+              <span className="text-sm text-gray-700 truncate">{SERVICE_LABELS[s.name] || s.name}</span>
             </div>
           ))}
         </div>

--- a/frontend/tests/components/dashboard/widgets.test.tsx
+++ b/frontend/tests/components/dashboard/widgets.test.tsx
@@ -33,15 +33,15 @@ describe("Dashboard Widgets", () => {
   describe("InfrastructureHealthWidget", () => {
     it("renders with mock data", async () => {
       mockApiGet.mockResolvedValueOnce({
-        components: [
-          { name: "GKE", status: "healthy", enabled: true },
-          { name: "GCS", status: "healthy", enabled: true },
+        services: [
+          { name: "experiments", status: "healthy" },
+          { name: "storage", status: "healthy" },
         ],
       });
       render(<InfrastructureHealthWidget />);
       await waitFor(() => {
-        expect(screen.getByText("GKE")).toBeInTheDocument();
-        expect(screen.getByText("GCS")).toBeInTheDocument();
+        expect(screen.getByText("Experiments")).toBeInTheDocument();
+        expect(screen.getByText("Storage")).toBeInTheDocument();
       });
     });
 
@@ -52,7 +52,7 @@ describe("Dashboard Widgets", () => {
     });
 
     it("handles empty state", async () => {
-      mockApiGet.mockResolvedValueOnce({ components: [] });
+      mockApiGet.mockResolvedValueOnce({ services: [] });
       render(<InfrastructureHealthWidget />);
       await waitFor(() => {
         expect(screen.getByTestId("widget-empty")).toBeInTheDocument();

--- a/helm/bioaf/templates/cronjob-config-backup.yaml
+++ b/helm/bioaf/templates/cronjob-config-backup.yaml
@@ -23,6 +23,6 @@ spec:
                   set -e
                   TIMESTAMP=$(date +%Y%m%d-%H%M%S)
                   curl -s http://{{ .Release.Name }}-backend:{{ .Values.backend.port }}/api/config > /tmp/config-backup.json
-                  gsutil cp /tmp/config-backup.json gs://{{ .Values.backend.env.BIOAF_GCS_BUCKET }}/config-backups/config-${TIMESTAMP}.json
-                  gsutil ls gs://{{ .Values.backend.env.BIOAF_GCS_BUCKET }}/config-backups/ | sort -r | tail -n +{{ add .Values.configBackup.retentionDays 1 }} | xargs -r gsutil rm
+                  gsutil cp /tmp/config-backup.json gs://{{ .Values.backupsBucket }}/config/config-${TIMESTAMP}.json
+                  gsutil ls gs://{{ .Values.backupsBucket }}/config/ | sort -r | tail -n +{{ add .Values.configBackup.retentionDays 1 }} | xargs -r gsutil rm
           restartPolicy: OnFailure

--- a/helm/bioaf/templates/cronjob-db-backup.yaml
+++ b/helm/bioaf/templates/cronjob-db-backup.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-db-backup
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  schedule: {{ .Values.dbBackup.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.serviceAccount.name }}
+          containers:
+            - name: db-backup
+              image: "{{ .Values.dbBackup.image.repository }}:{{ .Values.dbBackup.image.tag }}"
+              imagePullPolicy: {{ .Values.dbBackup.image.pullPolicy }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  curl -sf -X POST \
+                    http://{{ .Release.Name }}-backend:{{ .Values.backend.port }}/api/backups/trigger/postgres \
+                    -H "Content-Type: application/json" \
+                    -H "X-Internal-Service: db-backup-cronjob"
+          restartPolicy: OnFailure

--- a/helm/bioaf/values.yaml
+++ b/helm/bioaf/values.yaml
@@ -41,9 +41,18 @@ ingress:
     networking.gke.io/managed-certificates: bioaf-cert
     kubernetes.io/ingress.global-static-ip-name: bioaf-ip
 
+backupsBucket: ""
+
 configBackup:
   schedule: "0 2 * * *"
   retentionDays: 7
+  image:
+    repository: ghcr.io/bioaf/bioaf-backend
+    tag: latest
+    pullPolicy: IfNotPresent
+
+dbBackup:
+  schedule: "0 3 * * *"
   image:
     repository: ghcr.io/bioaf/bioaf-backend
     tag: latest

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -79,7 +79,8 @@ resource "google_storage_bucket" "results" {
   }
 }
 
-# Config backups bucket
+# DEPRECATED: Backups now go to the persistent backups bucket in the
+# foundation module. Kept for backward compatibility with existing deploys.
 resource "google_storage_bucket" "config_backups" {
   name                        = "bioaf-config-backups-${local.bucket_suffix}"
   location                    = var.region


### PR DESCRIPTION
## Summary

- **Logging**: Remove duplicate uvicorn access logs, keep the custom middleware that includes response timing and header redaction
- **Check for updates**: Wire Settings > Information "Check for updates" button to the GitHub Releases API with version comparison, changelog, and 1-hour cache
- **Backup & Recovery overhaul**: Replace the 5-tier mock backup system with a working 4-tier system (PostgreSQL pg_dump, GCS Object Versioning, Platform Config, Terraform State)
  - All backups go to GCS, never local filesystem
  - Persistent backups bucket in the Terraform foundation module (survives storage teardown)
  - On-demand backup triggers for database and config from the UI
  - Configurable schedule and retention settings persisted to platform_config
  - Terraform state file listing and download
  - Backup rotation based on retention settings
- **Database restore**: Full restore flow with 1-hour review period
  - Admin selects a pg_dump snapshot to restore
  - Backend creates bioaf_restore DB, runs pg_restore, swaps the connection pool
  - Admin reviews the restored data with a persistent countdown banner
  - Accept makes it permanent (DB rename), reject or timeout reverts automatically
  - Service restart during review naturally reverts (env var unchanged)
- **Dashboard service health**: Replace static grey dots with live health indicators
  - Logging middleware feeds in-memory request counters per service
  - Health derived from 5-minute rolling success rate (>75% green, 50-74% yellow, <50% red)
  - Services with no traffic stay grey, widget auto-refreshes every 60 seconds
- **ADR-004 revised** to reflect the implemented 4-tier GCS-only architecture

## Test plan

- [ ] Backend: 1580+ tests passing (pytest)
- [ ] Frontend: 392 tests passing (jest)
- [ ] Ruff format/check: clean
- [ ] Mypy: clean
- [ ] TSC: clean
- [ ] Markdown lint: clean
- [ ] Manual: trigger database backup, verify file appears in GCS bucket
- [ ] Manual: trigger config backup, verify JSON in GCS
- [ ] Manual: restore from a database backup, review, accept
- [ ] Manual: verify dashboard dots turn green after page traffic
- [ ] Manual: check for updates button on Settings > Information page