### PR TITLE
Fix cellxgene adapter, image pipeline, and publish UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,68 +26,9 @@ A turnkey computational biology platform for small biotech companies (5-50 resea
 
 ## Architecture
 
-```text
-                        +----------------------------+
-                        |     Researcher's Browser   |
-                        +----------------------------+
-                                     |
-                    +----------------+-----------------+
-                    |        Frontend (Next.js 14)     |
-                    |                                  |
-                    |  Projects   Pipelines   Results  |
-                    |  Workbench  Data & Files  Infra  |
-                    +-----------------+----------------+
-                                      |
-                    +-----------------+-----------------+
-                    |        Backend (FastAPI)          |
-                    |                                   |
-                    |  Experiment     Pipeline    File  |
-                    |  Service        Orchestrator Mgr  |
-                    |                                   |
-                    |  Event Bus  Notifications  Audit  |
-                    +---------+----------+--------------+
-                              |          |
-               +--------------+    +-----+----------+
-               |                   |  PostgreSQL 16 |
-               |                   |  (Cloud SQL)   |
-               |                   +----------------+
-               |
-    +----------+-----------+
-    | BioAF Adapter Layer  |
-    |       (BAL)          |
-    |                      |
-    |  Compute   Storage   |
-    |  Provider  Provider  |
-    |  Notebook Provider   |
-    +--+-------+-------+---+
-       |       |       |
-       v       v       v
-  +---------+-----+---------+              +--------------------+
-  |     GKE Autopilot       |              |  SLURM + NFS       |
-  |  +---------+---------+  |              |  (coming soon)     |
-  |  |Pipelines|Notebooks|  |              +--------------------+
-  |  |Node Pool|Node Pool|  |
-  |  +---------+---------+  |
-  +----------+--+-----------+
-             |  |
-  +----------+  +----------+
-  |                        |
-  v                        v
-+----------+     +---------+---------+---------+---------+
-| Secret   |     |              GCS Buckets              |
-| Manager  |     |  ingest/  raw/  working/  results/    |
-+----------+     +---------------------------------------+
-
-                         Data Flow
-                         --------
-
-  FASTQs from sequencer         Pipeline results
-        |                              ^
-        v                              |
-  [ bioaf-ingest ]  -->  [ bioaf-raw ]  -->  [ bioaf-working ]  -->  [ bioaf-results ]
-    auto-ingest          permanent           intermediate             final outputs
-    (Pub/Sub)            storage             (TTL 30 days)            h5ad, plots, QC
-```
+<p align="center">
+  <img src="assets/bioAF_Architecture.svg" alt="bioAF System Architecture" width="100%" />
+</p>
 
 ### How it works
 

--- a/assets/bioAF_Architecture.svg
+++ b/assets/bioAF_Architecture.svg
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 950" width="1200" height="950">
+  <defs>
+    <marker id="ah" markerWidth="6" markerHeight="5" refX="6" refY="2.5" orient="auto">
+      <polygon points="0 0, 6 2.5, 0 5" fill="#94A3B8"/>
+    </marker>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="950" fill="#F8FAFC"/>
+
+  <!-- Title -->
+  <text x="430" y="32" text-anchor="middle" font-size="20" font-weight="bold" fill="#1E293B">bioAF v0.4.0 — System Architecture</text>
+
+  <!-- ==================== BROWSER ==================== -->
+  <rect x="295" y="52" width="250" height="38" rx="8" fill="#3B82F6"/>
+  <text x="420" y="76" text-anchor="middle" font-size="13" font-weight="600" fill="#FFFFFF">Researcher's Browser</text>
+
+  <!-- Arrow: Browser to Nginx -->
+  <line x1="420" y1="90" x2="420" y2="112" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+
+  <!-- ==================== NGINX ==================== -->
+  <rect x="40" y="115" width="760" height="30" rx="6" fill="#475569"/>
+  <text x="420" y="135" text-anchor="middle" font-size="11" fill="#FFFFFF">Nginx Reverse Proxy · HTTP/HTTPS · TLS Termination</text>
+
+  <!-- Arrow: Nginx to Frontend -->
+  <line x1="420" y1="145" x2="420" y2="163" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+
+  <!-- ==================== FRONTEND ==================== -->
+  <path d="M48,165 H792 Q800,165 800,173 V193 H40 V173 Q40,165 48,165 Z" fill="#2563EB"/>
+  <path d="M40,193 H800 V275 Q800,283 792,283 H48 Q40,283 40,275 V193 Z" fill="#EFF6FF"/>
+  <text x="420" y="183" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">Frontend — Next.js 14 / React 18 / TypeScript / Tailwind CSS</text>
+
+  <!-- Frontend Row 1 -->
+  <rect x="50" y="199" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="140" y="220" text-anchor="middle" font-size="11" fill="#1E40AF">Dashboard</text>
+
+  <rect x="237" y="199" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="327" y="220" text-anchor="middle" font-size="11" fill="#1E40AF">Experiments &amp; Samples</text>
+
+  <rect x="424" y="199" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="514" y="220" text-anchor="middle" font-size="11" fill="#1E40AF">Pipelines &amp; Runs</text>
+
+  <rect x="611" y="199" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="701" y="220" text-anchor="middle" font-size="11" fill="#1E40AF">Notebooks &amp; Environments</text>
+
+  <!-- Frontend Row 2 -->
+  <rect x="50" y="241" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="140" y="262" text-anchor="middle" font-size="11" fill="#1E40AF">Data &amp; Files</text>
+
+  <rect x="237" y="241" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="327" y="262" text-anchor="middle" font-size="11" fill="#1E40AF">Results &amp; Visualization</text>
+
+  <rect x="424" y="241" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="514" y="262" text-anchor="middle" font-size="11" fill="#1E40AF">Infrastructure</text>
+
+  <rect x="611" y="241" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="701" y="262" text-anchor="middle" font-size="11" fill="#1E40AF">Settings &amp; Admin</text>
+
+  <!-- Arrow: Frontend to Backend -->
+  <line x1="420" y1="283" x2="420" y2="301" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+
+  <!-- ==================== BACKEND ==================== -->
+  <path d="M48,303 H792 Q800,303 800,311 V331 H40 V311 Q40,303 48,303 Z" fill="#2563EB"/>
+  <path d="M40,331 H800 V453 Q800,461 792,461 H48 Q40,461 40,453 V331 Z" fill="#EFF6FF"/>
+  <text x="420" y="321" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">Backend — FastAPI / Python 3.12 / Async</text>
+
+  <!-- Backend Row 1 -->
+  <rect x="50" y="337" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="140" y="358" text-anchor="middle" font-size="11" fill="#1E40AF">Experiment Service</text>
+
+  <rect x="237" y="337" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="327" y="358" text-anchor="middle" font-size="11" fill="#1E40AF">Pipeline Orchestrator</text>
+
+  <rect x="424" y="337" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="514" y="358" text-anchor="middle" font-size="11" fill="#1E40AF">Notebook Manager</text>
+
+  <rect x="611" y="337" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="701" y="358" text-anchor="middle" font-size="11" fill="#1E40AF">File Manager</text>
+
+  <!-- Backend Row 2 -->
+  <rect x="50" y="377" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="140" y="398" text-anchor="middle" font-size="11" fill="#1E40AF">Environment Builder</text>
+
+  <rect x="237" y="377" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="327" y="398" text-anchor="middle" font-size="11" fill="#1E40AF">Cost Service</text>
+
+  <rect x="424" y="377" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="514" y="398" text-anchor="middle" font-size="11" fill="#1E40AF">Backup &amp; Recovery</text>
+
+  <rect x="611" y="377" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="701" y="398" text-anchor="middle" font-size="11" fill="#1E40AF">Infrastructure (TF)</text>
+
+  <!-- Backend Row 3 -->
+  <rect x="50" y="417" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="140" y="438" text-anchor="middle" font-size="11" fill="#1E40AF">Event Bus</text>
+
+  <rect x="237" y="417" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="327" y="438" text-anchor="middle" font-size="11" fill="#1E40AF">Notification Router</text>
+
+  <rect x="424" y="417" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="514" y="438" text-anchor="middle" font-size="11" fill="#1E40AF">Search Integration</text>
+
+  <rect x="611" y="417" width="180" height="32" rx="5" fill="#FFFFFF" stroke="#BFDBFE" stroke-width="1"/>
+  <text x="701" y="438" text-anchor="middle" font-size="11" fill="#1E40AF">GitOps</text>
+
+  <!-- Arrows: Backend to PostgreSQL and BAL -->
+  <line x1="150" y1="461" x2="150" y2="481" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+  <line x1="540" y1="461" x2="540" y2="481" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+
+  <!-- ==================== POSTGRESQL ==================== -->
+  <rect x="40" y="483" width="220" height="68" rx="8" fill="#059669"/>
+  <text x="150" y="510" text-anchor="middle" font-size="13" font-weight="600" fill="#FFFFFF">PostgreSQL 16</text>
+  <text x="150" y="527" text-anchor="middle" font-size="10" fill="#A7F3D0">Docker Container</text>
+  <text x="150" y="542" text-anchor="middle" font-size="10" fill="#A7F3D0">SQLAlchemy · Alembic (57 migrations)</text>
+
+  <!-- ==================== BAL ==================== -->
+  <path d="M288,483 H792 Q800,483 800,491 V511 H280 V491 Q280,483 288,483 Z" fill="#D97706"/>
+  <path d="M280,511 H800 V543 Q800,551 792,551 H288 Q280,551 280,543 V511 Z" fill="#FFFBEB"/>
+  <text x="540" y="501" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">BioAF Adapter Layer (BAL)</text>
+
+  <rect x="286" y="515" width="122" height="30" rx="5" fill="#FFFFFF" stroke="#FDE68A" stroke-width="1"/>
+  <text x="347" y="534" text-anchor="middle" font-size="10" fill="#92400E">Compute Provider</text>
+
+  <rect x="414" y="515" width="122" height="30" rx="5" fill="#FFFFFF" stroke="#FDE68A" stroke-width="1"/>
+  <text x="475" y="534" text-anchor="middle" font-size="10" fill="#92400E">Storage Provider</text>
+
+  <rect x="542" y="515" width="122" height="30" rx="5" fill="#FFFFFF" stroke="#FDE68A" stroke-width="1"/>
+  <text x="603" y="534" text-anchor="middle" font-size="10" fill="#92400E">Notebook Provider</text>
+
+  <rect x="670" y="515" width="122" height="30" rx="5" fill="#FFFFFF" stroke="#FDE68A" stroke-width="1"/>
+  <text x="731" y="534" text-anchor="middle" font-size="10" fill="#92400E">Cellxgene Provider</text>
+
+  <!-- Arrow: BAL to GKE -->
+  <line x1="540" y1="551" x2="540" y2="571" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+
+  <!-- ==================== GKE AUTOPILOT ==================== -->
+  <path d="M48,573 H792 Q800,573 800,581 V601 H40 V581 Q40,573 48,573 Z" fill="#059669"/>
+  <path d="M40,601 H800 V687 Q800,695 792,695 H48 Q40,695 40,687 V601 Z" fill="#ECFDF5"/>
+  <text x="420" y="591" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">GKE Autopilot — Kubernetes Workloads</text>
+
+  <!-- GKE Row 1 (4 items) -->
+  <rect x="50" y="609" width="178" height="32" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="139" y="630" text-anchor="middle" font-size="10" fill="#065F46">Pipelines (NF / Snakemake)</text>
+
+  <rect x="235" y="609" width="178" height="32" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="324" y="630" text-anchor="middle" font-size="11" fill="#065F46">JupyterHub Sessions</text>
+
+  <rect x="420" y="609" width="178" height="32" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="509" y="630" text-anchor="middle" font-size="11" fill="#065F46">RStudio Sessions</text>
+
+  <rect x="605" y="609" width="178" height="32" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="694" y="630" text-anchor="middle" font-size="11" fill="#065F46">SSH Work Nodes</text>
+
+  <!-- GKE Row 2 (3 items) -->
+  <rect x="50" y="651" width="242" height="32" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="171" y="672" text-anchor="middle" font-size="11" fill="#065F46">cellxgene Viewer</text>
+
+  <rect x="299" y="651" width="242" height="32" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="420" y="672" text-anchor="middle" font-size="11" fill="#065F46">QC Dashboards</text>
+
+  <rect x="548" y="651" width="242" height="32" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="669" y="672" text-anchor="middle" font-size="11" fill="#065F46">Meilisearch</text>
+
+  <!-- Arrow: GKE to GCP Services -->
+  <line x1="420" y1="695" x2="420" y2="713" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+
+  <!-- ==================== GCP SERVICES ==================== -->
+  <rect x="50" y="715" width="242" height="34" rx="6" fill="#059669"/>
+  <text x="171" y="737" text-anchor="middle" font-size="11" font-weight="600" fill="#FFFFFF">Secret Manager</text>
+
+  <rect x="299" y="715" width="242" height="34" rx="6" fill="#059669"/>
+  <text x="420" y="737" text-anchor="middle" font-size="11" font-weight="600" fill="#FFFFFF">Cloud Build</text>
+
+  <rect x="548" y="715" width="242" height="34" rx="6" fill="#059669"/>
+  <text x="669" y="737" text-anchor="middle" font-size="11" font-weight="600" fill="#FFFFFF">Artifact Registry</text>
+
+  <!-- Arrow: GCP Services to GCS -->
+  <line x1="420" y1="749" x2="420" y2="767" stroke="#94A3B8" stroke-width="2" marker-end="url(#ah)"/>
+
+  <!-- ==================== GCS BUCKETS ==================== -->
+  <path d="M48,769 H792 Q800,769 800,777 V797 H40 V777 Q40,769 48,769 Z" fill="#059669"/>
+  <path d="M40,797 H800 V829 Q800,837 792,837 H48 Q40,837 40,829 V797 Z" fill="#ECFDF5"/>
+  <text x="420" y="787" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">Google Cloud Storage</text>
+
+  <rect x="46" y="801" width="144" height="30" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="118" y="820" text-anchor="middle" font-size="10" fill="#065F46">bioaf-ingest</text>
+
+  <rect x="197" y="801" width="144" height="30" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="269" y="820" text-anchor="middle" font-size="10" fill="#065F46">bioaf-raw</text>
+
+  <rect x="348" y="801" width="144" height="30" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="420" y="820" text-anchor="middle" font-size="10" fill="#065F46">bioaf-working</text>
+
+  <rect x="499" y="801" width="144" height="30" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="571" y="820" text-anchor="middle" font-size="10" fill="#065F46">bioaf-results</text>
+
+  <rect x="650" y="801" width="144" height="30" rx="5" fill="#FFFFFF" stroke="#A7F3D0" stroke-width="1"/>
+  <text x="722" y="820" text-anchor="middle" font-size="10" fill="#065F46">bioaf-backups</text>
+
+  <!-- ==================== RIGHT SIDEBAR ==================== -->
+  <path d="M838,165 H1152 Q1160,165 1160,173 V193 H830 V173 Q830,165 838,165 Z" fill="#7C3AED"/>
+  <path d="M830,193 H1160 V829 Q1160,837 1152,837 H838 Q830,837 830,829 V193 Z" fill="#F5F3FF"/>
+  <text x="995" y="183" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">Cross-Cutting Concerns</text>
+
+  <!-- 1. JWT Authentication -->
+  <rect x="842" y="210" width="306" height="65" rx="6" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="1"/>
+  <text x="995" y="232" text-anchor="middle" font-size="12" font-weight="600" fill="#5B21B6">JWT Authentication</text>
+  <text x="995" y="248" text-anchor="middle" font-size="10" fill="#6B7280">HS256 tokens · Bearer auth</text>
+  <text x="995" y="263" text-anchor="middle" font-size="10" fill="#6B7280">Public path bypass for health / login</text>
+
+  <!-- 2. Middleware Stack -->
+  <rect x="842" y="289" width="306" height="65" rx="6" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="1"/>
+  <text x="995" y="311" text-anchor="middle" font-size="12" font-weight="600" fill="#5B21B6">Middleware Stack</text>
+  <text x="995" y="327" text-anchor="middle" font-size="10" fill="#6B7280">Auth · Logging · Rate Limiting</text>
+  <text x="995" y="342" text-anchor="middle" font-size="10" fill="#6B7280">Security Headers (HSTS, CSP, XFO)</text>
+
+  <!-- 3. Immutable Audit Log -->
+  <rect x="842" y="368" width="306" height="65" rx="6" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="1"/>
+  <text x="995" y="390" text-anchor="middle" font-size="12" font-weight="600" fill="#5B21B6">Immutable Audit Log</text>
+  <text x="995" y="406" text-anchor="middle" font-size="10" fill="#6B7280">Every action recorded with full context</text>
+  <text x="995" y="421" text-anchor="middle" font-size="10" fill="#6B7280">Filterable · Exportable · Paginated</text>
+
+  <!-- 4. Notifications -->
+  <rect x="842" y="447" width="306" height="65" rx="6" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="1"/>
+  <text x="995" y="469" text-anchor="middle" font-size="12" font-weight="600" fill="#5B21B6">Event-Driven Notifications</text>
+  <text x="995" y="485" text-anchor="middle" font-size="10" fill="#6B7280">In-app · Email (SMTP) · Slack (OAuth)</text>
+  <text x="995" y="500" text-anchor="middle" font-size="10" fill="#6B7280">30+ subscribable event types</text>
+
+  <!-- 5. Custom RBAC -->
+  <rect x="842" y="526" width="306" height="65" rx="6" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="1"/>
+  <text x="995" y="548" text-anchor="middle" font-size="12" font-weight="600" fill="#5B21B6">Custom RBAC</text>
+  <text x="995" y="564" text-anchor="middle" font-size="10" fill="#6B7280">4 built-in roles + custom creation</text>
+  <text x="995" y="579" text-anchor="middle" font-size="10" fill="#6B7280">Per-resource, per-action grants</text>
+
+  <!-- 6. 4-Tier Backup -->
+  <rect x="842" y="605" width="306" height="65" rx="6" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="1"/>
+  <text x="995" y="627" text-anchor="middle" font-size="12" font-weight="600" fill="#5B21B6">4-Tier Backup System</text>
+  <text x="995" y="643" text-anchor="middle" font-size="10" fill="#6B7280">pg_dump · GCS versioning</text>
+  <text x="995" y="658" text-anchor="middle" font-size="10" fill="#6B7280">Config exports · Terraform state</text>
+
+  <!-- 7. UI-Driven Terraform -->
+  <rect x="842" y="684" width="306" height="65" rx="6" fill="#FFFFFF" stroke="#DDD6FE" stroke-width="1"/>
+  <text x="995" y="706" text-anchor="middle" font-size="12" font-weight="600" fill="#5B21B6">UI-Driven Terraform</text>
+  <text x="995" y="722" text-anchor="middle" font-size="10" fill="#6B7280">Infrastructure as Code via browser</text>
+  <text x="995" y="737" text-anchor="middle" font-size="10" fill="#6B7280">Component catalog with cost estimates</text>
+
+  <!-- ==================== NOTES ==================== -->
+  <text x="420" y="870" text-anchor="middle" font-size="11" fill="#94A3B8" font-style="italic">SLURM + NFS compute stack is architecturally defined in the BioAF Adapter Layer but not yet implemented.</text>
+
+  <!-- ==================== LEGEND ==================== -->
+  <rect x="280" y="895" width="14" height="14" rx="3" fill="#2563EB"/>
+  <text x="300" y="907" font-size="11" fill="#475569">Application Layer</text>
+
+  <rect x="430" y="895" width="14" height="14" rx="3" fill="#059669"/>
+  <text x="450" y="907" font-size="11" fill="#475569">GCP Infrastructure</text>
+
+  <rect x="590" y="895" width="14" height="14" rx="3" fill="#D97706"/>
+  <text x="610" y="907" font-size="11" fill="#475569">Adapter Layer</text>
+
+  <rect x="730" y="895" width="14" height="14" rx="3" fill="#7C3AED"/>
+  <text x="750" y="907" font-size="11" fill="#475569">Cross-Cutting</text>
+
+  <rect x="870" y="895" width="14" height="14" rx="3" fill="#475569"/>
+  <text x="890" y="907" font-size="11" fill="#475569">Reverse Proxy</text>
+
+</svg>

--- a/backend/alembic/versions/056_add_access_url_to_cellxgene_publications.py
+++ b/backend/alembic/versions/056_add_access_url_to_cellxgene_publications.py
@@ -1,0 +1,24 @@
+"""Add access_url to cellxgene_publications.
+
+Revision ID: 056
+Revises: 055
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "056"
+down_revision = "055"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cellxgene_publications",
+        sa.Column("access_url", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("cellxgene_publications", "access_url")

--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -114,3 +114,22 @@ class NotebookProvider(ABC):
     @abstractmethod
     async def get_connection_command(self, session_id: str) -> str:
         """Get SSH/exec command for direct access to the session."""
+
+
+class CellxgeneProvider(ABC):
+    """Abstract interface for cellxgene visualization backends."""
+
+    @abstractmethod
+    async def deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
+        """Deploy a cellxgene instance for an h5ad dataset.
+
+        Returns dict with pod_name, namespace, status, and access_url.
+        """
+
+    @abstractmethod
+    async def teardown(self, publication_id: int) -> dict:
+        """Tear down a cellxgene instance. Returns confirmation dict."""
+
+    @abstractmethod
+    async def get_status(self, publication_id: int) -> dict:
+        """Get the status of a cellxgene instance."""

--- a/backend/app/adapters/cellxgene/kubernetes.py
+++ b/backend/app/adapters/cellxgene/kubernetes.py
@@ -55,19 +55,24 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
         self._cluster_config: dict | None = None
         self._namespace_ready = False
 
-    async def _resolve_image(self) -> str:
-        """Read the cellxgene image URI from platform_config."""
+    async def _read_platform_config(self, *keys: str) -> dict[str, str]:
+        """Read values from platform_config."""
         if not self._session_factory:
-            raise RuntimeError("No session_factory; cannot resolve cellxgene image URI")
+            return {}
 
         from sqlalchemy import text as sa_text
 
+        placeholders = ", ".join(f"'{k}'" for k in keys)
         async with self._session_factory() as session:
-            row = (
-                await session.execute(sa_text("SELECT value FROM platform_config WHERE key = 'cellxgene_image'"))
-            ).fetchone()
+            result = await session.execute(
+                sa_text(f"SELECT key, value FROM platform_config WHERE key IN ({placeholders})")
+            )
+            return {r[0]: r[1] for r in result.fetchall()}
 
-        uri = row[0] if row else None
+    async def _resolve_image(self) -> str:
+        """Read the cellxgene image URI from platform_config."""
+        config = await self._read_platform_config("cellxgene_image")
+        uri = config.get("cellxgene_image")
         if not uri or uri == "null":
             raise RuntimeError("Cellxgene image not built yet. Enable the cellxgene component to trigger a build.")
         return uri
@@ -77,7 +82,9 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
         image = await self._resolve_image()
 
         namespace = DEFAULT_CELLXGENE_NAMESPACE
-        await self.ensure_cellxgene_namespace(namespace)
+        config = await self._read_platform_config("notebook_runner_sa_email")
+        sa_email = (config.get("notebook_runner_sa_email") or "").strip()
+        await self.ensure_cellxgene_namespace(namespace, gcp_sa_email=sa_email)
 
         name = f"cellxgene-{publication_id}"
         apps_v1 = self._get_k8s_apps_client()
@@ -364,6 +371,7 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
             logger.info("Namespace %s already exists, skipping setup", namespace)
             if gcp_sa_email:
                 self._patch_sa_annotation(core_v1, namespace, gcp_sa_email)
+                await self._ensure_workload_identity_binding(gcp_sa_email, namespace)
             self._namespace_ready = True
             return
         except ApiException as e:
@@ -418,7 +426,87 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
             ),
         )
         logger.info("Created role binding in %s", namespace)
+
+        # Bind the KSA to the GCP SA for Workload Identity
+        if gcp_sa_email:
+            await self._ensure_workload_identity_binding(gcp_sa_email, namespace)
+
         self._namespace_ready = True
+
+    async def _ensure_workload_identity_binding(self, gcp_sa_email: str, namespace: str) -> None:
+        """Grant the cellxgene KSA permission to impersonate the GCP SA."""
+        try:
+            import google.auth
+            import google.auth.transport.requests
+            import json as _json
+            import urllib.request
+
+            config = await self._read_platform_config("gcp_credential_source", "gcp_service_account_key")
+            sa_key = config.get("gcp_service_account_key", "")
+            if sa_key and sa_key != "null":
+                from google.oauth2 import service_account as sa_mod
+
+                credentials = sa_mod.Credentials.from_service_account_info(
+                    _json.loads(sa_key),
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                )
+            else:
+                credentials, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+
+            auth_req = google.auth.transport.requests.Request()
+            credentials.refresh(auth_req)
+
+            member = f"serviceAccount:{gcp_sa_email.split('@')[1].split('.')[0]}.svc.id.goog[{namespace}/bioaf-cellxgene-runner]"
+
+            # Get current IAM policy
+            url = f"https://iam.googleapis.com/v1/projects/-/serviceAccounts/{gcp_sa_email}:getIamPolicy"
+            req = urllib.request.Request(
+                url,
+                data=b"{}",
+                headers={
+                    "Authorization": f"Bearer {credentials.token}",
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req) as resp:
+                policy = _json.loads(resp.read().decode())
+
+            # Check if binding already exists
+            bindings = policy.get("bindings", [])
+            wi_binding = None
+            for b in bindings:
+                if b["role"] == "roles/iam.workloadIdentityUser":
+                    wi_binding = b
+                    break
+
+            if wi_binding and member in wi_binding.get("members", []):
+                logger.info("Workload Identity binding already exists for %s", member)
+                return
+
+            if wi_binding:
+                wi_binding["members"].append(member)
+            else:
+                bindings.append({"role": "roles/iam.workloadIdentityUser", "members": [member]})
+            policy["bindings"] = bindings
+
+            # Set updated policy
+            set_url = f"https://iam.googleapis.com/v1/projects/-/serviceAccounts/{gcp_sa_email}:setIamPolicy"
+            set_req = urllib.request.Request(
+                set_url,
+                data=_json.dumps({"policy": policy}).encode(),
+                headers={
+                    "Authorization": f"Bearer {credentials.token}",
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(set_req) as resp:
+                resp.read()
+
+            logger.info("Added Workload Identity binding for %s on %s", member, gcp_sa_email)
+        except Exception:
+            logger.exception("Failed to set Workload Identity binding for cellxgene")
 
     @staticmethod
     def _patch_sa_annotation(core_v1, namespace: str, gcp_sa_email: str) -> None:

--- a/backend/app/adapters/cellxgene/kubernetes.py
+++ b/backend/app/adapters/cellxgene/kubernetes.py
@@ -119,8 +119,8 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
             ),
             spec=client.V1ServiceSpec(
                 selector={"app": name},
-                ports=[client.V1ServicePort(port=80, target_port=5005)],
-                type="ClusterIP",
+                ports=[client.V1ServicePort(port=5005, target_port=5005)],
+                type="LoadBalancer",
             ),
         )
         core_v1.create_namespaced_service(namespace=namespace, body=service)
@@ -420,28 +420,69 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
     # -- Background readiness polling --
 
     async def _poll_deployment_ready(self, publication_id: int, name: str, namespace: str) -> None:
-        """Background: poll for deployment readiness, then update the DB."""
+        """Background: poll for deployment readiness and LB IP, then update the DB."""
         try:
+            import httpx
+
             apps_v1 = self._get_k8s_apps_client()
 
+            # Wait for deployment readiness (up to 5 minutes)
+            deployment_ready = False
             for _ in range(60):
                 try:
                     dep = apps_v1.read_namespaced_deployment_status(name=name, namespace=namespace)
                     if dep.status.ready_replicas and dep.status.ready_replicas >= 1:
-                        logger.info("Cellxgene deployment %s is ready", name)
-                        await self._update_publication_status(publication_id, "published")
-                        return
+                        deployment_ready = True
+                        break
                 except Exception:
                     pass
                 await asyncio.sleep(5)
 
-            logger.error("Cellxgene deployment %s not ready after 5 min", name)
-            await self._update_publication_status(publication_id, "failed")
+            if not deployment_ready:
+                logger.error("Cellxgene deployment %s not ready after 5 min", name)
+                await self._update_publication_in_db(publication_id, "failed", None)
+                return
+
+            logger.info("Cellxgene deployment %s is ready, waiting for LB IP", name)
+
+            # Wait for LoadBalancer external IP (up to 3 minutes)
+            api_client = self._get_api_client()
+            k8s_config = api_client.configuration
+            svc_url = f"{k8s_config.host}/api/v1/namespaces/{namespace}/services/{name}"
+            headers = {"Authorization": list(k8s_config.api_key.values())[0]}
+
+            access_url = None
+            for _ in range(36):
+                try:
+                    resp = httpx.get(
+                        svc_url,
+                        headers=headers,
+                        verify=k8s_config.ssl_ca_cert or False,
+                        timeout=10,
+                    )
+                    if resp.status_code == 200:
+                        ingress_list = resp.json().get("status", {}).get("loadBalancer", {}).get("ingress") or []
+                        if ingress_list:
+                            ext_ip = ingress_list[0].get("ip") or ingress_list[0].get("hostname")
+                            access_url = f"http://{ext_ip}:5005"
+                            logger.info("External URL for cellxgene %s: %s", publication_id, access_url)
+                            break
+                except Exception:
+                    pass
+                await asyncio.sleep(5)
+
+            if not access_url:
+                logger.warning("LoadBalancer IP not ready for cellxgene %s after 3 min", name)
+
+            await self._update_publication_in_db(publication_id, "published", access_url)
+
         except Exception:
             logger.exception("Background poll failed for cellxgene %s", name)
-            await self._update_publication_status(publication_id, "failed")
+            await self._update_publication_in_db(publication_id, "failed", None)
 
-    async def _update_publication_status(self, publication_id: int, status: str) -> None:
+    async def _update_publication_in_db(
+        self, publication_id: int, status: str, access_url: str | None
+    ) -> None:
         if not self._session_factory:
             logger.warning("No session_factory, cannot update publication %s in DB", publication_id)
             return
@@ -454,9 +495,11 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
                 if status == "published":
                     await db.execute(
                         text(
-                            "UPDATE cellxgene_publications SET status = :status, published_at = :now WHERE id = :id"
+                            "UPDATE cellxgene_publications "
+                            "SET status = :status, published_at = :now, access_url = :url "
+                            "WHERE id = :id"
                         ),
-                        {"status": status, "now": now, "id": publication_id},
+                        {"status": status, "now": now, "url": access_url, "id": publication_id},
                     )
                 else:
                     await db.execute(
@@ -464,6 +507,9 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
                         {"status": status, "id": publication_id},
                     )
                 await db.commit()
-                logger.info("Updated publication %s: status=%s", publication_id, status)
+                logger.info(
+                    "Updated publication %s: status=%s access_url=%s",
+                    publication_id, status, access_url,
+                )
         except Exception:
             logger.exception("Failed to update publication %s in DB", publication_id)

--- a/backend/app/adapters/cellxgene/kubernetes.py
+++ b/backend/app/adapters/cellxgene/kubernetes.py
@@ -151,12 +151,11 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
                             client.V1Container(
                                 name="gcs-download",
                                 image="google/cloud-sdk:slim",
-                                command=["/bin/sh", "-c", f"gsutil cp '{gcs_uri}' {local_path}"],
-                                env=[
-                                    client.V1EnvVar(
-                                        name="GOOGLE_APPLICATION_CREDENTIALS",
-                                        value="/gcp/key.json",
-                                    )
+                                command=[
+                                    "/bin/sh",
+                                    "-c",
+                                    f"gcloud auth activate-service-account --key-file=/gcp/key.json "
+                                    f"&& gsutil cp '{gcs_uri}' {local_path}",
                                 ],
                                 volume_mounts=[
                                     client.V1VolumeMount(name="data", mount_path="/data"),

--- a/backend/app/adapters/cellxgene/kubernetes.py
+++ b/backend/app/adapters/cellxgene/kubernetes.py
@@ -1,18 +1,15 @@
 """Kubernetes cellxgene adapter.
 
-Supports local/mock mode for development and real K8s API for production.
-Mode is controlled by the BIOAF_COMPUTE_MODE environment variable.
-
-When running outside the cluster (e.g., Docker Compose on a VM), the adapter
-builds a K8s client from platform_config credentials (gke_cluster_endpoint,
-gke_cluster_ca_cert, GCP service account key).
+Always deploys real cellxgene pods to the GKE cluster. When running outside
+the cluster (e.g., Docker Compose on a VM), the adapter builds a K8s client
+from platform_config credentials (gke_cluster_endpoint, gke_cluster_ca_cert,
+GCP service account key).
 """
 
 import asyncio
 import base64
 import json as _json
 import logging
-import os
 import tempfile
 import time
 from datetime import datetime, timezone
@@ -38,43 +35,159 @@ def _get_gcp_token(service_account_key_json: str) -> str:
     return credentials.token
 
 
-# In-memory instance store for local mode
-_local_instances: dict[int, dict] = {}
-
 DEFAULT_CELLXGENE_NAMESPACE = "bioaf-cellxgene"
 
 
 class KubernetesCellxgeneProvider(CellxgeneProvider):
-    """Kubernetes cellxgene backend with local mode for development."""
+    """Kubernetes cellxgene backend.
+
+    Connects to the GKE cluster via incluster config (when running as a pod)
+    or platform_config credentials (when running outside the cluster, e.g.
+    Docker Compose on a GCP VM).
+    """
 
     _TOKEN_TTL_SECONDS = 2700  # 45 minutes
 
     def __init__(self, session_factory=None):
-        self._mode = os.environ.get("BIOAF_COMPUTE_MODE", "local")
         self._session_factory = session_factory
         self._api_client: client.ApiClient | None = None
         self._client_created_at: float = 0.0
         self._cluster_config: dict | None = None
         self._namespace_ready = False
 
-    @property
-    def is_local(self) -> bool:
-        return self._mode == "local"
-
     async def deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
-        if self.is_local:
-            return self._local_deploy(publication_id, gcs_uri, dataset_name)
-        return await self._k8s_deploy(publication_id, gcs_uri, dataset_name)
+        await self._get_api_client_async()
+
+        namespace = DEFAULT_CELLXGENE_NAMESPACE
+        await self.ensure_cellxgene_namespace(namespace)
+
+        name = f"cellxgene-{publication_id}"
+        apps_v1 = self._get_k8s_apps_client()
+        core_v1 = self._get_k8s_core_client()
+
+        deployment = client.V1Deployment(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=namespace,
+                labels={
+                    "bioaf.io/managed": "true",
+                    "bioaf.io/publication": str(publication_id),
+                },
+            ),
+            spec=client.V1DeploymentSpec(
+                replicas=1,
+                selector=client.V1LabelSelector(match_labels={"app": name}),
+                template=client.V1PodTemplateSpec(
+                    metadata=client.V1ObjectMeta(labels={"app": name}),
+                    spec=client.V1PodSpec(
+                        service_account_name="bioaf-cellxgene-runner",
+                        node_selector={"bioaf.io/pool": "interactive"},
+                        tolerations=[
+                            client.V1Toleration(
+                                key="bioaf.io/pool",
+                                value="interactive",
+                                effect="NoSchedule",
+                            )
+                        ],
+                        containers=[
+                            client.V1Container(
+                                name="cellxgene",
+                                image="cellxgene:latest",
+                                args=["launch", "--host", "0.0.0.0", gcs_uri],
+                                ports=[client.V1ContainerPort(container_port=5005)],
+                                resources=client.V1ResourceRequirements(
+                                    requests={"cpu": "1", "memory": "4Gi"},
+                                    limits={"cpu": "2", "memory": "8Gi"},
+                                ),
+                            )
+                        ],
+                    ),
+                ),
+            ),
+        )
+        apps_v1.create_namespaced_deployment(namespace=namespace, body=deployment)
+        logger.info("Created cellxgene deployment %s in %s", name, namespace)
+
+        service = client.V1Service(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=namespace,
+                labels={
+                    "bioaf.io/managed": "true",
+                    "bioaf.io/publication": str(publication_id),
+                },
+            ),
+            spec=client.V1ServiceSpec(
+                selector={"app": name},
+                ports=[client.V1ServicePort(port=80, target_port=5005)],
+                type="ClusterIP",
+            ),
+        )
+        core_v1.create_namespaced_service(namespace=namespace, body=service)
+        logger.info("Created cellxgene service %s in %s", name, namespace)
+
+        # Poll for readiness in background
+        asyncio.create_task(self._poll_deployment_ready(publication_id, name, namespace))
+
+        return {
+            "publication_id": publication_id,
+            "pod_name": name,
+            "namespace": namespace,
+            "status": "starting",
+            "access_url": None,
+        }
 
     async def teardown(self, publication_id: int) -> dict:
-        if self.is_local:
-            return self._local_teardown(publication_id)
-        return await self._k8s_teardown(publication_id)
+        await self._get_api_client_async()
+
+        name = f"cellxgene-{publication_id}"
+        namespace = DEFAULT_CELLXGENE_NAMESPACE
+
+        apps_v1 = self._get_k8s_apps_client()
+        core_v1 = self._get_k8s_core_client()
+
+        try:
+            apps_v1.delete_namespaced_deployment(name=name, namespace=namespace)
+            logger.info("Deleted cellxgene deployment %s", name)
+        except Exception as e:
+            logger.warning("Failed to delete cellxgene deployment %s: %s", name, e)
+
+        try:
+            core_v1.delete_namespaced_service(name=name, namespace=namespace)
+            logger.info("Deleted cellxgene service %s", name)
+        except Exception as e:
+            logger.warning("Failed to delete cellxgene service %s: %s", name, e)
+
+        return {
+            "publication_id": publication_id,
+            "status": "stopped",
+            "stopped_at": datetime.now(timezone.utc).isoformat(),
+        }
 
     async def get_status(self, publication_id: int) -> dict:
-        if self.is_local:
-            return self._local_get_status(publication_id)
-        return await self._k8s_get_status(publication_id)
+        await self._get_api_client_async()
+
+        name = f"cellxgene-{publication_id}"
+        namespace = DEFAULT_CELLXGENE_NAMESPACE
+        apps_v1 = self._get_k8s_apps_client()
+
+        try:
+            dep = apps_v1.read_namespaced_deployment_status(name=name, namespace=namespace)
+            ready = dep.status.ready_replicas or 0
+            status = "running" if ready >= 1 else "starting"
+        except Exception:
+            return {
+                "publication_id": publication_id,
+                "status": "unknown",
+                "pod_name": name,
+            }
+
+        return {
+            "publication_id": publication_id,
+            "status": status,
+            "pod_name": name,
+            "namespace": namespace,
+        }
 
     # -- Cluster config --
 
@@ -176,7 +289,10 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
         return self._api_client
 
     def _get_api_client(self) -> client.ApiClient:
-        """Get or create a K8s ApiClient (sync version)."""
+        """Get or create a K8s ApiClient (sync version).
+
+        Uses cached client if available; does not reload from DB.
+        """
         if self._api_client is not None and not self._is_token_expired():
             return self._api_client
 
@@ -301,90 +417,7 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
         except Exception:
             logger.warning("Could not patch SA annotation for Workload Identity")
 
-    # -- K8s API implementations --
-
-    async def _k8s_deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
-        """Deploy a cellxgene pod on the GKE cluster."""
-        await self._get_api_client_async()
-
-        namespace = DEFAULT_CELLXGENE_NAMESPACE
-        await self.ensure_cellxgene_namespace(namespace)
-
-        name = f"cellxgene-{publication_id}"
-        apps_v1 = self._get_k8s_apps_client()
-        core_v1 = self._get_k8s_core_client()
-
-        deployment = client.V1Deployment(
-            metadata=client.V1ObjectMeta(
-                name=name,
-                namespace=namespace,
-                labels={
-                    "bioaf.io/managed": "true",
-                    "bioaf.io/publication": str(publication_id),
-                },
-            ),
-            spec=client.V1DeploymentSpec(
-                replicas=1,
-                selector=client.V1LabelSelector(match_labels={"app": name}),
-                template=client.V1PodTemplateSpec(
-                    metadata=client.V1ObjectMeta(labels={"app": name}),
-                    spec=client.V1PodSpec(
-                        service_account_name="bioaf-cellxgene-runner",
-                        node_selector={"bioaf.io/pool": "interactive"},
-                        tolerations=[
-                            client.V1Toleration(
-                                key="bioaf.io/pool",
-                                value="interactive",
-                                effect="NoSchedule",
-                            )
-                        ],
-                        containers=[
-                            client.V1Container(
-                                name="cellxgene",
-                                image="cellxgene:latest",
-                                args=["launch", "--host", "0.0.0.0", gcs_uri],
-                                ports=[client.V1ContainerPort(container_port=5005)],
-                                resources=client.V1ResourceRequirements(
-                                    requests={"cpu": "1", "memory": "4Gi"},
-                                    limits={"cpu": "2", "memory": "8Gi"},
-                                ),
-                            )
-                        ],
-                    ),
-                ),
-            ),
-        )
-        apps_v1.create_namespaced_deployment(namespace=namespace, body=deployment)
-        logger.info("Created cellxgene deployment %s in %s", name, namespace)
-
-        service = client.V1Service(
-            metadata=client.V1ObjectMeta(
-                name=name,
-                namespace=namespace,
-                labels={
-                    "bioaf.io/managed": "true",
-                    "bioaf.io/publication": str(publication_id),
-                },
-            ),
-            spec=client.V1ServiceSpec(
-                selector={"app": name},
-                ports=[client.V1ServicePort(port=80, target_port=5005)],
-                type="ClusterIP",
-            ),
-        )
-        core_v1.create_namespaced_service(namespace=namespace, body=service)
-        logger.info("Created cellxgene service %s in %s", name, namespace)
-
-        # Poll for readiness in background
-        asyncio.create_task(self._poll_deployment_ready(publication_id, name, namespace))
-
-        return {
-            "publication_id": publication_id,
-            "pod_name": name,
-            "namespace": namespace,
-            "status": "starting",
-            "access_url": None,
-        }
+    # -- Background readiness polling --
 
     async def _poll_deployment_ready(self, publication_id: int, name: str, namespace: str) -> None:
         """Background: poll for deployment readiness, then update the DB."""
@@ -434,93 +467,3 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
                 logger.info("Updated publication %s: status=%s", publication_id, status)
         except Exception:
             logger.exception("Failed to update publication %s in DB", publication_id)
-
-    async def _k8s_teardown(self, publication_id: int) -> dict:
-        """Delete the cellxgene deployment and service."""
-        await self._get_api_client_async()
-
-        name = f"cellxgene-{publication_id}"
-        namespace = DEFAULT_CELLXGENE_NAMESPACE
-
-        apps_v1 = self._get_k8s_apps_client()
-        core_v1 = self._get_k8s_core_client()
-
-        try:
-            apps_v1.delete_namespaced_deployment(name=name, namespace=namespace)
-            logger.info("Deleted cellxgene deployment %s", name)
-        except Exception as e:
-            logger.warning("Failed to delete cellxgene deployment %s: %s", name, e)
-
-        try:
-            core_v1.delete_namespaced_service(name=name, namespace=namespace)
-            logger.info("Deleted cellxgene service %s", name)
-        except Exception as e:
-            logger.warning("Failed to delete cellxgene service %s: %s", name, e)
-
-        return {
-            "publication_id": publication_id,
-            "status": "stopped",
-            "stopped_at": datetime.now(timezone.utc).isoformat(),
-        }
-
-    async def _k8s_get_status(self, publication_id: int) -> dict:
-        """Query K8s API for deployment status."""
-        await self._get_api_client_async()
-
-        name = f"cellxgene-{publication_id}"
-        namespace = DEFAULT_CELLXGENE_NAMESPACE
-        apps_v1 = self._get_k8s_apps_client()
-
-        try:
-            dep = apps_v1.read_namespaced_deployment_status(name=name, namespace=namespace)
-            ready = dep.status.ready_replicas or 0
-            status = "running" if ready >= 1 else "starting"
-        except Exception:
-            return {
-                "publication_id": publication_id,
-                "status": "unknown",
-                "pod_name": name,
-            }
-
-        return {
-            "publication_id": publication_id,
-            "status": status,
-            "pod_name": name,
-            "namespace": namespace,
-        }
-
-    # -- Local mode implementations --
-
-    def _local_deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
-        instance = {
-            "publication_id": publication_id,
-            "pod_name": f"cellxgene-{publication_id}",
-            "namespace": DEFAULT_CELLXGENE_NAMESPACE,
-            "status": "running",
-            "access_url": f"http://localhost:5005/cellxgene/{publication_id}/",
-            "gcs_uri": gcs_uri,
-            "dataset_name": dataset_name,
-            "created_at": datetime.now(timezone.utc).isoformat(),
-        }
-        _local_instances[publication_id] = instance
-        logger.info("Local mode: deployed cellxgene %s for %s", publication_id, dataset_name)
-        return instance
-
-    def _local_teardown(self, publication_id: int) -> dict:
-        if publication_id in _local_instances:
-            _local_instances[publication_id]["status"] = "stopped"
-            _local_instances[publication_id]["stopped_at"] = datetime.now(timezone.utc).isoformat()
-        logger.info("Local mode: torn down cellxgene %s", publication_id)
-        return {
-            "publication_id": publication_id,
-            "status": "stopped",
-            "stopped_at": datetime.now(timezone.utc).isoformat(),
-        }
-
-    def _local_get_status(self, publication_id: int) -> dict:
-        if publication_id in _local_instances:
-            return _local_instances[publication_id]
-        return {
-            "publication_id": publication_id,
-            "status": "unknown",
-        }

--- a/backend/app/adapters/cellxgene/kubernetes.py
+++ b/backend/app/adapters/cellxgene/kubernetes.py
@@ -1,0 +1,526 @@
+"""Kubernetes cellxgene adapter.
+
+Supports local/mock mode for development and real K8s API for production.
+Mode is controlled by the BIOAF_COMPUTE_MODE environment variable.
+
+When running outside the cluster (e.g., Docker Compose on a VM), the adapter
+builds a K8s client from platform_config credentials (gke_cluster_endpoint,
+gke_cluster_ca_cert, GCP service account key).
+"""
+
+import asyncio
+import base64
+import json as _json
+import logging
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+
+from kubernetes import client, config
+
+from app.adapters.base import CellxgeneProvider
+
+logger = logging.getLogger("bioaf.adapters.cellxgene.k8s")
+
+
+def _get_gcp_token(service_account_key_json: str) -> str:
+    """Exchange a GCP service account key for an access token."""
+    from google.oauth2 import service_account
+    import google.auth.transport.requests
+
+    key_data = _json.loads(service_account_key_json)
+    credentials = service_account.Credentials.from_service_account_info(
+        key_data,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+    credentials.refresh(google.auth.transport.requests.Request())
+    return credentials.token
+
+
+# In-memory instance store for local mode
+_local_instances: dict[int, dict] = {}
+
+DEFAULT_CELLXGENE_NAMESPACE = "bioaf-cellxgene"
+
+
+class KubernetesCellxgeneProvider(CellxgeneProvider):
+    """Kubernetes cellxgene backend with local mode for development."""
+
+    _TOKEN_TTL_SECONDS = 2700  # 45 minutes
+
+    def __init__(self, session_factory=None):
+        self._mode = os.environ.get("BIOAF_COMPUTE_MODE", "local")
+        self._session_factory = session_factory
+        self._api_client: client.ApiClient | None = None
+        self._client_created_at: float = 0.0
+        self._cluster_config: dict | None = None
+        self._namespace_ready = False
+
+    @property
+    def is_local(self) -> bool:
+        return self._mode == "local"
+
+    async def deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
+        if self.is_local:
+            return self._local_deploy(publication_id, gcs_uri, dataset_name)
+        return await self._k8s_deploy(publication_id, gcs_uri, dataset_name)
+
+    async def teardown(self, publication_id: int) -> dict:
+        if self.is_local:
+            return self._local_teardown(publication_id)
+        return await self._k8s_teardown(publication_id)
+
+    async def get_status(self, publication_id: int) -> dict:
+        if self.is_local:
+            return self._local_get_status(publication_id)
+        return await self._k8s_get_status(publication_id)
+
+    # -- Cluster config --
+
+    async def load_cluster_config(self, force: bool = False) -> dict:
+        """Read GKE cluster config from platform_config.
+
+        Caches the result. Re-reads when forced or when the cached endpoint
+        is missing/null so newly deployed clusters are picked up.
+        """
+        if self._cluster_config is not None and not force:
+            endpoint = self._cluster_config.get("gke_cluster_endpoint", "")
+            if endpoint and endpoint != "null":
+                return self._cluster_config
+
+        from sqlalchemy import text as sa_text
+
+        if not self._session_factory:
+            self._cluster_config = {}
+            return self._cluster_config
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                sa_text(
+                    "SELECT key, value FROM platform_config "
+                    "WHERE key IN ("
+                    "  'gke_cluster_endpoint', 'gke_cluster_ca_cert',"
+                    "  'gcp_credential_source', 'gcp_service_account_key',"
+                    "  'gke_cluster_name', 'gcp_project_id', 'gcp_zone'"
+                    ")"
+                )
+            )
+            self._cluster_config = {r[0]: r[1] for r in result.fetchall()}
+
+        if force:
+            self._api_client = None
+
+        return self._cluster_config
+
+    def _build_out_of_cluster_client(self) -> client.ApiClient:
+        """Build a K8s ApiClient using platform_config credentials."""
+        cfg = self._cluster_config or {}
+
+        endpoint = cfg.get("gke_cluster_endpoint", "")
+        ca_cert_b64 = cfg.get("gke_cluster_ca_cert", "")
+        sa_key = cfg.get("gcp_service_account_key", "")
+
+        if not endpoint or endpoint == "null":
+            raise RuntimeError("No GKE cluster endpoint in platform_config. Deploy the compute stack first.")
+
+        if not endpoint.startswith("https://"):
+            endpoint = f"https://{endpoint}"
+
+        token = _get_gcp_token(sa_key)
+
+        ca_cert_bytes = base64.b64decode(ca_cert_b64)
+        ca_file = tempfile.NamedTemporaryFile(delete=False, suffix=".crt")
+        ca_file.write(ca_cert_bytes)
+        ca_file.close()
+
+        configuration = client.Configuration()
+        configuration.host = endpoint
+        configuration.ssl_ca_cert = ca_file.name
+        configuration.api_key = {"authorization": f"Bearer {token}"}
+
+        self._client_created_at = time.monotonic()
+        return client.ApiClient(configuration)
+
+    def _is_token_expired(self) -> bool:
+        if self._client_created_at == 0.0:
+            return False
+        return (time.monotonic() - self._client_created_at) > self._TOKEN_TTL_SECONDS
+
+    async def _get_api_client_async(self) -> client.ApiClient:
+        """Get or create a K8s ApiClient, trying incluster first."""
+        if self._api_client is not None and not self._is_token_expired():
+            return self._api_client
+
+        if self._is_token_expired():
+            logger.info("GCP access token approaching expiry, refreshing K8s client")
+            self._api_client = None
+
+        try:
+            config.load_incluster_config()
+            self._api_client = client.ApiClient()
+            logger.info("Using incluster K8s config")
+        except Exception:
+            logger.info("Not running in cluster, using platform_config credentials")
+            await self.load_cluster_config(force=True)
+            try:
+                self._api_client = self._build_out_of_cluster_client()
+                logger.info(
+                    "K8s client built for endpoint %s",
+                    (self._cluster_config or {}).get("gke_cluster_endpoint"),
+                )
+            except Exception:
+                logger.exception("Failed to build out-of-cluster K8s client")
+                raise
+
+        return self._api_client
+
+    def _get_api_client(self) -> client.ApiClient:
+        """Get or create a K8s ApiClient (sync version)."""
+        if self._api_client is not None and not self._is_token_expired():
+            return self._api_client
+
+        if self._is_token_expired():
+            logger.info("GCP access token approaching expiry, refreshing K8s client")
+            self._api_client = None
+
+        try:
+            config.load_incluster_config()
+            self._api_client = client.ApiClient()
+            logger.info("Using incluster K8s config")
+        except Exception:
+            logger.info("Not running in cluster, using platform_config credentials")
+            try:
+                self._api_client = self._build_out_of_cluster_client()
+                logger.info(
+                    "K8s client built for endpoint %s",
+                    (self._cluster_config or {}).get("gke_cluster_endpoint"),
+                )
+            except Exception:
+                logger.exception("Failed to build out-of-cluster K8s client")
+                raise
+
+        return self._api_client
+
+    def _get_k8s_core_client(self):
+        return client.CoreV1Api(api_client=self._get_api_client())
+
+    def _get_k8s_apps_client(self):
+        return client.AppsV1Api(api_client=self._get_api_client())
+
+    def _get_k8s_rbac_client(self):
+        return client.RbacAuthorizationV1Api(api_client=self._get_api_client())
+
+    # -- Namespace setup --
+
+    async def ensure_cellxgene_namespace(
+        self, namespace: str = DEFAULT_CELLXGENE_NAMESPACE, gcp_sa_email: str = ""
+    ) -> None:
+        """Ensure the cellxgene namespace and service account exist."""
+        from kubernetes.client.rest import ApiException
+
+        if self._namespace_ready:
+            return
+
+        core_v1 = self._get_k8s_core_client()
+        rbac_v1 = self._get_k8s_rbac_client()
+
+        try:
+            core_v1.read_namespace(name=namespace)
+            logger.info("Namespace %s already exists, skipping setup", namespace)
+            if gcp_sa_email:
+                self._patch_sa_annotation(core_v1, namespace, gcp_sa_email)
+            self._namespace_ready = True
+            return
+        except ApiException as e:
+            if e.status != 404:
+                raise
+
+        core_v1.create_namespace(
+            body=client.V1Namespace(
+                metadata=client.V1ObjectMeta(
+                    name=namespace,
+                    labels={"bioaf.io/managed": "true"},
+                )
+            )
+        )
+        logger.info("Created namespace %s", namespace)
+
+        sa_annotations = {}
+        if gcp_sa_email:
+            sa_annotations["iam.gke.io/gcp-service-account"] = gcp_sa_email
+
+        core_v1.create_namespaced_service_account(
+            namespace=namespace,
+            body=client.V1ServiceAccount(
+                metadata=client.V1ObjectMeta(
+                    name="bioaf-cellxgene-runner",
+                    labels={"bioaf.io/managed": "true"},
+                    annotations=sa_annotations or None,
+                )
+            ),
+        )
+        logger.info("Created service account bioaf-cellxgene-runner in %s", namespace)
+
+        rbac_v1.create_namespaced_role_binding(
+            namespace=namespace,
+            body=client.V1RoleBinding(
+                metadata=client.V1ObjectMeta(
+                    name="bioaf-cellxgene-runner-binding",
+                    labels={"bioaf.io/managed": "true"},
+                ),
+                role_ref=client.V1RoleRef(
+                    api_group="rbac.authorization.k8s.io",
+                    kind="ClusterRole",
+                    name="edit",
+                ),
+                subjects=[
+                    client.RbacV1Subject(
+                        kind="ServiceAccount",
+                        name="bioaf-cellxgene-runner",
+                        namespace=namespace,
+                    )
+                ],
+            ),
+        )
+        logger.info("Created role binding in %s", namespace)
+        self._namespace_ready = True
+
+    @staticmethod
+    def _patch_sa_annotation(core_v1, namespace: str, gcp_sa_email: str) -> None:
+        try:
+            sa = core_v1.read_namespaced_service_account(name="bioaf-cellxgene-runner", namespace=namespace)
+            current = (sa.metadata.annotations or {}).get("iam.gke.io/gcp-service-account", "")
+            if current != gcp_sa_email:
+                core_v1.patch_namespaced_service_account(
+                    name="bioaf-cellxgene-runner",
+                    namespace=namespace,
+                    body={"metadata": {"annotations": {"iam.gke.io/gcp-service-account": gcp_sa_email}}},
+                )
+                logger.info("Patched Workload Identity annotation on bioaf-cellxgene-runner")
+        except Exception:
+            logger.warning("Could not patch SA annotation for Workload Identity")
+
+    # -- K8s API implementations --
+
+    async def _k8s_deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
+        """Deploy a cellxgene pod on the GKE cluster."""
+        await self._get_api_client_async()
+
+        namespace = DEFAULT_CELLXGENE_NAMESPACE
+        await self.ensure_cellxgene_namespace(namespace)
+
+        name = f"cellxgene-{publication_id}"
+        apps_v1 = self._get_k8s_apps_client()
+        core_v1 = self._get_k8s_core_client()
+
+        deployment = client.V1Deployment(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=namespace,
+                labels={
+                    "bioaf.io/managed": "true",
+                    "bioaf.io/publication": str(publication_id),
+                },
+            ),
+            spec=client.V1DeploymentSpec(
+                replicas=1,
+                selector=client.V1LabelSelector(match_labels={"app": name}),
+                template=client.V1PodTemplateSpec(
+                    metadata=client.V1ObjectMeta(labels={"app": name}),
+                    spec=client.V1PodSpec(
+                        service_account_name="bioaf-cellxgene-runner",
+                        node_selector={"bioaf.io/pool": "interactive"},
+                        tolerations=[
+                            client.V1Toleration(
+                                key="bioaf.io/pool",
+                                value="interactive",
+                                effect="NoSchedule",
+                            )
+                        ],
+                        containers=[
+                            client.V1Container(
+                                name="cellxgene",
+                                image="cellxgene:latest",
+                                args=["launch", "--host", "0.0.0.0", gcs_uri],
+                                ports=[client.V1ContainerPort(container_port=5005)],
+                                resources=client.V1ResourceRequirements(
+                                    requests={"cpu": "1", "memory": "4Gi"},
+                                    limits={"cpu": "2", "memory": "8Gi"},
+                                ),
+                            )
+                        ],
+                    ),
+                ),
+            ),
+        )
+        apps_v1.create_namespaced_deployment(namespace=namespace, body=deployment)
+        logger.info("Created cellxgene deployment %s in %s", name, namespace)
+
+        service = client.V1Service(
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=namespace,
+                labels={
+                    "bioaf.io/managed": "true",
+                    "bioaf.io/publication": str(publication_id),
+                },
+            ),
+            spec=client.V1ServiceSpec(
+                selector={"app": name},
+                ports=[client.V1ServicePort(port=80, target_port=5005)],
+                type="ClusterIP",
+            ),
+        )
+        core_v1.create_namespaced_service(namespace=namespace, body=service)
+        logger.info("Created cellxgene service %s in %s", name, namespace)
+
+        # Poll for readiness in background
+        asyncio.create_task(self._poll_deployment_ready(publication_id, name, namespace))
+
+        return {
+            "publication_id": publication_id,
+            "pod_name": name,
+            "namespace": namespace,
+            "status": "starting",
+            "access_url": None,
+        }
+
+    async def _poll_deployment_ready(self, publication_id: int, name: str, namespace: str) -> None:
+        """Background: poll for deployment readiness, then update the DB."""
+        try:
+            apps_v1 = self._get_k8s_apps_client()
+
+            for _ in range(60):
+                try:
+                    dep = apps_v1.read_namespaced_deployment_status(name=name, namespace=namespace)
+                    if dep.status.ready_replicas and dep.status.ready_replicas >= 1:
+                        logger.info("Cellxgene deployment %s is ready", name)
+                        await self._update_publication_status(publication_id, "published")
+                        return
+                except Exception:
+                    pass
+                await asyncio.sleep(5)
+
+            logger.error("Cellxgene deployment %s not ready after 5 min", name)
+            await self._update_publication_status(publication_id, "failed")
+        except Exception:
+            logger.exception("Background poll failed for cellxgene %s", name)
+            await self._update_publication_status(publication_id, "failed")
+
+    async def _update_publication_status(self, publication_id: int, status: str) -> None:
+        if not self._session_factory:
+            logger.warning("No session_factory, cannot update publication %s in DB", publication_id)
+            return
+
+        try:
+            async with self._session_factory() as db:
+                from sqlalchemy import text
+
+                now = datetime.now(timezone.utc)
+                if status == "published":
+                    await db.execute(
+                        text(
+                            "UPDATE cellxgene_publications SET status = :status, published_at = :now WHERE id = :id"
+                        ),
+                        {"status": status, "now": now, "id": publication_id},
+                    )
+                else:
+                    await db.execute(
+                        text("UPDATE cellxgene_publications SET status = :status WHERE id = :id"),
+                        {"status": status, "id": publication_id},
+                    )
+                await db.commit()
+                logger.info("Updated publication %s: status=%s", publication_id, status)
+        except Exception:
+            logger.exception("Failed to update publication %s in DB", publication_id)
+
+    async def _k8s_teardown(self, publication_id: int) -> dict:
+        """Delete the cellxgene deployment and service."""
+        await self._get_api_client_async()
+
+        name = f"cellxgene-{publication_id}"
+        namespace = DEFAULT_CELLXGENE_NAMESPACE
+
+        apps_v1 = self._get_k8s_apps_client()
+        core_v1 = self._get_k8s_core_client()
+
+        try:
+            apps_v1.delete_namespaced_deployment(name=name, namespace=namespace)
+            logger.info("Deleted cellxgene deployment %s", name)
+        except Exception as e:
+            logger.warning("Failed to delete cellxgene deployment %s: %s", name, e)
+
+        try:
+            core_v1.delete_namespaced_service(name=name, namespace=namespace)
+            logger.info("Deleted cellxgene service %s", name)
+        except Exception as e:
+            logger.warning("Failed to delete cellxgene service %s: %s", name, e)
+
+        return {
+            "publication_id": publication_id,
+            "status": "stopped",
+            "stopped_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    async def _k8s_get_status(self, publication_id: int) -> dict:
+        """Query K8s API for deployment status."""
+        await self._get_api_client_async()
+
+        name = f"cellxgene-{publication_id}"
+        namespace = DEFAULT_CELLXGENE_NAMESPACE
+        apps_v1 = self._get_k8s_apps_client()
+
+        try:
+            dep = apps_v1.read_namespaced_deployment_status(name=name, namespace=namespace)
+            ready = dep.status.ready_replicas or 0
+            status = "running" if ready >= 1 else "starting"
+        except Exception:
+            return {
+                "publication_id": publication_id,
+                "status": "unknown",
+                "pod_name": name,
+            }
+
+        return {
+            "publication_id": publication_id,
+            "status": status,
+            "pod_name": name,
+            "namespace": namespace,
+        }
+
+    # -- Local mode implementations --
+
+    def _local_deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
+        instance = {
+            "publication_id": publication_id,
+            "pod_name": f"cellxgene-{publication_id}",
+            "namespace": DEFAULT_CELLXGENE_NAMESPACE,
+            "status": "running",
+            "access_url": f"http://localhost:5005/cellxgene/{publication_id}/",
+            "gcs_uri": gcs_uri,
+            "dataset_name": dataset_name,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _local_instances[publication_id] = instance
+        logger.info("Local mode: deployed cellxgene %s for %s", publication_id, dataset_name)
+        return instance
+
+    def _local_teardown(self, publication_id: int) -> dict:
+        if publication_id in _local_instances:
+            _local_instances[publication_id]["status"] = "stopped"
+            _local_instances[publication_id]["stopped_at"] = datetime.now(timezone.utc).isoformat()
+        logger.info("Local mode: torn down cellxgene %s", publication_id)
+        return {
+            "publication_id": publication_id,
+            "status": "stopped",
+            "stopped_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def _local_get_status(self, publication_id: int) -> dict:
+        if publication_id in _local_instances:
+            return _local_instances[publication_id]
+        return {
+            "publication_id": publication_id,
+            "status": "unknown",
+        }

--- a/backend/app/adapters/cellxgene/kubernetes.py
+++ b/backend/app/adapters/cellxgene/kubernetes.py
@@ -77,16 +77,49 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
             raise RuntimeError("Cellxgene image not built yet. Enable the cellxgene component to trigger a build.")
         return uri
 
+    async def _ensure_gcp_secret(self, namespace: str) -> None:
+        """Create or update a K8s Secret with the GCP service account key."""
+        from kubernetes.client.rest import ApiException
+
+        config = await self._read_platform_config("gcp_service_account_key")
+        sa_key = config.get("gcp_service_account_key", "")
+        if not sa_key or sa_key == "null":
+            logger.warning("No GCP service account key in platform_config; skipping secret")
+            return
+
+        core_v1 = self._get_k8s_core_client()
+        secret_name = "gcp-sa-key"
+
+        secret = client.V1Secret(
+            metadata=client.V1ObjectMeta(
+                name=secret_name,
+                namespace=namespace,
+                labels={"bioaf.io/managed": "true"},
+            ),
+            string_data={"key.json": sa_key},
+        )
+
+        try:
+            core_v1.read_namespaced_secret(name=secret_name, namespace=namespace)
+            core_v1.replace_namespaced_secret(name=secret_name, namespace=namespace, body=secret)
+            logger.info("Updated GCP SA secret in %s", namespace)
+        except ApiException as e:
+            if e.status == 404:
+                core_v1.create_namespaced_secret(namespace=namespace, body=secret)
+                logger.info("Created GCP SA secret in %s", namespace)
+            else:
+                raise
+
     async def deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
         await self._get_api_client_async()
         image = await self._resolve_image()
 
         namespace = DEFAULT_CELLXGENE_NAMESPACE
-        config = await self._read_platform_config("notebook_runner_sa_email")
-        sa_email = (config.get("notebook_runner_sa_email") or "").strip()
-        await self.ensure_cellxgene_namespace(namespace, gcp_sa_email=sa_email)
+        await self.ensure_cellxgene_namespace(namespace)
+        await self._ensure_gcp_secret(namespace)
 
         name = f"cellxgene-{publication_id}"
+        local_path = "/data/dataset.h5ad"
         apps_v1 = self._get_k8s_apps_client()
         core_v1 = self._get_k8s_core_client()
 
@@ -114,17 +147,47 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
                                 effect="NoSchedule",
                             )
                         ],
+                        init_containers=[
+                            client.V1Container(
+                                name="gcs-download",
+                                image="google/cloud-sdk:slim",
+                                command=["/bin/sh", "-c", f"gsutil cp '{gcs_uri}' {local_path}"],
+                                env=[
+                                    client.V1EnvVar(
+                                        name="GOOGLE_APPLICATION_CREDENTIALS",
+                                        value="/gcp/key.json",
+                                    )
+                                ],
+                                volume_mounts=[
+                                    client.V1VolumeMount(name="data", mount_path="/data"),
+                                    client.V1VolumeMount(name="gcp-sa", mount_path="/gcp", read_only=True),
+                                ],
+                            )
+                        ],
                         containers=[
                             client.V1Container(
                                 name="cellxgene",
                                 image=image,
-                                args=["launch", "--host", "0.0.0.0", gcs_uri],
+                                args=["launch", "--host", "0.0.0.0", local_path],
                                 ports=[client.V1ContainerPort(container_port=5005)],
+                                volume_mounts=[
+                                    client.V1VolumeMount(name="data", mount_path="/data", read_only=True),
+                                ],
                                 resources=client.V1ResourceRequirements(
                                     requests={"cpu": "1", "memory": "4Gi"},
                                     limits={"cpu": "2", "memory": "8Gi"},
                                 ),
                             )
+                        ],
+                        volumes=[
+                            client.V1Volume(
+                                name="data",
+                                empty_dir=client.V1EmptyDirVolumeSource(size_limit="20Gi"),
+                            ),
+                            client.V1Volume(
+                                name="gcp-sa",
+                                secret=client.V1SecretVolumeSource(secret_name="gcp-sa-key"),
+                            ),
                         ],
                     ),
                 ),
@@ -354,9 +417,7 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
 
     # -- Namespace setup --
 
-    async def ensure_cellxgene_namespace(
-        self, namespace: str = DEFAULT_CELLXGENE_NAMESPACE, gcp_sa_email: str = ""
-    ) -> None:
+    async def ensure_cellxgene_namespace(self, namespace: str = DEFAULT_CELLXGENE_NAMESPACE) -> None:
         """Ensure the cellxgene namespace and service account exist."""
         from kubernetes.client.rest import ApiException
 
@@ -369,9 +430,6 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
         try:
             core_v1.read_namespace(name=namespace)
             logger.info("Namespace %s already exists, skipping setup", namespace)
-            if gcp_sa_email:
-                self._patch_sa_annotation(core_v1, namespace, gcp_sa_email)
-                await self._ensure_workload_identity_binding(gcp_sa_email, namespace)
             self._namespace_ready = True
             return
         except ApiException as e:
@@ -388,17 +446,12 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
         )
         logger.info("Created namespace %s", namespace)
 
-        sa_annotations = {}
-        if gcp_sa_email:
-            sa_annotations["iam.gke.io/gcp-service-account"] = gcp_sa_email
-
         core_v1.create_namespaced_service_account(
             namespace=namespace,
             body=client.V1ServiceAccount(
                 metadata=client.V1ObjectMeta(
                     name="bioaf-cellxgene-runner",
                     labels={"bioaf.io/managed": "true"},
-                    annotations=sa_annotations or None,
                 )
             ),
         )
@@ -426,102 +479,7 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
             ),
         )
         logger.info("Created role binding in %s", namespace)
-
-        # Bind the KSA to the GCP SA for Workload Identity
-        if gcp_sa_email:
-            await self._ensure_workload_identity_binding(gcp_sa_email, namespace)
-
         self._namespace_ready = True
-
-    async def _ensure_workload_identity_binding(self, gcp_sa_email: str, namespace: str) -> None:
-        """Grant the cellxgene KSA permission to impersonate the GCP SA."""
-        try:
-            import google.auth
-            import google.auth.transport.requests
-            import json as _json
-            import urllib.request
-
-            config = await self._read_platform_config("gcp_credential_source", "gcp_service_account_key")
-            sa_key = config.get("gcp_service_account_key", "")
-            if sa_key and sa_key != "null":
-                from google.oauth2 import service_account as sa_mod
-
-                credentials = sa_mod.Credentials.from_service_account_info(
-                    _json.loads(sa_key),
-                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
-                )
-            else:
-                credentials, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
-
-            auth_req = google.auth.transport.requests.Request()
-            credentials.refresh(auth_req)
-
-            member = f"serviceAccount:{gcp_sa_email.split('@')[1].split('.')[0]}.svc.id.goog[{namespace}/bioaf-cellxgene-runner]"
-
-            # Get current IAM policy
-            url = f"https://iam.googleapis.com/v1/projects/-/serviceAccounts/{gcp_sa_email}:getIamPolicy"
-            req = urllib.request.Request(
-                url,
-                data=b"{}",
-                headers={
-                    "Authorization": f"Bearer {credentials.token}",
-                    "Content-Type": "application/json",
-                },
-                method="POST",
-            )
-            with urllib.request.urlopen(req) as resp:
-                policy = _json.loads(resp.read().decode())
-
-            # Check if binding already exists
-            bindings = policy.get("bindings", [])
-            wi_binding = None
-            for b in bindings:
-                if b["role"] == "roles/iam.workloadIdentityUser":
-                    wi_binding = b
-                    break
-
-            if wi_binding and member in wi_binding.get("members", []):
-                logger.info("Workload Identity binding already exists for %s", member)
-                return
-
-            if wi_binding:
-                wi_binding["members"].append(member)
-            else:
-                bindings.append({"role": "roles/iam.workloadIdentityUser", "members": [member]})
-            policy["bindings"] = bindings
-
-            # Set updated policy
-            set_url = f"https://iam.googleapis.com/v1/projects/-/serviceAccounts/{gcp_sa_email}:setIamPolicy"
-            set_req = urllib.request.Request(
-                set_url,
-                data=_json.dumps({"policy": policy}).encode(),
-                headers={
-                    "Authorization": f"Bearer {credentials.token}",
-                    "Content-Type": "application/json",
-                },
-                method="POST",
-            )
-            with urllib.request.urlopen(set_req) as resp:
-                resp.read()
-
-            logger.info("Added Workload Identity binding for %s on %s", member, gcp_sa_email)
-        except Exception:
-            logger.exception("Failed to set Workload Identity binding for cellxgene")
-
-    @staticmethod
-    def _patch_sa_annotation(core_v1, namespace: str, gcp_sa_email: str) -> None:
-        try:
-            sa = core_v1.read_namespaced_service_account(name="bioaf-cellxgene-runner", namespace=namespace)
-            current = (sa.metadata.annotations or {}).get("iam.gke.io/gcp-service-account", "")
-            if current != gcp_sa_email:
-                core_v1.patch_namespaced_service_account(
-                    name="bioaf-cellxgene-runner",
-                    namespace=namespace,
-                    body={"metadata": {"annotations": {"iam.gke.io/gcp-service-account": gcp_sa_email}}},
-                )
-                logger.info("Patched Workload Identity annotation on bioaf-cellxgene-runner")
-        except Exception:
-            logger.warning("Could not patch SA annotation for Workload Identity")
 
     # -- Background readiness polling --
 

--- a/backend/app/adapters/cellxgene/kubernetes.py
+++ b/backend/app/adapters/cellxgene/kubernetes.py
@@ -55,8 +55,26 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
         self._cluster_config: dict | None = None
         self._namespace_ready = False
 
+    async def _resolve_image(self) -> str:
+        """Read the cellxgene image URI from platform_config."""
+        if not self._session_factory:
+            raise RuntimeError("No session_factory; cannot resolve cellxgene image URI")
+
+        from sqlalchemy import text as sa_text
+
+        async with self._session_factory() as session:
+            row = (
+                await session.execute(sa_text("SELECT value FROM platform_config WHERE key = 'cellxgene_image'"))
+            ).fetchone()
+
+        uri = row[0] if row else None
+        if not uri or uri == "null":
+            raise RuntimeError("Cellxgene image not built yet. Enable the cellxgene component to trigger a build.")
+        return uri
+
     async def deploy(self, publication_id: int, gcs_uri: str, dataset_name: str) -> dict:
         await self._get_api_client_async()
+        image = await self._resolve_image()
 
         namespace = DEFAULT_CELLXGENE_NAMESPACE
         await self.ensure_cellxgene_namespace(namespace)
@@ -92,7 +110,7 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
                         containers=[
                             client.V1Container(
                                 name="cellxgene",
-                                image="cellxgene:latest",
+                                image=image,
                                 args=["launch", "--host", "0.0.0.0", gcs_uri],
                                 ports=[client.V1ContainerPort(container_port=5005)],
                                 resources=client.V1ResourceRequirements(
@@ -480,9 +498,7 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
             logger.exception("Background poll failed for cellxgene %s", name)
             await self._update_publication_in_db(publication_id, "failed", None)
 
-    async def _update_publication_in_db(
-        self, publication_id: int, status: str, access_url: str | None
-    ) -> None:
+    async def _update_publication_in_db(self, publication_id: int, status: str, access_url: str | None) -> None:
         if not self._session_factory:
             logger.warning("No session_factory, cannot update publication %s in DB", publication_id)
             return
@@ -509,7 +525,9 @@ class KubernetesCellxgeneProvider(CellxgeneProvider):
                 await db.commit()
                 logger.info(
                     "Updated publication %s: status=%s access_url=%s",
-                    publication_id, status, access_url,
+                    publication_id,
+                    status,
+                    access_url,
                 )
         except Exception:
             logger.exception("Failed to update publication %s in DB", publication_id)

--- a/backend/app/adapters/registry.py
+++ b/backend/app/adapters/registry.py
@@ -9,7 +9,7 @@ import logging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.adapters.base import ComputeProvider, NotebookProvider, StorageProvider
+from app.adapters.base import CellxgeneProvider, ComputeProvider, NotebookProvider, StorageProvider
 
 logger = logging.getLogger("bioaf.adapters.registry")
 
@@ -19,18 +19,20 @@ VALID_COMPUTE_STACKS = ("kubernetes", "slurm")
 _compute_adapter: ComputeProvider | None = None
 _storage_adapter: StorageProvider | None = None
 _notebook_adapter: NotebookProvider | None = None
+_cellxgene_adapter: CellxgeneProvider | None = None
 _initialized: bool = False
 
 
 def _create_adapters(
     compute_stack: str,
     session_factory=None,
-) -> tuple[ComputeProvider, StorageProvider, NotebookProvider]:
+) -> tuple[ComputeProvider, StorageProvider, NotebookProvider, CellxgeneProvider]:
     """Instantiate adapters based on the compute_stack value."""
     if compute_stack not in VALID_COMPUTE_STACKS:
         raise ValueError(f"Unknown compute_stack '{compute_stack}'. Valid options: {VALID_COMPUTE_STACKS}")
 
     if compute_stack == "kubernetes":
+        from app.adapters.cellxgene.kubernetes import KubernetesCellxgeneProvider
         from app.adapters.compute.kubernetes import KubernetesComputeProvider
         from app.adapters.notebooks.kubernetes import KubernetesNotebookProvider
         from app.adapters.storage.gcs import GcsStorageProvider
@@ -39,8 +41,10 @@ def _create_adapters(
             KubernetesComputeProvider(session_factory=session_factory),
             GcsStorageProvider(),
             KubernetesNotebookProvider(session_factory=session_factory),
+            KubernetesCellxgeneProvider(session_factory=session_factory),
         )
     else:
+        from app.adapters.cellxgene.kubernetes import KubernetesCellxgeneProvider
         from app.adapters.compute.slurm import SlurmComputeProvider
         from app.adapters.notebooks.slurm import SlurmNotebookProvider
         from app.adapters.storage.nfs import NfsStorageProvider
@@ -49,19 +53,20 @@ def _create_adapters(
             SlurmComputeProvider(),
             NfsStorageProvider(),
             SlurmNotebookProvider(),
+            KubernetesCellxgeneProvider(session_factory=session_factory),
         )
 
 
 async def initialize_adapters(session: AsyncSession, session_factory=None) -> None:
     """Read compute_stack from platform_config and initialize adapters."""
-    global _compute_adapter, _storage_adapter, _notebook_adapter, _initialized
+    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _initialized
 
     result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'compute_stack'"))
     row = result.first()
     compute_stack = row[0] if row else "kubernetes"
 
     logger.info("Initializing BAL adapters for compute_stack=%s", compute_stack)
-    _compute_adapter, _storage_adapter, _notebook_adapter = _create_adapters(
+    _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter = _create_adapters(
         compute_stack, session_factory=session_factory
     )
 
@@ -71,15 +76,17 @@ async def initialize_adapters(session: AsyncSession, session_factory=None) -> No
         await _compute_adapter.load_cluster_config()
     if hasattr(_notebook_adapter, "load_cluster_config"):
         await _notebook_adapter.load_cluster_config()
+    if hasattr(_cellxgene_adapter, "load_cluster_config"):
+        await _cellxgene_adapter.load_cluster_config()
 
     _initialized = True
 
 
 def initialize_adapters_sync(compute_stack: str) -> None:
     """Initialize adapters synchronously from a known value (for testing)."""
-    global _compute_adapter, _storage_adapter, _notebook_adapter, _initialized
+    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _initialized
 
-    _compute_adapter, _storage_adapter, _notebook_adapter = _create_adapters(compute_stack)
+    _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter = _create_adapters(compute_stack)
     _initialized = True
 
 
@@ -104,10 +111,18 @@ def get_notebook_adapter() -> NotebookProvider:
     return _notebook_adapter
 
 
+def get_cellxgene_adapter() -> CellxgeneProvider:
+    """Get the active cellxgene adapter."""
+    if not _initialized or _cellxgene_adapter is None:
+        raise RuntimeError("Adapter registry not initialized. Call initialize_adapters() first.")
+    return _cellxgene_adapter
+
+
 def reset_registry() -> None:
     """Reset the registry (for testing)."""
-    global _compute_adapter, _storage_adapter, _notebook_adapter, _initialized
+    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _initialized
     _compute_adapter = None
     _storage_adapter = None
     _notebook_adapter = None
+    _cellxgene_adapter = None
     _initialized = False

--- a/backend/app/api/cellxgene.py
+++ b/backend/app/api/cellxgene.py
@@ -30,6 +30,7 @@ def _pub_response(pub) -> CellxgenePublicationResponse:
         id=pub.id,
         dataset_name=pub.dataset_name,
         stable_url=pub.stable_url,
+        access_url=pub.access_url,
         status=pub.status,
         file=file_resp,
         experiment_id=pub.experiment_id,

--- a/backend/app/api/cellxgene.py
+++ b/backend/app/api/cellxgene.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_permission
 from app.database import get_session
-from app.schemas.cellxgene import CellxgenePublicationResponse, CellxgenePublishRequest
+from app.schemas.cellxgene import CellxgenePublicationResponse, CellxgenePublishableFile, CellxgenePublishRequest
 from app.schemas.experiment import UserSummary
 from app.schemas.file import FileResponse
 from app.services.cellxgene_service import CellxgeneService
@@ -102,7 +102,7 @@ async def list_publications(
     return [_pub_response(p) for p in pubs]
 
 
-@router.get("/publishable-files")
+@router.get("/publishable-files", response_model=list[CellxgenePublishableFile])
 async def list_publishable_files(
     request: Request,
     session: AsyncSession = Depends(get_session),
@@ -112,21 +112,64 @@ async def list_publishable_files(
 
     files = await CellxgeneService.list_publishable_files(session, org_id)
     return [
-        FileResponse(
+        CellxgenePublishableFile(
             id=f.id,
             filename=f.filename,
             gcs_uri=f.gcs_uri,
             size_bytes=f.size_bytes,
-            md5_checksum=f.md5_checksum,
             file_type=f.file_type,
-            tags=f.tags_json if isinstance(f.tags_json, list) else [],
-            uploader=None,
-            experiment_id=f.experiment_id,
-            upload_timestamp=f.upload_timestamp,
+            project_name=f.project.name if f.project else None,
+            experiment_name=f.experiment.name if f.experiment else None,
+            sample_names=getattr(f, "_sample_names", []),
+            source_type=f.source_type,
+            cellxgene_ready=False,
+            cellxgene_status="not inspected",
             created_at=f.created_at,
         )
         for f in files
     ]
+
+
+@router.get("/inspect/{file_id}")
+async def inspect_file(
+    file_id: int,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+):
+    """Inspect an h5ad file for cellxgene compatibility.
+
+    Downloads and reads HDF5 metadata to check for embeddings.
+    """
+    from sqlalchemy import select as sa_select
+
+    from app.models.file import File
+    from app.services.credential_injector import load_gcp_credentials
+    from app.services.h5ad_inspector import inspect_h5ad
+
+    current_user = request.state.current_user
+    org_id = int(current_user["org_id"])
+
+    result = await session.execute(sa_select(File).where(File.id == file_id, File.organization_id == org_id))
+    file = result.scalar_one_or_none()
+    if not file:
+        raise HTTPException(404, "File not found")
+
+    # Load GCP credentials from platform_config
+    from sqlalchemy import text
+
+    config_rows = (
+        await session.execute(
+            text(
+                "SELECT key, value FROM platform_config "
+                "WHERE key IN ('gcp_credential_source', 'gcp_service_account_key', 'gcp_service_account_email')"
+            )
+        )
+    ).fetchall()
+    config = {r[0]: r[1] for r in config_rows}
+    credentials = load_gcp_credentials(config)
+
+    info = inspect_h5ad(file.gcs_uri, credentials=credentials)
+    return info
 
 
 @router.get("/{publication_id}", response_model=CellxgenePublicationResponse)

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -39,6 +39,8 @@ from app.services.terraform_executor import TerraformExecutor
 
 # Components that require the bioaf-scrna notebook image
 _NOTEBOOK_COMPONENTS = {"rstudio", "jupyterhub"}
+# Components that require the cellxgene image
+_CELLXGENE_COMPONENTS = {"cellxgene"}
 
 logger = logging.getLogger("bioaf.stack_deploy_api")
 
@@ -629,6 +631,28 @@ async def stack_component_toggle(
                     new_status = "provisioning"
                 except Exception as exc:
                     logger.warning("Failed to start notebook image build: %s", exc)
+                    new_status = "build_failed"
+
+        # Cellxgene needs its own image
+        if component_key in _CELLXGENE_COMPONENTS:
+            from app.services.cellxgene_image_service import build_cellxgene_image
+
+            cxg_image = (
+                await session.execute(text("SELECT value FROM platform_config WHERE key = 'cellxgene_image'"))
+            ).scalar_one_or_none()
+            cxg_build_status = (
+                await session.execute(
+                    text("SELECT value FROM platform_config WHERE key = 'cellxgene_image_build_status'")
+                )
+            ).scalar_one_or_none()
+
+            needs_build = not cxg_image or cxg_image == "null" or cxg_build_status not in ("SUCCESS",)
+            if needs_build:
+                try:
+                    await build_cellxgene_image(session)
+                    new_status = "provisioning"
+                except Exception as exc:
+                    logger.warning("Failed to start cellxgene image build: %s", exc)
                     new_status = "build_failed"
 
         await session.execute(

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -557,6 +557,7 @@ async def stack_components_list(
 @router.post("/api/v1/infrastructure/stack/components/{component_key}/toggle")
 async def stack_component_toggle(
     component_key: str,
+    force_rebuild: bool = False,
     current_user: dict = require_permission("infrastructure", "configure"),
     session: AsyncSession = Depends(get_session),
 ) -> ComponentToggleResponse:
@@ -622,9 +623,7 @@ async def stack_component_toggle(
                 )
             ).scalar_one_or_none()
 
-            # Trigger a build if: no image URI, or image URI is set but the
-            # build never succeeded (stale URI from a pre-fix attempt).
-            needs_build = not scrna_image or scrna_image == "null" or build_status not in ("SUCCESS",)
+            needs_build = force_rebuild or not scrna_image or scrna_image == "null" or build_status not in ("SUCCESS",)
             if needs_build:
                 try:
                     await build_notebook_image(session)
@@ -646,7 +645,7 @@ async def stack_component_toggle(
                 )
             ).scalar_one_or_none()
 
-            needs_build = not cxg_image or cxg_image == "null" or cxg_build_status not in ("SUCCESS",)
+            needs_build = force_rebuild or not cxg_image or cxg_image == "null" or cxg_build_status not in ("SUCCESS",)
             if needs_build:
                 try:
                     await build_cellxgene_image(session)

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -726,6 +726,32 @@ async def notebook_image_build_status(
     )
 
 
+@router.get("/api/v1/infrastructure/cellxgene-image/build-status")
+async def cellxgene_image_build_status(
+    current_user: dict = require_permission("infrastructure", "view"),
+    session: AsyncSession = Depends(get_session),
+) -> NotebookImageBuildStatus:
+    """Return current cellxgene image build status."""
+    rows = (
+        await session.execute(
+            text(
+                "SELECT key, value FROM platform_config "
+                "WHERE key IN ('cellxgene_image_build_id', 'cellxgene_image_build_status', 'cellxgene_image')"
+            )
+        )
+    ).fetchall()
+    config = {r[0]: r[1] for r in rows}
+
+    def _non_null(val: str | None) -> str | None:
+        return val if val and val != "null" else None
+
+    return NotebookImageBuildStatus(
+        build_id=_non_null(config.get("cellxgene_image_build_id")),
+        build_status=_non_null(config.get("cellxgene_image_build_status")),
+        image_uri=_non_null(config.get("cellxgene_image")),
+    )
+
+
 @router.post("/api/v1/infrastructure/notebook-image/cancel")
 async def notebook_image_cancel(
     current_user: dict = require_permission("infrastructure", "configure"),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -152,6 +152,7 @@ async def lifespan(app: FastAPI):
     background_tasks.append(asyncio.create_task(_pubsub_listener_loop()))
     background_tasks.append(asyncio.create_task(_session_monitor_loop()))
     background_tasks.append(asyncio.create_task(_notebook_image_build_loop()))
+    background_tasks.append(asyncio.create_task(_cellxgene_image_build_loop()))
     background_tasks.append(asyncio.create_task(_environment_build_poll_loop()))
     background_tasks.append(asyncio.create_task(_work_node_heartbeat_loop()))
     background_tasks.append(asyncio.create_task(_export_cleanup_loop()))
@@ -540,6 +541,24 @@ async def _notebook_image_build_loop():
             break
         except Exception as e:
             logger.error("Notebook image build monitor error: %s", e)
+
+
+async def _cellxgene_image_build_loop():
+    """Poll active cellxgene image builds every 30 seconds."""
+    from app.database import async_session_factory
+    from app.services.cellxgene_image_service import poll_image_build as poll_cellxgene_build
+
+    while True:
+        try:
+            await asyncio.sleep(30)
+            async with async_session_factory() as session:
+                status = await poll_cellxgene_build(session)
+                if status:
+                    await session.commit()
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error("Cellxgene image build monitor error: %s", e)
 
 
 async def _environment_build_poll_loop():

--- a/backend/app/models/cellxgene_publication.py
+++ b/backend/app/models/cellxgene_publication.py
@@ -15,6 +15,7 @@ class CellxgenePublication(Base):
     experiment_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("experiments.id"), nullable=True)
     dataset_name: Mapped[str] = mapped_column(String(255), nullable=False)
     stable_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    access_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     status: Mapped[str] = mapped_column(String(50), nullable=False, default="publishing")
     published_by_user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"), nullable=True)
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/schemas/cellxgene.py
+++ b/backend/app/schemas/cellxgene.py
@@ -6,6 +6,21 @@ from app.schemas.experiment import UserSummary
 from app.schemas.file import FileResponse
 
 
+class CellxgenePublishableFile(BaseModel):
+    id: int
+    filename: str
+    gcs_uri: str
+    size_bytes: int | None
+    file_type: str
+    project_name: str | None = None
+    experiment_name: str | None = None
+    sample_names: list[str] = []
+    source_type: str = "upload"
+    cellxgene_ready: bool = False
+    cellxgene_status: str = "unknown"
+    created_at: datetime
+
+
 class CellxgenePublishRequest(BaseModel):
     file_id: int
     experiment_id: int | None = None

--- a/backend/app/schemas/cellxgene.py
+++ b/backend/app/schemas/cellxgene.py
@@ -16,6 +16,7 @@ class CellxgenePublicationResponse(BaseModel):
     id: int
     dataset_name: str
     stable_url: str | None
+    access_url: str | None
     status: str
     file: FileResponse | None = None
     experiment_id: int | None

--- a/backend/app/services/cellxgene_image_service.py
+++ b/backend/app/services/cellxgene_image_service.py
@@ -29,7 +29,7 @@ IMAGE_TAG = "latest"
 DOCKERFILE_CONTENT = """\
 FROM python:3.11-slim
 
-RUN pip install --no-cache-dir cellxgene google-cloud-storage
+RUN pip install --no-cache-dir cellxgene gcsfs
 
 EXPOSE 5005
 

--- a/backend/app/services/cellxgene_image_service.py
+++ b/backend/app/services/cellxgene_image_service.py
@@ -1,0 +1,264 @@
+"""Cellxgene image build service.
+
+Manages the Cloud Build job for the cellxgene container image. Follows the
+same pattern as notebook_image_service: embedded Dockerfile, GCS context
+upload, Cloud Build submission, and polling.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import tarfile
+import time
+
+import google.auth
+import google.auth.transport.requests
+from google.cloud import storage
+from google.oauth2 import service_account
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger("bioaf.cellxgene_image")
+
+AR_REPO_ID = "bioaf-images"
+IMAGE_NAME = "bioaf-cellxgene"
+IMAGE_TAG = "latest"
+
+DOCKERFILE_CONTENT = """\
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir cellxgene google-cloud-storage
+
+EXPOSE 5005
+
+ENTRYPOINT ["cellxgene"]
+"""
+
+
+def get_image_uri(project_id: str, region: str) -> str:
+    """Construct the full Artifact Registry image URI."""
+    return f"{region}-docker.pkg.dev/{project_id}/{AR_REPO_ID}/{IMAGE_NAME}:{IMAGE_TAG}"
+
+
+async def _get_credentials(session: AsyncSession):
+    """Load GCP credentials from platform_config."""
+    result = await session.execute(
+        text("SELECT key, value FROM platform_config WHERE key IN ('gcp_credential_source', 'gcp_service_account_key')")
+    )
+    config = {r[0]: r[1] for r in result.fetchall()}
+
+    if config.get("gcp_credential_source") != "service_account_key":
+        creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        return creds
+
+    key_json = config.get("gcp_service_account_key")
+    if not key_json or key_json == "null":
+        creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        return creds
+
+    key_data = json.loads(key_json)
+    return service_account.Credentials.from_service_account_info(
+        key_data,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+
+
+def _authorized_request(credentials, method: str, url: str, body: dict | None = None) -> dict:
+    """Make an authenticated HTTP request to a GCP REST API."""
+    import urllib.request
+
+    auth_req = google.auth.transport.requests.Request()
+    credentials.refresh(auth_req)
+
+    headers = {
+        "Authorization": f"Bearer {credentials.token}",
+        "Content-Type": "application/json",
+    }
+
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else ""
+        logger.error("GCP API %s %s -> %d: %s", method, url, e.code, error_body)
+        raise
+
+
+async def _read_config(session: AsyncSession, key: str) -> str:
+    row = (await session.execute(text("SELECT value FROM platform_config WHERE key = :k").bindparams(k=key))).fetchone()
+    return row[0] if row else "null"
+
+
+async def _set_config(session: AsyncSession, key: str, value: str) -> None:
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value) VALUES (:k, :v) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()"
+        ).bindparams(k=key, v=value)
+    )
+
+
+async def _upload_build_context(session: AsyncSession, project_id: str, working_bucket: str) -> str:
+    """Create a tar.gz with the Dockerfile and upload to GCS."""
+    credentials = await _get_credentials(session)
+    client = storage.Client(project=project_id, credentials=credentials)
+    bucket = client.bucket(working_bucket)
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        dockerfile_bytes = DOCKERFILE_CONTENT.encode()
+        info = tarfile.TarInfo(name="Dockerfile")
+        info.size = len(dockerfile_bytes)
+        info.mtime = int(time.time())
+        tar.addfile(info, io.BytesIO(dockerfile_bytes))
+
+    buf.seek(0)
+    object_path = "builds/bioaf-cellxgene/source.tar.gz"
+    blob = bucket.blob(object_path)
+    blob.upload_from_file(buf, content_type="application/gzip")
+    logger.info("Uploaded build context to gs://%s/%s", working_bucket, object_path)
+
+    return object_path
+
+
+async def submit_image_build(session: AsyncSession, project_id: str, region: str) -> str:
+    """Submit a Cloud Build job for the cellxgene image. Returns the build ID."""
+    working_bucket = await _read_config(session, "working_bucket_name")
+    if not working_bucket or working_bucket == "null":
+        raise ValueError("Working bucket not configured. Deploy storage first.")
+
+    object_path = await _upload_build_context(session, project_id, working_bucket)
+
+    image_uri = get_image_uri(project_id, region)
+    credentials = await _get_credentials(session)
+
+    sa_email = await _read_config(session, "gcp_service_account_email")
+    if not sa_email or sa_email == "null":
+        sa_email = getattr(credentials, "service_account_email", None)
+
+    build_url = f"https://cloudbuild.googleapis.com/v1/projects/{project_id}/builds"
+    build_body: dict = {
+        "source": {
+            "storageSource": {
+                "bucket": working_bucket,
+                "object": object_path,
+            }
+        },
+        "steps": [
+            {
+                "name": "gcr.io/cloud-builders/docker",
+                "args": ["build", "-t", image_uri, "-f", "Dockerfile", "."],
+            }
+        ],
+        "images": [image_uri],
+        "options": {
+            "machineType": "E2_HIGHCPU_8",
+        },
+        "timeout": "3600s",
+    }
+    if sa_email and sa_email != "null":
+        build_body["serviceAccount"] = f"projects/{project_id}/serviceAccounts/{sa_email}"
+        build_body["options"]["defaultLogsBucketBehavior"] = "REGIONAL_USER_OWNED_BUCKET"
+        logger.info("Cloud Build will run as SA: %s", sa_email)
+
+    result = _authorized_request(credentials, "POST", build_url, build_body)
+    build_id = result.get("metadata", {}).get("build", {}).get("id", "")
+    logger.info("Submitted Cloud Build %s for image %s", build_id, image_uri)
+
+    await _set_config(session, "cellxgene_image_build_id", build_id)
+    await _set_config(session, "cellxgene_image_build_status", "WORKING")
+
+    return build_id
+
+
+async def check_build_status(session: AsyncSession, project_id: str, build_id: str) -> str:
+    """Check the status of a Cloud Build job."""
+    credentials = await _get_credentials(session)
+    url = f"https://cloudbuild.googleapis.com/v1/projects/{project_id}/builds/{build_id}"
+
+    try:
+        result = _authorized_request(credentials, "GET", url)
+        return result.get("status", "UNKNOWN")
+    except Exception as e:
+        logger.error("Failed to check build %s: %s", build_id, e)
+        return "UNKNOWN"
+
+
+async def build_cellxgene_image(session: AsyncSession) -> str:
+    """Full flow: ensure AR repo exists, submit build, return build ID.
+
+    Called when the cellxgene component is enabled. The image URI is NOT
+    written until the build succeeds (via poll_image_build).
+    """
+    from app.services.notebook_image_service import ensure_artifact_registry
+
+    project_id = await _read_config(session, "gcp_project_id")
+    region = await _read_config(session, "gcp_region")
+
+    if not project_id or project_id == "null":
+        raise ValueError("GCP project not configured")
+    if not region or region == "null":
+        raise ValueError("GCP region not configured")
+
+    await _set_config(session, "cellxgene_image", "null")
+    await _set_config(session, "cellxgene_image_build_status", "null")
+    await _set_config(session, "cellxgene_image_build_id", "null")
+
+    # Reuse the shared AR repo
+    await ensure_artifact_registry(session, project_id, region)
+
+    build_id = await submit_image_build(session, project_id, region)
+    return build_id
+
+
+async def poll_image_build(session: AsyncSession) -> str | None:
+    """Check if there is an active cellxgene image build and update its status.
+
+    Called by the background task loop. Returns the current status
+    or None if no active build.
+    """
+    build_id = await _read_config(session, "cellxgene_image_build_id")
+    if not build_id or build_id == "null":
+        return None
+
+    current_status = await _read_config(session, "cellxgene_image_build_status")
+    if current_status in ("SUCCESS", "FAILURE", "CANCELLED", "TIMEOUT"):
+        return current_status
+
+    project_id = await _read_config(session, "gcp_project_id")
+    if not project_id or project_id == "null":
+        return None
+
+    status = await check_build_status(session, project_id, build_id)
+    await _set_config(session, "cellxgene_image_build_status", status)
+
+    if status == "SUCCESS":
+        logger.info("Cellxgene image build %s completed successfully", build_id)
+        region = await _read_config(session, "gcp_region")
+        image_uri = get_image_uri(project_id, region)
+        await _set_config(session, "cellxgene_image", image_uri)
+        await session.execute(
+            text("""
+            UPDATE component_states SET status = 'enabled'
+            WHERE component_key = 'cellxgene'
+            AND enabled = true AND status = 'provisioning'
+            """)
+        )
+    elif status in ("FAILURE", "CANCELLED", "TIMEOUT"):
+        logger.error("Cellxgene image build %s failed with status %s", build_id, status)
+        await _set_config(session, "cellxgene_image", "null")
+        await session.execute(
+            text("""
+            UPDATE component_states SET status = 'build_failed'
+            WHERE component_key = 'cellxgene'
+            AND enabled = true AND status = 'provisioning'
+            """)
+        )
+
+    await session.flush()
+    return status

--- a/backend/app/services/cellxgene_service.py
+++ b/backend/app/services/cellxgene_service.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.adapters.registry import get_cellxgene_adapter
 from app.models.cellxgene_publication import CellxgenePublication
 from app.models.file import File
 from app.services.audit_service import log_action
@@ -54,9 +55,10 @@ class CellxgeneService:
             details={"dataset_name": dataset_name, "file_id": file_id},
         )
 
-        # Deploy cellxgene pod (async, don't block response)
+        # Deploy cellxgene via adapter
         try:
-            await CellxgeneService._deploy_cellxgene_pod(pub.id, file.gcs_uri, dataset_name)
+            adapter = get_cellxgene_adapter()
+            await adapter.deploy(pub.id, file.gcs_uri, dataset_name)
             pub.status = "published"
             pub.published_at = datetime.now(timezone.utc)
         except Exception as e:
@@ -78,7 +80,8 @@ class CellxgeneService:
         await session.flush()
 
         try:
-            await CellxgeneService._teardown_cellxgene_pod(publication_id)
+            adapter = get_cellxgene_adapter()
+            await adapter.teardown(publication_id)
             pub.status = "unpublished"
             pub.unpublished_at = datetime.now(timezone.utc)
         except Exception as e:
@@ -153,88 +156,3 @@ class CellxgeneService:
             .order_by(File.created_at.desc())
         )
         return list(result.scalars().all())
-
-    @staticmethod
-    async def _deploy_cellxgene_pod(publication_id: int, gcs_uri: str, dataset_name: str) -> None:
-        """Deploy a cellxgene pod via Kubernetes API."""
-        try:
-            from kubernetes import client as k8s_client, config as k8s_config
-
-            try:
-                k8s_config.load_incluster_config()
-            except k8s_config.ConfigException:
-                k8s_config.load_kube_config()
-
-            apps_v1 = k8s_client.AppsV1Api()
-            core_v1 = k8s_client.CoreV1Api()
-
-            name = f"cellxgene-{publication_id}"
-            namespace = "bioaf-cellxgene"
-
-            # Create deployment
-            deployment = k8s_client.V1Deployment(
-                metadata=k8s_client.V1ObjectMeta(name=name, namespace=namespace),
-                spec=k8s_client.V1DeploymentSpec(
-                    replicas=1,
-                    selector=k8s_client.V1LabelSelector(match_labels={"app": name}),
-                    template=k8s_client.V1PodTemplateSpec(
-                        metadata=k8s_client.V1ObjectMeta(labels={"app": name}),
-                        spec=k8s_client.V1PodSpec(
-                            containers=[
-                                k8s_client.V1Container(
-                                    name="cellxgene",
-                                    image="cellxgene:latest",
-                                    args=["launch", "--host", "0.0.0.0", gcs_uri],
-                                    ports=[k8s_client.V1ContainerPort(container_port=5005)],
-                                )
-                            ]
-                        ),
-                    ),
-                ),
-            )
-            apps_v1.create_namespaced_deployment(namespace=namespace, body=deployment)
-
-            # Create service
-            service = k8s_client.V1Service(
-                metadata=k8s_client.V1ObjectMeta(name=name, namespace=namespace),
-                spec=k8s_client.V1ServiceSpec(
-                    selector={"app": name},
-                    ports=[k8s_client.V1ServicePort(port=80, target_port=5005)],
-                    type="ClusterIP",
-                ),
-            )
-            core_v1.create_namespaced_service(namespace=namespace, body=service)
-
-            logger.info("Deployed cellxgene pod %s", name)
-        except ImportError:
-            logger.warning("kubernetes package not installed, skipping pod deployment")
-        except Exception as e:
-            logger.error("Kubernetes deployment failed: %s", e)
-            raise
-
-    @staticmethod
-    async def _teardown_cellxgene_pod(publication_id: int) -> None:
-        """Teardown cellxgene pod."""
-        try:
-            from kubernetes import client as k8s_client, config as k8s_config
-
-            try:
-                k8s_config.load_incluster_config()
-            except k8s_config.ConfigException:
-                k8s_config.load_kube_config()
-
-            apps_v1 = k8s_client.AppsV1Api()
-            core_v1 = k8s_client.CoreV1Api()
-
-            name = f"cellxgene-{publication_id}"
-            namespace = "bioaf-cellxgene"
-
-            apps_v1.delete_namespaced_deployment(name=name, namespace=namespace)
-            core_v1.delete_namespaced_service(name=name, namespace=namespace)
-
-            logger.info("Torn down cellxgene pod %s", name)
-        except ImportError:
-            logger.warning("kubernetes package not installed, skipping pod teardown")
-        except Exception as e:
-            logger.error("Kubernetes teardown failed: %s", e)
-            raise

--- a/backend/app/services/cellxgene_service.py
+++ b/backend/app/services/cellxgene_service.py
@@ -55,12 +55,12 @@ class CellxgeneService:
             details={"dataset_name": dataset_name, "file_id": file_id},
         )
 
-        # Deploy cellxgene via adapter
+        # Deploy cellxgene via adapter. Status stays "publishing" until the
+        # background poller confirms the deployment is ready and sets
+        # "published" with the access_url.
         try:
             adapter = get_cellxgene_adapter()
             await adapter.deploy(pub.id, file.gcs_uri, dataset_name)
-            pub.status = "published"
-            pub.published_at = datetime.now(timezone.utc)
         except Exception as e:
             logger.error("Failed to deploy cellxgene pod for publication %d: %s", pub.id, e)
             pub.status = "failed"

--- a/backend/app/services/cellxgene_service.py
+++ b/backend/app/services/cellxgene_service.py
@@ -134,8 +134,13 @@ class CellxgeneService:
 
     @staticmethod
     async def list_publishable_files(session: AsyncSession, org_id: int) -> list[File]:
-        """Return h5ad files that have no active cellxgene publication."""
-        # Subquery: file IDs with active publications
+        """Return h5ad files that have no active cellxgene publication.
+
+        Eagerly loads project, experiment, and sample relationships for
+        display in the publish form.
+        """
+        from app.models.sample import Sample, sample_files
+
         active_pub_file_ids = (
             select(CellxgenePublication.file_id)
             .where(
@@ -148,6 +153,10 @@ class CellxgeneService:
 
         result = await session.execute(
             select(File)
+            .options(
+                selectinload(File.project),
+                selectinload(File.experiment),
+            )
             .where(
                 File.organization_id == org_id,
                 File.file_type == "h5ad",
@@ -155,4 +164,26 @@ class CellxgeneService:
             )
             .order_by(File.created_at.desc())
         )
-        return list(result.scalars().all())
+        files = list(result.scalars().all())
+
+        # Load sample names for each file via the join table
+        if files:
+            file_ids = [f.id for f in files]
+            sample_rows = (
+                await session.execute(
+                    select(sample_files.c.file_id, Sample.sample_id_external)
+                    .join(Sample, Sample.id == sample_files.c.sample_id)
+                    .where(sample_files.c.file_id.in_(file_ids))
+                )
+            ).fetchall()
+            file_samples: dict[int, list[str]] = {}
+            for fid, sid_ext in sample_rows:
+                if sid_ext:
+                    file_samples.setdefault(fid, []).append(sid_ext)
+            for f in files:
+                f._sample_names = file_samples.get(f.id, [])  # type: ignore[attr-defined]
+        else:
+            for f in files:
+                f._sample_names = []  # type: ignore[attr-defined]
+
+        return files

--- a/backend/app/services/h5ad_inspector.py
+++ b/backend/app/services/h5ad_inspector.py
@@ -1,0 +1,85 @@
+"""Lightweight h5ad file inspector.
+
+Reads HDF5 group metadata from GCS to determine cellxgene compatibility
+(requires obsm embeddings like X_umap or X_tsne). Downloads the file to
+a temp file for h5py to read -- runs on demand per file, not in bulk.
+"""
+
+import logging
+import tempfile
+
+import h5py
+from google.cloud import storage
+
+logger = logging.getLogger("bioaf.h5ad_inspector")
+
+# Embeddings that cellxgene can use as layouts
+KNOWN_EMBEDDINGS = {"X_umap", "X_tsne", "X_pca", "X_draw_graph_fa", "X_diffmap"}
+
+
+def inspect_h5ad(gcs_uri: str, credentials=None) -> dict:
+    """Inspect an h5ad file on GCS and return metadata.
+
+    Returns dict with:
+        - embeddings: list of obsm keys (e.g. ["X_umap", "X_pca"])
+        - cell_count: number of observations (rows)
+        - gene_count: number of variables (columns)
+        - cellxgene_ready: bool, True if at least one 2D embedding exists
+        - missing: human-readable description of what's missing, or None
+    """
+    try:
+        path = gcs_uri.replace("gs://", "")
+        bucket_name = path.split("/")[0]
+        blob_path = "/".join(path.split("/")[1:])
+
+        client = storage.Client(credentials=credentials)
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_path)
+
+        with tempfile.NamedTemporaryFile(suffix=".h5ad") as tmp:
+            blob.download_to_file(tmp)
+            tmp.flush()
+            tmp.seek(0)
+
+            with h5py.File(tmp.name, "r") as f:
+                obsm_keys = list(f["obsm"].keys()) if "obsm" in f else []
+
+                cell_count = 0
+                if "X" in f:
+                    x = f["X"]
+                    if hasattr(x, "shape"):
+                        cell_count = x.shape[0]
+                if cell_count == 0 and "obs" in f:
+                    cell_count = f["obs"].attrs.get("_index_length", 0)
+
+                gene_count = 0
+                if "X" in f:
+                    x = f["X"]
+                    if hasattr(x, "shape") and len(x.shape) > 1:
+                        gene_count = x.shape[1]
+                if gene_count == 0 and "var" in f:
+                    gene_count = f["var"].attrs.get("_index_length", 0)
+
+        embeddings = [k for k in obsm_keys if k.startswith("X_")]
+        has_layout = any(k in KNOWN_EMBEDDINGS for k in embeddings)
+
+        missing_parts = []
+        if not has_layout:
+            missing_parts.append("embeddings (UMAP/t-SNE)")
+
+        return {
+            "embeddings": embeddings,
+            "cell_count": cell_count,
+            "gene_count": gene_count,
+            "cellxgene_ready": has_layout,
+            "missing": ", ".join(missing_parts) if missing_parts else None,
+        }
+    except Exception as e:
+        logger.warning("Failed to inspect h5ad %s: %s", gcs_uri, e)
+        return {
+            "embeddings": [],
+            "cell_count": 0,
+            "gene_count": 0,
+            "cellxgene_ready": False,
+            "missing": "unable to inspect file",
+        }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.4.0"
+version = "0.4.1"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "python-multipart>=0.0.6",
     "pyyaml>=6.0",
     "PyJWT[crypto]>=2.8",
+    "h5py>=3.10",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/tests/test_component_toggle_image_build.py
+++ b/backend/tests/test_component_toggle_image_build.py
@@ -163,12 +163,19 @@ async def test_toggle_rstudio_rebuilds_when_no_build_status(
 
 
 @pytest.mark.asyncio
-async def test_toggle_cellxgene_does_not_trigger_build(client, session, admin_token, admin_user, seed_deployed_stack):
-    """Enabling non-notebook components does not trigger image build."""
-    with patch(
-        "app.api.stack_deploy.build_notebook_image",
-        new_callable=AsyncMock,
-    ) as mock_build:
+async def test_toggle_cellxgene_triggers_own_build(client, session, admin_token, admin_user, seed_deployed_stack):
+    """Enabling cellxgene triggers its own image build, not the notebook one."""
+    with (
+        patch(
+            "app.api.stack_deploy.build_notebook_image",
+            new_callable=AsyncMock,
+        ) as mock_notebook_build,
+        patch(
+            "app.services.cellxgene_image_service.build_cellxgene_image",
+            new_callable=AsyncMock,
+            return_value="fake-build-id",
+        ) as mock_cxg_build,
+    ):
         response = await client.post(
             "/api/v1/infrastructure/stack/components/cellxgene/toggle",
             headers={"Authorization": f"Bearer {admin_token}"},
@@ -176,8 +183,9 @@ async def test_toggle_cellxgene_does_not_trigger_build(client, session, admin_to
     assert response.status_code == 200
     data = response.json()
     assert data["enabled"] is True
-    assert data["status"] == "enabled"
-    mock_build.assert_not_called()
+    assert data["status"] == "provisioning"
+    mock_notebook_build.assert_not_called()
+    mock_cxg_build.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_k8s_cellxgene_adapter.py
+++ b/backend/tests/test_k8s_cellxgene_adapter.py
@@ -37,6 +37,7 @@ def mock_k8s(adapter):
             new_callable=AsyncMock,
             return_value="us-central1-docker.pkg.dev/p/r/bioaf-cellxgene:latest",
         ),
+        patch.object(adapter, "_ensure_gcp_secret", new_callable=AsyncMock),
         patch.object(adapter, "_get_k8s_apps_client", return_value=mock_apps),
         patch.object(adapter, "_get_k8s_core_client", return_value=mock_core),
         patch.object(adapter, "_get_k8s_rbac_client", return_value=mock_rbac),
@@ -80,6 +81,22 @@ class TestCellxgeneDeploy:
         await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
         svc_body = mock_k8s["core"].create_namespaced_service.call_args[1]["body"]
         assert svc_body.spec.type == "LoadBalancer"
+
+    @pytest.mark.asyncio
+    async def test_deploy_uses_init_container_for_gcs_download(self, adapter, mock_k8s):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        dep_body = mock_k8s["apps"].create_namespaced_deployment.call_args[1]["body"]
+        init_containers = dep_body.spec.template.spec.init_containers
+        assert len(init_containers) == 1
+        assert init_containers[0].name == "gcs-download"
+        assert "gsutil cp" in init_containers[0].command[2]
+
+    @pytest.mark.asyncio
+    async def test_deploy_cellxgene_serves_local_path(self, adapter, mock_k8s):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        dep_body = mock_k8s["apps"].create_namespaced_deployment.call_args[1]["body"]
+        main_container = dep_body.spec.template.spec.containers[0]
+        assert "/data/dataset.h5ad" in main_container.args
 
 
 class TestCellxgeneTeardown:

--- a/backend/tests/test_k8s_cellxgene_adapter.py
+++ b/backend/tests/test_k8s_cellxgene_adapter.py
@@ -1,110 +1,148 @@
 """Tests for the Kubernetes cellxgene adapter.
 
-Covers local mode (deploy/teardown/status) and K8s namespace setup.
+Covers deploy/teardown/status (with mocked K8s clients) and namespace setup.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.adapters.cellxgene.kubernetes import (
-    KubernetesCellxgeneProvider,
-    _local_instances,
-)
-
-
-@pytest.fixture(autouse=True)
-def set_local_mode(monkeypatch):
-    monkeypatch.setenv("BIOAF_COMPUTE_MODE", "local")
-
-
-@pytest.fixture(autouse=True)
-def clear_instances():
-    _local_instances.clear()
-    yield
-    _local_instances.clear()
+from app.adapters.cellxgene.kubernetes import KubernetesCellxgeneProvider
 
 
 @pytest.fixture
 def adapter():
-    return KubernetesCellxgeneProvider()
+    provider = KubernetesCellxgeneProvider()
+    # Pre-populate cluster config so _get_api_client_async won't hit the DB
+    provider._cluster_config = {
+        "gke_cluster_endpoint": "https://10.0.0.1",
+        "gke_cluster_ca_cert": "",
+        "gcp_service_account_key": "",
+    }
+    return provider
+
+
+@pytest.fixture
+def mock_k8s(adapter):
+    """Patch all K8s client accessors with mocks."""
+    mock_apps = MagicMock()
+    mock_core = MagicMock()
+    mock_rbac = MagicMock()
+
+    with (
+        patch.object(adapter, "_get_api_client_async", new_callable=AsyncMock),
+        patch.object(adapter, "_get_k8s_apps_client", return_value=mock_apps),
+        patch.object(adapter, "_get_k8s_core_client", return_value=mock_core),
+        patch.object(adapter, "_get_k8s_rbac_client", return_value=mock_rbac),
+        patch("asyncio.create_task"),
+    ):
+        # Namespace already exists so ensure_cellxgene_namespace is a no-op
+        adapter._namespace_ready = True
+        yield {"apps": mock_apps, "core": mock_core, "rbac": mock_rbac}
 
 
 class TestCellxgeneDeploy:
     @pytest.mark.asyncio
-    async def test_deploy_returns_publication_id(self, adapter):
+    async def test_deploy_returns_publication_id(self, adapter, mock_k8s):
         result = await adapter.deploy(42, "gs://bucket/data.h5ad", "My Dataset")
         assert result["publication_id"] == 42
 
     @pytest.mark.asyncio
-    async def test_deploy_returns_running_status(self, adapter):
+    async def test_deploy_returns_starting_status(self, adapter, mock_k8s):
         result = await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
-        assert result["status"] == "running"
+        assert result["status"] == "starting"
 
     @pytest.mark.asyncio
-    async def test_deploy_stores_in_local_instances(self, adapter):
-        await adapter.deploy(7, "gs://bucket/data.h5ad", "Dataset")
-        assert 7 in _local_instances
-
-    @pytest.mark.asyncio
-    async def test_deploy_sets_pod_name(self, adapter):
+    async def test_deploy_sets_pod_name(self, adapter, mock_k8s):
         result = await adapter.deploy(5, "gs://bucket/data.h5ad", "Dataset")
         assert result["pod_name"] == "cellxgene-5"
+
+    @pytest.mark.asyncio
+    async def test_deploy_creates_deployment_and_service(self, adapter, mock_k8s):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        mock_k8s["apps"].create_namespaced_deployment.assert_called_once()
+        mock_k8s["core"].create_namespaced_service.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_deploy_uses_correct_namespace(self, adapter, mock_k8s):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        call_kwargs = mock_k8s["apps"].create_namespaced_deployment.call_args[1]
+        assert call_kwargs["namespace"] == "bioaf-cellxgene"
 
 
 class TestCellxgeneTeardown:
     @pytest.mark.asyncio
-    async def test_teardown_returns_stopped(self, adapter):
-        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+    async def test_teardown_returns_stopped(self, adapter, mock_k8s):
         result = await adapter.teardown(1)
         assert result["status"] == "stopped"
 
     @pytest.mark.asyncio
-    async def test_teardown_updates_local_store(self, adapter):
-        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+    async def test_teardown_deletes_deployment_and_service(self, adapter, mock_k8s):
         await adapter.teardown(1)
-        assert _local_instances[1]["status"] == "stopped"
+        mock_k8s["apps"].delete_namespaced_deployment.assert_called_once_with(
+            name="cellxgene-1", namespace="bioaf-cellxgene"
+        )
+        mock_k8s["core"].delete_namespaced_service.assert_called_once_with(
+            name="cellxgene-1", namespace="bioaf-cellxgene"
+        )
 
     @pytest.mark.asyncio
-    async def test_teardown_nonexistent_returns_stopped(self, adapter):
+    async def test_teardown_tolerates_missing_resources(self, adapter, mock_k8s):
+        from kubernetes.client.rest import ApiException
+
+        mock_k8s["apps"].delete_namespaced_deployment.side_effect = ApiException(status=404)
+        mock_k8s["core"].delete_namespaced_service.side_effect = ApiException(status=404)
         result = await adapter.teardown(999)
         assert result["status"] == "stopped"
 
 
 class TestCellxgeneGetStatus:
     @pytest.mark.asyncio
-    async def test_status_of_running_instance(self, adapter):
-        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+    async def test_status_running(self, adapter, mock_k8s):
+        mock_dep = MagicMock()
+        mock_dep.status.ready_replicas = 1
+        mock_k8s["apps"].read_namespaced_deployment_status.return_value = mock_dep
+
         result = await adapter.get_status(1)
         assert result["status"] == "running"
 
     @pytest.mark.asyncio
-    async def test_status_of_unknown_instance(self, adapter):
+    async def test_status_starting(self, adapter, mock_k8s):
+        mock_dep = MagicMock()
+        mock_dep.status.ready_replicas = 0
+        mock_k8s["apps"].read_namespaced_deployment_status.return_value = mock_dep
+
+        result = await adapter.get_status(1)
+        assert result["status"] == "starting"
+
+    @pytest.mark.asyncio
+    async def test_status_unknown_on_error(self, adapter, mock_k8s):
+        mock_k8s["apps"].read_namespaced_deployment_status.side_effect = Exception("gone")
         result = await adapter.get_status(999)
         assert result["status"] == "unknown"
 
 
 class TestCellxgeneNamespaceSetup:
     @pytest.fixture
-    def k8s_adapter(self, monkeypatch):
-        monkeypatch.setenv("BIOAF_COMPUTE_MODE", "k8s")
-        return KubernetesCellxgeneProvider()
+    def fresh_adapter(self):
+        provider = KubernetesCellxgeneProvider()
+        provider._cluster_config = {
+            "gke_cluster_endpoint": "https://10.0.0.1",
+        }
+        return provider
 
     @pytest.mark.asyncio
-    async def test_creates_namespace_sa_and_rolebinding(self, k8s_adapter):
+    async def test_creates_namespace_sa_and_rolebinding(self, fresh_adapter):
         mock_core_v1 = MagicMock()
         mock_rbac_v1 = MagicMock()
 
         from kubernetes.client.rest import ApiException
 
         mock_core_v1.read_namespace.side_effect = ApiException(status=404)
-        mock_core_v1.create_namespace.return_value = MagicMock()
-        mock_core_v1.create_namespaced_service_account.return_value = MagicMock()
-        mock_rbac_v1.create_namespaced_role_binding.return_value = MagicMock()
 
-        with patch.object(k8s_adapter, "_get_k8s_core_client", return_value=mock_core_v1):
-            with patch.object(k8s_adapter, "_get_k8s_rbac_client", return_value=mock_rbac_v1):
-                await k8s_adapter.ensure_cellxgene_namespace()
+        with patch.object(fresh_adapter, "_get_k8s_core_client", return_value=mock_core_v1):
+            with patch.object(fresh_adapter, "_get_k8s_rbac_client", return_value=mock_rbac_v1):
+                await fresh_adapter.ensure_cellxgene_namespace()
 
         mock_core_v1.create_namespace.assert_called_once()
         mock_core_v1.create_namespaced_service_account.assert_called_once()
@@ -118,15 +156,15 @@ class TestCellxgeneNamespaceSetup:
         assert sa_call[1]["body"].metadata.name == "bioaf-cellxgene-runner"
 
     @pytest.mark.asyncio
-    async def test_skips_creation_if_namespace_exists(self, k8s_adapter):
+    async def test_skips_creation_if_namespace_exists(self, fresh_adapter):
         mock_core_v1 = MagicMock()
         mock_rbac_v1 = MagicMock()
 
         mock_core_v1.read_namespace.return_value = MagicMock()
 
-        with patch.object(k8s_adapter, "_get_k8s_core_client", return_value=mock_core_v1):
-            with patch.object(k8s_adapter, "_get_k8s_rbac_client", return_value=mock_rbac_v1):
-                await k8s_adapter.ensure_cellxgene_namespace()
+        with patch.object(fresh_adapter, "_get_k8s_core_client", return_value=mock_core_v1):
+            with patch.object(fresh_adapter, "_get_k8s_rbac_client", return_value=mock_rbac_v1):
+                await fresh_adapter.ensure_cellxgene_namespace()
 
         mock_core_v1.create_namespace.assert_not_called()
         mock_core_v1.create_namespaced_service_account.assert_not_called()

--- a/backend/tests/test_k8s_cellxgene_adapter.py
+++ b/backend/tests/test_k8s_cellxgene_adapter.py
@@ -69,6 +69,12 @@ class TestCellxgeneDeploy:
         call_kwargs = mock_k8s["apps"].create_namespaced_deployment.call_args[1]
         assert call_kwargs["namespace"] == "bioaf-cellxgene"
 
+    @pytest.mark.asyncio
+    async def test_deploy_creates_loadbalancer_service(self, adapter, mock_k8s):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        svc_body = mock_k8s["core"].create_namespaced_service.call_args[1]["body"]
+        assert svc_body.spec.type == "LoadBalancer"
+
 
 class TestCellxgeneTeardown:
     @pytest.mark.asyncio

--- a/backend/tests/test_k8s_cellxgene_adapter.py
+++ b/backend/tests/test_k8s_cellxgene_adapter.py
@@ -31,6 +31,12 @@ def mock_k8s(adapter):
 
     with (
         patch.object(adapter, "_get_api_client_async", new_callable=AsyncMock),
+        patch.object(
+            adapter,
+            "_resolve_image",
+            new_callable=AsyncMock,
+            return_value="us-central1-docker.pkg.dev/p/r/bioaf-cellxgene:latest",
+        ),
         patch.object(adapter, "_get_k8s_apps_client", return_value=mock_apps),
         patch.object(adapter, "_get_k8s_core_client", return_value=mock_core),
         patch.object(adapter, "_get_k8s_rbac_client", return_value=mock_rbac),

--- a/backend/tests/test_k8s_cellxgene_adapter.py
+++ b/backend/tests/test_k8s_cellxgene_adapter.py
@@ -1,0 +1,133 @@
+"""Tests for the Kubernetes cellxgene adapter.
+
+Covers local mode (deploy/teardown/status) and K8s namespace setup.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.adapters.cellxgene.kubernetes import (
+    KubernetesCellxgeneProvider,
+    _local_instances,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_local_mode(monkeypatch):
+    monkeypatch.setenv("BIOAF_COMPUTE_MODE", "local")
+
+
+@pytest.fixture(autouse=True)
+def clear_instances():
+    _local_instances.clear()
+    yield
+    _local_instances.clear()
+
+
+@pytest.fixture
+def adapter():
+    return KubernetesCellxgeneProvider()
+
+
+class TestCellxgeneDeploy:
+    @pytest.mark.asyncio
+    async def test_deploy_returns_publication_id(self, adapter):
+        result = await adapter.deploy(42, "gs://bucket/data.h5ad", "My Dataset")
+        assert result["publication_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_deploy_returns_running_status(self, adapter):
+        result = await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        assert result["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_deploy_stores_in_local_instances(self, adapter):
+        await adapter.deploy(7, "gs://bucket/data.h5ad", "Dataset")
+        assert 7 in _local_instances
+
+    @pytest.mark.asyncio
+    async def test_deploy_sets_pod_name(self, adapter):
+        result = await adapter.deploy(5, "gs://bucket/data.h5ad", "Dataset")
+        assert result["pod_name"] == "cellxgene-5"
+
+
+class TestCellxgeneTeardown:
+    @pytest.mark.asyncio
+    async def test_teardown_returns_stopped(self, adapter):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        result = await adapter.teardown(1)
+        assert result["status"] == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_teardown_updates_local_store(self, adapter):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        await adapter.teardown(1)
+        assert _local_instances[1]["status"] == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_teardown_nonexistent_returns_stopped(self, adapter):
+        result = await adapter.teardown(999)
+        assert result["status"] == "stopped"
+
+
+class TestCellxgeneGetStatus:
+    @pytest.mark.asyncio
+    async def test_status_of_running_instance(self, adapter):
+        await adapter.deploy(1, "gs://bucket/data.h5ad", "Dataset")
+        result = await adapter.get_status(1)
+        assert result["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_status_of_unknown_instance(self, adapter):
+        result = await adapter.get_status(999)
+        assert result["status"] == "unknown"
+
+
+class TestCellxgeneNamespaceSetup:
+    @pytest.fixture
+    def k8s_adapter(self, monkeypatch):
+        monkeypatch.setenv("BIOAF_COMPUTE_MODE", "k8s")
+        return KubernetesCellxgeneProvider()
+
+    @pytest.mark.asyncio
+    async def test_creates_namespace_sa_and_rolebinding(self, k8s_adapter):
+        mock_core_v1 = MagicMock()
+        mock_rbac_v1 = MagicMock()
+
+        from kubernetes.client.rest import ApiException
+
+        mock_core_v1.read_namespace.side_effect = ApiException(status=404)
+        mock_core_v1.create_namespace.return_value = MagicMock()
+        mock_core_v1.create_namespaced_service_account.return_value = MagicMock()
+        mock_rbac_v1.create_namespaced_role_binding.return_value = MagicMock()
+
+        with patch.object(k8s_adapter, "_get_k8s_core_client", return_value=mock_core_v1):
+            with patch.object(k8s_adapter, "_get_k8s_rbac_client", return_value=mock_rbac_v1):
+                await k8s_adapter.ensure_cellxgene_namespace()
+
+        mock_core_v1.create_namespace.assert_called_once()
+        mock_core_v1.create_namespaced_service_account.assert_called_once()
+        mock_rbac_v1.create_namespaced_role_binding.assert_called_once()
+
+        ns_body = mock_core_v1.create_namespace.call_args[1]["body"]
+        assert ns_body.metadata.name == "bioaf-cellxgene"
+
+        sa_call = mock_core_v1.create_namespaced_service_account.call_args
+        assert sa_call[1]["namespace"] == "bioaf-cellxgene"
+        assert sa_call[1]["body"].metadata.name == "bioaf-cellxgene-runner"
+
+    @pytest.mark.asyncio
+    async def test_skips_creation_if_namespace_exists(self, k8s_adapter):
+        mock_core_v1 = MagicMock()
+        mock_rbac_v1 = MagicMock()
+
+        mock_core_v1.read_namespace.return_value = MagicMock()
+
+        with patch.object(k8s_adapter, "_get_k8s_core_client", return_value=mock_core_v1):
+            with patch.object(k8s_adapter, "_get_k8s_rbac_client", return_value=mock_rbac_v1):
+                await k8s_adapter.ensure_cellxgene_namespace()
+
+        mock_core_v1.create_namespace.assert_not_called()
+        mock_core_v1.create_namespaced_service_account.assert_not_called()
+        mock_rbac_v1.create_namespaced_role_binding.assert_not_called()

--- a/docker/Dockerfile.cellxgene
+++ b/docker/Dockerfile.cellxgene
@@ -1,0 +1,16 @@
+# bioAF cellxgene explorer
+#
+# Lightweight image for serving h5ad datasets via cellxgene's interactive
+# single-cell data explorer. Includes google-cloud-storage for reading
+# files directly from GCS.
+#
+# Build:
+#   docker build -f docker/Dockerfile.cellxgene -t bioaf-cellxgene:latest .
+
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir cellxgene google-cloud-storage
+
+EXPOSE 5005
+
+ENTRYPOINT ["cellxgene"]

--- a/docker/Dockerfile.cellxgene
+++ b/docker/Dockerfile.cellxgene
@@ -9,7 +9,7 @@
 
 FROM python:3.11-slim
 
-RUN pip install --no-cache-dir cellxgene google-cloud-storage
+RUN pip install --no-cache-dir cellxgene gcsfs
 
 EXPOSE 5005
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -14,6 +14,7 @@ import { DeployRecoveryModal } from "@/components/infrastructure/DeployRecoveryM
 import { useDeploymentProgress } from "@/hooks/useDeploymentProgress";
 import { isAuthenticated } from "@/lib/auth";
 import { api } from "@/lib/api";
+import { invalidateComponentCache } from "@/hooks/useComponents";
 
 interface TerraformStatus {
   terraform_initialized: boolean;
@@ -364,6 +365,7 @@ export default function InfraComponentsPage() {
     setTogglingComponent(componentKey);
     try {
       await api.post(`/api/v1/infrastructure/stack/components/${componentKey}/toggle`);
+      invalidateComponentCache();
       setRefreshKey((k) => k + 1);
     } catch (e) {
       const message = e instanceof Error ? e.message : "Toggle failed";
@@ -394,6 +396,7 @@ export default function InfraComponentsPage() {
       // Disable then re-enable to trigger a fresh build
       await api.post(`/api/v1/infrastructure/stack/components/${componentKey}/toggle`);
       await api.post(`/api/v1/infrastructure/stack/components/${componentKey}/toggle`);
+      invalidateComponentCache();
       setRefreshKey((k) => k + 1);
     } catch (e) {
       const message = e instanceof Error ? e.message : "Retry failed";

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -146,11 +146,9 @@ export default function InfraComponentsPage() {
   const [configError, setConfigError] = useState("");
   const [componentErrors, setComponentErrors] = useState<Record<string, string>>({});
   const [togglingComponent, setTogglingComponent] = useState<string | null>(null);
-  const [buildStatus, setBuildStatus] = useState<{
-    build_id: string | null;
-    build_status: string | null;
-    image_uri: string | null;
-  } | null>(null);
+  const [buildStatusMap, setBuildStatusMap] = useState<
+    Record<string, { build_id: string | null; build_status: string | null; image_uri: string | null }>
+  >({});
   const [showAbandonModal, setShowAbandonModal] = useState(false);
   const [abandonLoading, setAbandonLoading] = useState(false);
   const [showRecoveryModal, setShowRecoveryModal] = useState(false);
@@ -216,35 +214,57 @@ export default function InfraComponentsPage() {
   }, [stackStatus, deployProgress.active, recoveryCheckedOnLoad]);
 
   // Fetch build status when any component is provisioning or build_failed
-  const hasBuildRelated = componentsData?.components.some(
+  const buildRelatedComponents = componentsData?.components.filter(
     (c) => c.status === "provisioning" || c.status === "build_failed",
-  );
+  ) ?? [];
+  const hasBuildRelated = buildRelatedComponents.length > 0;
+
+  // Map component keys to their build status endpoints
+  const notebookKeys = new Set(["rstudio", "jupyterhub"]);
+  const cellxgeneKeys = new Set(["cellxgene"]);
+
   useEffect(() => {
     if (!hasBuildRelated) {
-      setBuildStatus(null);
+      setBuildStatusMap({});
       return;
     }
     let cancelled = false;
+
     async function pollBuild() {
-      try {
-        const status = await api.get<{
-          build_id: string | null;
-          build_status: string | null;
-          image_uri: string | null;
-        }>("/api/v1/infrastructure/notebook-image/build-status");
-        if (!cancelled) {
-          setBuildStatus(status);
-          // Build finished -- refresh component list
+      const endpoints: { type: string; url: string }[] = [];
+      if (buildRelatedComponents.some((c) => notebookKeys.has(c.key))) {
+        endpoints.push({ type: "notebook", url: "/api/v1/infrastructure/notebook-image/build-status" });
+      }
+      if (buildRelatedComponents.some((c) => cellxgeneKeys.has(c.key))) {
+        endpoints.push({ type: "cellxgene", url: "/api/v1/infrastructure/cellxgene-image/build-status" });
+      }
+
+      const results: Record<string, { build_id: string | null; build_status: string | null; image_uri: string | null }> = {};
+      let anyFinished = false;
+      for (const ep of endpoints) {
+        try {
+          const status = await api.get<{
+            build_id: string | null;
+            build_status: string | null;
+            image_uri: string | null;
+          }>(ep.url);
+          results[ep.type] = status;
           if (status.build_status && !["WORKING", "QUEUED"].includes(status.build_status)) {
-            setRefreshKey((k) => k + 1);
+            anyFinished = true;
           }
+        } catch {
+          // ignore
         }
-      } catch {
-        // ignore
+      }
+      if (!cancelled) {
+        setBuildStatusMap(results);
+        if (anyFinished) {
+          setRefreshKey((k) => k + 1);
+        }
       }
     }
+
     pollBuild();
-    // Only poll repeatedly if actively building
     const isActive = componentsData?.components.some((c) => c.status === "provisioning");
     if (isActive) {
       const interval = setInterval(pollBuild, 15000);
@@ -790,6 +810,11 @@ export default function InfraComponentsPage() {
                               key={comp.key}
                               className="bg-white rounded-lg shadow p-5 border border-gray-200"
                             >
+                              {(() => {
+                                // Resolve the right build status for this component
+                                const buildType = cellxgeneKeys.has(comp.key) ? "cellxgene" : "notebook";
+                                const buildStatus = buildStatusMap[buildType] ?? null;
+                                return (<>
                               <div className="flex items-start justify-between mb-2">
                                 <h3 className="font-semibold text-sm">{comp.name}</h3>
                                 {(() => {
@@ -828,7 +853,7 @@ export default function InfraComponentsPage() {
                               {comp.status === "provisioning" && buildStatus && !["FAILURE", "CANCELLED", "TIMEOUT"].includes(buildStatus.build_status ?? "") && (
                                 <div className="bg-amber-50 border border-amber-200 rounded p-2 mb-2">
                                   <p className="text-xs font-medium text-amber-800">
-                                    Building notebook image...
+                                    Building image...
                                   </p>
                                   <p className="text-xs text-amber-600 mt-0.5">
                                     Status: {buildStatus.build_status ?? "Starting"}
@@ -854,7 +879,7 @@ export default function InfraComponentsPage() {
                               {(comp.status === "build_failed" || (comp.status === "provisioning" && buildStatus && ["FAILURE", "CANCELLED", "TIMEOUT"].includes(buildStatus.build_status ?? ""))) && (
                                 <div className="bg-red-50 border border-red-200 rounded p-2 mb-2">
                                   <p className="text-xs font-medium text-red-800">
-                                    Notebook image build failed
+                                    Image build failed
                                   </p>
                                   {buildStatus?.build_id && (
                                     <p className="text-xs text-red-600 mt-0.5">
@@ -902,6 +927,8 @@ export default function InfraComponentsPage() {
                                   {componentErrors[comp.key]}
                                 </p>
                               )}
+                              </>);
+                              })()}
                             </div>
                           ))}
                       </div>

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -380,11 +380,47 @@ export default function InfraComponentsPage() {
     }
   }
 
+  // Components that have a built image
+  const imageComponents = new Set(["rstudio", "jupyterhub", "cellxgene"]);
+
   async function handleComponentToggle(componentKey: string) {
     setComponentErrors((prev) => ({ ...prev, [componentKey]: "" }));
+
+    // When re-enabling an image component, check if it already has a
+    // successful build and ask the user whether to rebuild.
+    const comp = componentsData?.components.find((c) => c.key === componentKey);
+    const isEnabling = comp && comp.status === "disabled";
+    let forceRebuild = false;
+
+    if (isEnabling && imageComponents.has(componentKey)) {
+      // Check if there's already a successful image for this component
+      const buildType = cellxgeneKeys.has(componentKey) ? "cellxgene" : "notebook";
+      const statusUrl = buildType === "cellxgene"
+        ? "/api/v1/infrastructure/cellxgene-image/build-status"
+        : "/api/v1/infrastructure/notebook-image/build-status";
+      try {
+        const status = await api.get<{
+          build_id: string | null;
+          build_status: string | null;
+          image_uri: string | null;
+        }>(statusUrl);
+        if (status.image_uri) {
+          forceRebuild = confirm(
+            "An existing image is available. Rebuild with the latest definition?\n\n"
+            + "Choose OK to rebuild, or Cancel to use the existing image."
+          );
+        }
+      } catch {
+        // No existing build -- proceed normally
+      }
+    }
+
     setTogglingComponent(componentKey);
     try {
-      await api.post(`/api/v1/infrastructure/stack/components/${componentKey}/toggle`);
+      const url = forceRebuild
+        ? `/api/v1/infrastructure/stack/components/${componentKey}/toggle?force_rebuild=true`
+        : `/api/v1/infrastructure/stack/components/${componentKey}/toggle`;
+      await api.post(url);
       invalidateComponentCache();
       setRefreshKey((k) => k + 1);
     } catch (e) {

--- a/frontend/src/app/results/cellxgene/page.tsx
+++ b/frontend/src/app/results/cellxgene/page.tsx
@@ -7,9 +7,9 @@ import { ContentLoading } from "@/components/shared/ContentLoading";
 import { api } from "@/lib/api";
 import type {
   CellxgenePublicationResponse,
-  FileResponse,
+  CellxgenePublishableFile,
+  CellxgeneFileInspection,
   ExperimentListResponse,
-  Experiment,
 } from "@/lib/types";
 
 function formatBytes(bytes: number | null): string {
@@ -53,16 +53,17 @@ function PublishForm({
   onPublish: (fileId: number, datasetName: string, experimentId: number | null) => void;
   onCancel: () => void;
 }) {
-  const [files, setFiles] = useState<FileResponse[]>([]);
+  const [files, setFiles] = useState<CellxgenePublishableFile[]>([]);
   const [loadingFiles, setLoadingFiles] = useState(true);
   const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
   const [datasetName, setDatasetName] = useState("");
-  const [experimentId, setExperimentId] = useState<number | null>(null);
+  const [inspection, setInspection] = useState<CellxgeneFileInspection | null>(null);
+  const [inspecting, setInspecting] = useState(false);
 
   useEffect(() => {
     (async () => {
       try {
-        const data = await api.get<FileResponse[]>("/api/cellxgene/publishable-files");
+        const data = await api.get<CellxgenePublishableFile[]>("/api/cellxgene/publishable-files");
         setFiles(data);
       } catch {
         // ignore
@@ -72,77 +73,122 @@ function PublishForm({
     })();
   }, []);
 
-  const handleFileSelect = (fileId: number) => {
+  const handleFileSelect = async (fileId: number) => {
     setSelectedFileId(fileId);
+    setInspection(null);
     const file = files.find((f) => f.id === fileId);
     if (file) {
-      // Auto-populate dataset name from filename (strip .h5ad extension)
       const suggestedName = file.filename.replace(/\.h5ad$/i, "");
       setDatasetName(suggestedName);
-      setExperimentId(file.experiment_id);
+    }
+
+    // Inspect the file for cellxgene compatibility
+    setInspecting(true);
+    try {
+      const info = await api.get<CellxgeneFileInspection>(`/api/cellxgene/inspect/${fileId}`);
+      setInspection(info);
+    } catch {
+      setInspection({ embeddings: [], cell_count: 0, gene_count: 0, cellxgene_ready: false, missing: "unable to inspect file" });
+    } finally {
+      setInspecting(false);
     }
   };
 
   const selectedFile = files.find((f) => f.id === selectedFileId);
-  const canPublish = selectedFileId != null && datasetName.trim().length > 0;
+  const canPublish = selectedFileId != null && datasetName.trim().length > 0 && inspection?.cellxgene_ready === true;
 
   return (
     <div className="bg-white rounded-lg shadow p-5 space-y-4 mb-6">
       <h3 className="font-semibold text-sm">Publish Dataset to cellxgene</h3>
 
-      {/* File picker */}
+      {/* File list */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Select h5ad file</label>
+        <label className="block text-sm font-medium text-gray-700 mb-2">Select h5ad file</label>
         {loadingFiles ? (
           <p className="text-sm text-gray-400">Loading available files...</p>
         ) : files.length === 0 ? (
           <p className="text-sm text-gray-400">No publishable h5ad files available.</p>
         ) : (
-          <select
-            value={selectedFileId ?? ""}
-            onChange={(e) => handleFileSelect(parseInt(e.target.value))}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
-          >
-            <option value="" disabled>Choose a file...</option>
+          <div className="border border-gray-200 rounded-md max-h-64 overflow-y-auto divide-y divide-gray-100">
             {files.map((f) => (
-              <option key={f.id} value={f.id}>
-                {f.filename} ({formatBytes(f.size_bytes)})
-              </option>
+              <button
+                key={f.id}
+                onClick={() => handleFileSelect(f.id)}
+                className={`w-full text-left px-3 py-2.5 flex items-start gap-2.5 hover:bg-gray-50 transition-colors ${
+                  selectedFileId === f.id ? "bg-blue-50 border-l-2 border-blue-500" : ""
+                }`}
+              >
+                <span className={`mt-1.5 w-2 h-2 rounded-full shrink-0 ${
+                  selectedFileId === f.id && inspection
+                    ? inspection.cellxgene_ready ? "bg-green-500" : "bg-yellow-500"
+                    : "bg-gray-300"
+                }`} />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900 truncate">{f.filename}</p>
+                  <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-gray-400 mt-0.5">
+                    {f.experiment_name && <span>Experiment: {f.experiment_name}</span>}
+                    {f.project_name && <span>Project: {f.project_name}</span>}
+                    {f.sample_names.length > 0 && <span>Samples: {f.sample_names.join(", ")}</span>}
+                    <span>{formatBytes(f.size_bytes)}</span>
+                    <span>{f.source_type === "pipeline_output" ? "Pipeline output" : f.source_type === "notebook_output" ? "Notebook output" : "Upload"}</span>
+                  </div>
+                </div>
+              </button>
             ))}
-          </select>
+          </div>
         )}
       </div>
 
-      {/* Selected file details */}
-      {selectedFile && (
-        <div className="bg-gray-50 rounded p-3 text-sm text-gray-600 space-y-1">
-          <p><span className="font-medium">File:</span> {selectedFile.filename}</p>
-          <p><span className="font-medium">Size:</span> {formatBytes(selectedFile.size_bytes)}</p>
-          {selectedFile.experiment_id && (
-            <p><span className="font-medium">Experiment ID:</span> {selectedFile.experiment_id}</p>
+      {/* Inspection result */}
+      {selectedFile && inspecting && (
+        <div className="bg-gray-50 rounded p-3 text-sm text-gray-500">
+          Inspecting file for cellxgene compatibility...
+        </div>
+      )}
+      {selectedFile && inspection && !inspecting && (
+        <div className={`rounded p-3 text-sm space-y-1 ${
+          inspection.cellxgene_ready ? "bg-green-50 text-green-800" : "bg-yellow-50 text-yellow-800"
+        }`}>
+          {inspection.cellxgene_ready ? (
+            <>
+              <p className="font-medium">Ready for cellxgene</p>
+              <p className="text-xs opacity-75">
+                {inspection.cell_count.toLocaleString()} cells, {inspection.gene_count.toLocaleString()} genes.
+                Embeddings: {inspection.embeddings.join(", ")}
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="font-medium">Not ready for cellxgene</p>
+              <p className="text-xs opacity-75">
+                Missing: {inspection.missing}.
+                This file needs secondary analysis (normalization, PCA, UMAP) before it can be viewed in cellxgene.
+              </p>
+            </>
           )}
-          <p><span className="font-medium">Uploaded:</span> {new Date(selectedFile.upload_timestamp).toLocaleDateString()}</p>
         </div>
       )}
 
       {/* Dataset name */}
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Dataset name</label>
-        <input
-          type="text"
-          value={datasetName}
-          onChange={(e) => setDatasetName(e.target.value)}
-          placeholder="Name for this cellxgene dataset"
-          className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
-        />
-      </div>
+      {selectedFile && inspection?.cellxgene_ready && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Dataset name</label>
+          <input
+            type="text"
+            value={datasetName}
+            onChange={(e) => setDatasetName(e.target.value)}
+            placeholder="Name for this cellxgene dataset"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+          />
+        </div>
+      )}
 
       {/* Actions */}
       <div className="flex gap-3">
         <button
           onClick={() => {
             if (selectedFileId && canPublish) {
-              onPublish(selectedFileId, datasetName.trim(), experimentId);
+              onPublish(selectedFileId, datasetName.trim(), null);
             }
           }}
           disabled={!canPublish}

--- a/frontend/src/app/results/cellxgene/page.tsx
+++ b/frontend/src/app/results/cellxgene/page.tsx
@@ -190,15 +190,20 @@ function PublicationCard({
         </div>
       </div>
       <div className="flex gap-3 items-center ml-4 shrink-0">
-        {isActive && pub.stable_url && (
+        {isActive && pub.access_url && (
           <a
-            href={pub.stable_url}
+            href={pub.access_url}
             target="_blank"
             rel="noopener noreferrer"
             className="px-3 py-1 text-sm font-medium text-blue-600 bg-blue-50 rounded hover:bg-blue-100"
           >
             Open
           </a>
+        )}
+        {isActive && !pub.access_url && (
+          <span className="px-3 py-1 text-sm text-gray-400">
+            Starting...
+          </span>
         )}
         {isActive && (
           <button

--- a/frontend/src/app/results/cellxgene/page.tsx
+++ b/frontend/src/app/results/cellxgene/page.tsx
@@ -27,7 +27,7 @@ function StatusBadge({ status }: { status: string }) {
       case "running":
         return "bg-green-100 text-green-700";
       case "publishing":
-        return "bg-blue-100 text-blue-700";
+        return "bg-yellow-100 text-yellow-700";
       case "unpublished":
         return "bg-gray-100 text-gray-500";
       case "failed":
@@ -37,9 +37,11 @@ function StatusBadge({ status }: { status: string }) {
     }
   })();
 
+  const label = status === "publishing" ? "publishing..." : status;
+
   return (
     <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${colorClass}`}>
-      {status}
+      {label}
     </span>
   );
 }
@@ -243,6 +245,14 @@ export default function CellxgenePage() {
   useEffect(() => {
     fetchPublications();
   }, [fetchPublications]);
+
+  // Auto-refresh while any publication is still publishing
+  const hasPublishing = publications.some((p) => p.status === "publishing");
+  useEffect(() => {
+    if (!hasPublishing) return;
+    const interval = setInterval(fetchPublications, 5000);
+    return () => clearInterval(interval);
+  }, [hasPublishing, fetchPublications]);
 
   // Load experiment names for display
   useEffect(() => {

--- a/frontend/src/hooks/useComponents.ts
+++ b/frontend/src/hooks/useComponents.ts
@@ -41,6 +41,12 @@ function mapComponents(
   }));
 }
 
+/** Invalidate the module-level cache so the next render re-fetches. */
+export function invalidateComponentCache() {
+  cachedComponents = null;
+  fetchPromise = null;
+}
+
 export function useComponents() {
   const [components, setComponents] = useState<ComponentState[]>(
     cachedComponents ?? [],

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -814,6 +814,29 @@ export interface StorageDashboard {
   last_updated: string;
 }
 
+export interface CellxgenePublishableFile {
+  id: number;
+  filename: string;
+  gcs_uri: string;
+  size_bytes: number | null;
+  file_type: string;
+  project_name: string | null;
+  experiment_name: string | null;
+  sample_names: string[];
+  source_type: string;
+  cellxgene_ready: boolean;
+  cellxgene_status: string;
+  created_at: string;
+}
+
+export interface CellxgeneFileInspection {
+  embeddings: string[];
+  cell_count: number;
+  gene_count: number;
+  cellxgene_ready: boolean;
+  missing: string | null;
+}
+
 export interface CellxgenePublicationResponse {
   id: number;
   dataset_name: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -818,6 +818,7 @@ export interface CellxgenePublicationResponse {
   id: number;
   dataset_name: string;
   stable_url: string | null;
+  access_url: string | null;
   status: string;
   file: FileResponse | null;
   experiment_id: number | null;


### PR DESCRIPTION
## Summary

- **Cellxgene adapter**: replaced inline K8s client initialization (which failed with "Invalid kube-config file") with a proper adapter in the BioAF Adapter Layer, using platform_config credentials for out-of-cluster auth, namespace/RBAC setup, and LoadBalancer services with external IP polling
- **Image build pipeline**: cellxgene now builds its own container image via Cloud Build when the component is enabled, matching the notebook image pattern. Includes per-component build status tracking in the UI and a rebuild prompt when re-enabling components
- **GCS access**: init container with injected SA key secret downloads h5ad files from GCS before cellxgene serves them locally, bypassing Workload Identity issues on the interactive node pool
- **Publish UX**: enriched file selector shows project, experiment, sample, size, and source type for each h5ad file. On-select h5ad inspection checks for embeddings and shows green/yellow readiness status with clear messaging when secondary analysis is needed
- **Sidebar refresh**: fixed component toggle not updating the navigation menu (stale module-level cache in useComponents hook)
- **Architecture diagram**: replaced ASCII diagram with SVG in README
- **Version bump**: 0.4.0 -> 0.4.1

## Test plan

- [x] Backend: 1604 tests pass (pytest)
- [x] Frontend: 392 tests pass (jest), 0 type errors (tsc)
- [x] Linting: ruff format, ruff check, mypy all clean
- [x] Markdown lint clean
- [x] Verified cellxgene deployment on live GKE cluster: namespace creation, SA/RBAC setup, Cloud Build image, GCS download via init container, LoadBalancer IP assignment
- [ ] End-to-end: publish an analyzed h5ad (with UMAP embeddings) and verify cellxgene serves it