### PR TITLE
Notebook file lifecycle, GCS mounts, and environment versioning

### DIFF
--- a/backend/alembic/versions/057_notebook_file_lifecycle.py
+++ b/backend/alembic/versions/057_notebook_file_lifecycle.py
@@ -1,0 +1,34 @@
+"""Notebook file lifecycle (ADR-040, ADR-041).
+
+Adds build_number to environment_versions for rebuild versioning (v1 -> v1.1).
+Adds gcs_output_prefix to compute_sessions for output persistence tracking.
+Adds unique constraint on (environment_id, version_number, build_number).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    # ADR-041: build_number for environment rebuild versioning
+    op.add_column(
+        "environment_versions",
+        sa.Column("build_number", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.create_unique_constraint(
+        "uq_env_version_build",
+        "environment_versions",
+        ["environment_id", "version_number", "build_number"],
+    )
+
+    # ADR-040: track where session outputs were persisted
+    op.add_column(
+        "compute_sessions",
+        sa.Column("gcs_output_prefix", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("compute_sessions", "gcs_output_prefix")
+    op.drop_constraint("uq_env_version_build", "environment_versions", type_="unique")
+    op.drop_column("environment_versions", "build_number")

--- a/backend/alembic/versions/057_notebook_file_lifecycle.py
+++ b/backend/alembic/versions/057_notebook_file_lifecycle.py
@@ -1,5 +1,8 @@
 """Notebook file lifecycle (ADR-040, ADR-041).
 
+Revision ID: 057
+Revises: 056
+
 Adds build_number to environment_versions for rebuild versioning (v1 -> v1.1).
 Adds gcs_output_prefix to compute_sessions for output persistence tracking.
 Adds unique constraint on (environment_id, version_number, build_number).
@@ -7,6 +10,11 @@ Adds unique constraint on (environment_id, version_number, build_number).
 
 from alembic import op
 import sqlalchemy as sa
+
+revision = "057"
+down_revision = "056"
+branch_labels = None
+depends_on = None
 
 
 def upgrade() -> None:

--- a/backend/app/adapters/notebooks/kubernetes.py
+++ b/backend/app/adapters/notebooks/kubernetes.py
@@ -326,6 +326,44 @@ class KubernetesNotebookProvider(NotebookProvider):
         logger.info("Created role binding in %s", namespace)
         self._namespace_ready = True
 
+    def _ensure_gcs_secret(self, namespace: str) -> bool:
+        """Create a K8s Secret with the GCP SA key for GCS access.
+
+        Returns True if the secret exists (created or already present).
+        """
+        import base64 as _b64
+
+        from kubernetes.client.rest import ApiException
+
+        cfg = self._cluster_config or {}
+        sa_key = cfg.get("gcp_service_account_key", "")
+        if not sa_key:
+            return False
+
+        core_client = self._get_k8s_core_client()
+        secret_name = "bioaf-gcs-sa-key"
+
+        try:
+            core_client.read_namespaced_secret(name=secret_name, namespace=namespace)
+            return True
+        except ApiException as e:
+            if e.status != 404:
+                logger.warning("Error checking GCS secret: %s", e)
+                return False
+
+        core_client.create_namespaced_secret(
+            namespace=namespace,
+            body={
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {"name": secret_name, "labels": {"bioaf.io/managed": "true"}},
+                "type": "Opaque",
+                "data": {"key.json": _b64.b64encode(sa_key.encode()).decode()},
+            },
+        )
+        logger.info("Created GCS SA key secret in %s", namespace)
+        return True
+
     @staticmethod
     def _patch_sa_annotation(core_v1, namespace: str, gcp_sa_email: str) -> None:
         """Ensure the notebook-runner SA has the Workload Identity annotation."""
@@ -344,7 +382,7 @@ class KubernetesNotebookProvider(NotebookProvider):
 
     # -- K8s API implementations (production) --
 
-    def _build_pod_manifest(self, session_spec: dict) -> dict:
+    def _build_pod_manifest(self, session_spec: dict, has_gcs_secret: bool = False) -> dict:
         """Build a Kubernetes Pod manifest from a session spec.
 
         Extracted from _k8s_launch_session so it can be unit-tested without
@@ -610,6 +648,18 @@ class KubernetesNotebookProvider(NotebookProvider):
                 }
             )
 
+        # Mount GCS SA key secret into all init containers and the main container
+        # so gsutil / GCP client libraries can authenticate.
+        if has_gcs_secret:
+            gcs_vol_mount = {"name": "gcp-sa-key", "mountPath": "/secrets/gcp", "readOnly": True}
+            gcs_env = {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": "/secrets/gcp/key.json"}
+            for ic in init_containers:
+                ic.setdefault("volumeMounts", []).append(gcs_vol_mount)
+                ic.setdefault("env", []).append(gcs_env)
+            notebook_container.setdefault("env", []).append(gcs_env)
+            notebook_container["volumeMounts"].append(gcs_vol_mount)
+            volumes.append({"name": "gcp-sa-key", "secret": {"secretName": "bioaf-gcs-sa-key"}})
+
         # Pod annotations -- GCS FUSE CSI driver requires this for sidecar injection
         annotations: dict[str, str] = {}
         if has_fuse_volumes:
@@ -664,7 +714,10 @@ class KubernetesNotebookProvider(NotebookProvider):
 
         await self.ensure_notebook_namespace(namespace, gcp_sa_email=session_spec.get("notebook_runner_sa_email", ""))
 
-        pod_manifest = self._build_pod_manifest(session_spec)
+        # Ensure GCS credentials secret exists for bucket access
+        has_gcs_secret = self._ensure_gcs_secret(namespace)
+
+        pod_manifest = self._build_pod_manifest(session_spec, has_gcs_secret=has_gcs_secret)
         gcs_home_prefix = pod_manifest.pop("_gcs_home_prefix")
 
         pod_name = pod_manifest["metadata"]["name"]

--- a/backend/app/adapters/notebooks/kubernetes.py
+++ b/backend/app/adapters/notebooks/kubernetes.py
@@ -250,7 +250,14 @@ class KubernetesNotebookProvider(NotebookProvider):
         """Ensure the notebook namespace and service account exist."""
         from kubernetes.client.rest import ApiException
 
+        # Always patch the SA annotation when a SA email is provided, even if
+        # the namespace was already set up on a previous call.  The annotation
+        # may be missing if the namespace was created before Workload Identity
+        # was configured.
         if self._namespace_ready:
+            if gcp_sa_email:
+                core_v1 = self._get_k8s_core_client()
+                self._patch_sa_annotation(core_v1, namespace, gcp_sa_email)
             return
 
         core_v1 = self._get_k8s_core_client()
@@ -333,7 +340,7 @@ class KubernetesNotebookProvider(NotebookProvider):
                 )
                 logger.info("Patched Workload Identity annotation on bioaf-notebook-runner")
         except Exception:
-            logger.warning("Could not patch SA annotation for Workload Identity")
+            logger.exception("Failed to patch Workload Identity annotation on bioaf-notebook-runner")
 
     # -- K8s API implementations (production) --
 

--- a/backend/app/adapters/notebooks/kubernetes.py
+++ b/backend/app/adapters/notebooks/kubernetes.py
@@ -24,6 +24,9 @@ from app.adapters.base import NotebookProvider
 from app.services.session_persistence import (
     generate_sync_in_command,
     generate_sync_out_command,
+    generate_outputs_sync_command,
+    generate_script_capture_command,
+    generate_list_outputs_command,
 )
 
 logger = logging.getLogger("bioaf.adapters.notebooks.k8s")
@@ -911,8 +914,10 @@ class KubernetesNotebookProvider(NotebookProvider):
         pod_name: str = "",
         namespace: str = DEFAULT_NOTEBOOK_NAMESPACE,
         gcs_home_prefix: str = "",
+        working_bucket: str = "",
+        session_type: str = "jupyter",
     ) -> dict:
-        """Final git commit, sync to GCS, then delete pod and service."""
+        """Final git commit, sync outputs to GCS, then delete pod and service."""
         from kubernetes.stream import stream
 
         core_client = self._get_k8s_core_client()
@@ -991,6 +996,79 @@ class KubernetesNotebookProvider(NotebookProvider):
             except Exception as e:
                 logger.warning("GCS sync-out failed for pod %s: %s", pod_name, e)
 
+        # Sync /outputs/ and capture scripts to GCS (ADR-040)
+        output_files: list[dict] = []
+        gcs_output_prefix = ""
+        if working_bucket and pod_name:
+            gcs_output_prefix = f"gs://{working_bucket}/sessions/{session_id}/outputs/"
+            gcs_scripts_prefix = f"gs://{working_bucket}/sessions/{session_id}/scripts/"
+
+            # Determine home directory based on session type
+            if session_type == "ssh":
+                # SSH sessions create a user-specific home; fall back to generic
+                exec_home = "/home"
+            else:
+                exec_home = HOME_DIR
+
+            # 1. Sync /outputs/ to working bucket
+            try:
+                outputs_cmd = generate_outputs_sync_command("/outputs", gcs_output_prefix)
+                stream(
+                    core_client.connect_get_namespaced_pod_exec,
+                    name=pod_name,
+                    namespace=namespace,
+                    command=outputs_cmd,
+                    stderr=True,
+                    stdin=False,
+                    stdout=True,
+                    tty=False,
+                    _request_timeout=1800,
+                )
+                logger.info("Outputs sync complete for pod %s", pod_name)
+            except Exception as e:
+                logger.warning("Outputs sync failed for pod %s: %s", pod_name, e)
+
+            # 2. Capture notebook/script files
+            try:
+                scripts_cmd = generate_script_capture_command(exec_home, gcs_scripts_prefix)
+                stream(
+                    core_client.connect_get_namespaced_pod_exec,
+                    name=pod_name,
+                    namespace=namespace,
+                    command=scripts_cmd,
+                    stderr=True,
+                    stdin=False,
+                    stdout=True,
+                    tty=False,
+                    _request_timeout=300,
+                )
+                logger.info("Script capture complete for pod %s", pod_name)
+            except Exception as e:
+                logger.warning("Script capture failed for pod %s: %s", pod_name, e)
+
+            # 3. List all output files for registration
+            try:
+                list_prefix = f"gs://{working_bucket}/sessions/{session_id}/"
+                list_cmd = generate_list_outputs_command(list_prefix)
+                raw_output = stream(
+                    core_client.connect_get_namespaced_pod_exec,
+                    name=pod_name,
+                    namespace=namespace,
+                    command=list_cmd,
+                    stderr=True,
+                    stdin=False,
+                    stdout=True,
+                    tty=False,
+                    _request_timeout=60,
+                )
+                if raw_output:
+                    from app.services.session_output_service import parse_gsutil_ls_output
+
+                    output_files = parse_gsutil_ls_output(str(raw_output))
+                    logger.info("Found %d output files for session %s", len(output_files), session_id)
+            except Exception as e:
+                logger.warning("Output file listing failed for pod %s: %s", pod_name, e)
+
         # Delete pod
         try:
             core_client.delete_namespaced_pod(name=pod_name, namespace=namespace)
@@ -1010,6 +1088,8 @@ class KubernetesNotebookProvider(NotebookProvider):
             "session_id": session_id,
             "status": "stopped",
             "stopped_at": datetime.now(timezone.utc).isoformat(),
+            "output_files": output_files,
+            "gcs_output_prefix": gcs_output_prefix,
         }
 
     async def _k8s_get_session_status(
@@ -1122,6 +1202,8 @@ class KubernetesNotebookProvider(NotebookProvider):
             "session_id": session_id,
             "status": "stopped",
             "stopped_at": datetime.now(timezone.utc).isoformat(),
+            "output_files": [],
+            "gcs_output_prefix": "",
         }
 
     def _local_get_session_status(self, session_id: str) -> dict:

--- a/backend/app/adapters/notebooks/kubernetes.py
+++ b/backend/app/adapters/notebooks/kubernetes.py
@@ -650,12 +650,21 @@ class KubernetesNotebookProvider(NotebookProvider):
 
         # Mount GCS SA key secret into all init containers and the main container
         # so gsutil / GCP client libraries can authenticate.
+        # On GKE with Workload Identity enabled, gsutil prefers the metadata
+        # server over GOOGLE_APPLICATION_CREDENTIALS, so we explicitly activate
+        # the service account in each init container command.
+        _GCS_KEY_PATH = "/secrets/gcp/key.json"
+        _GCS_AUTH_PREFIX = f"gcloud auth activate-service-account --key-file={_GCS_KEY_PATH} && "
         if has_gcs_secret:
             gcs_vol_mount = {"name": "gcp-sa-key", "mountPath": "/secrets/gcp", "readOnly": True}
-            gcs_env = {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": "/secrets/gcp/key.json"}
+            gcs_env = {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": _GCS_KEY_PATH}
             for ic in init_containers:
                 ic.setdefault("volumeMounts", []).append(gcs_vol_mount)
                 ic.setdefault("env", []).append(gcs_env)
+                # Prepend gcloud auth activation to the shell command
+                cmd: list[str] = ic.get("command", [])
+                if len(cmd) >= 3 and cmd[0] == "/bin/sh" and cmd[1] == "-c":
+                    cmd[2] = _GCS_AUTH_PREFIX + str(cmd[2])
             notebook_container.setdefault("env", []).append(gcs_env)
             notebook_container["volumeMounts"].append(gcs_vol_mount)
             volumes.append({"name": "gcp-sa-key", "secret": {"secretName": "bioaf-gcs-sa-key"}})

--- a/backend/app/adapters/notebooks/kubernetes.py
+++ b/backend/app/adapters/notebooks/kubernetes.py
@@ -531,13 +531,21 @@ class KubernetesNotebookProvider(NotebookProvider):
         # Input file data sync init container
         input_files = session_spec.get("input_files", [])
         if input_files:
-            copy_cmds = [f"gsutil cp {f['gcs_uri']} /data/{f['relative_path']}" for f in input_files]
-            # Generate FILE_INVENTORY.md
+            # Create subdirectories and copy files preserving hierarchy
+            copy_cmds: list[str] = []
+            for f in input_files:
+                dest_path = f"/data/{f['relative_path']}"
+                dest_dir = "/".join(dest_path.split("/")[:-1])
+                copy_cmds.append(f"mkdir -p {dest_dir} && gsutil cp {f['gcs_uri']} {dest_path}")
+            # Generate FILE_INVENTORY.md using a heredoc to avoid backtick
+            # interpretation by the shell (backticks in markdown trigger
+            # command substitution inside double-quoted printf)
             inventory_lines = ["# File Inventory", "", "Files mounted at session start:", ""]
             for f in input_files:
-                inventory_lines.append(f"- `/data/{f['relative_path']}` (source: `{f['gcs_uri']}`)")
-            inventory_content = "\\n".join(inventory_lines)
-            copy_cmds.append(f'printf "{inventory_content}" > /data/FILE_INVENTORY.md')
+                inventory_lines.append(f"- /data/{f['relative_path']} (source: {f['gcs_uri']})")
+            inventory_content = "\n".join(inventory_lines)
+            # Use heredoc with single-quoted delimiter to prevent all expansion
+            copy_cmds.append(f"cat > /data/FILE_INVENTORY.md << 'INVENTORY_EOF'\n{inventory_content}\nINVENTORY_EOF")
             data_sync_cmd = " && ".join(copy_cmds)
             init_containers.append(
                 {
@@ -549,6 +557,10 @@ class KubernetesNotebookProvider(NotebookProvider):
             )
             volumes.append({"name": "data", "emptyDir": {"sizeLimit": "50Gi"}})
             volume_mounts.append({"name": "data", "mountPath": "/data", "readOnly": True})
+
+        # Writable /outputs/ directory for all session types (ADR-040)
+        volume_mounts.append({"name": "outputs", "mountPath": "/outputs"})
+        volumes.append({"name": "outputs", "emptyDir": {"sizeLimit": "50Gi"}})
 
         # Track whether any GCS FUSE CSI volumes are used
         has_fuse_volumes = False

--- a/backend/app/adapters/notebooks/kubernetes.py
+++ b/backend/app/adapters/notebooks/kubernetes.py
@@ -337,20 +337,18 @@ class KubernetesNotebookProvider(NotebookProvider):
 
     # -- K8s API implementations (production) --
 
-    async def _k8s_launch_session(self, session_spec: dict) -> dict:
-        """Launch a notebook pod on the GKE interactive node pool."""
-        # Ensure API client is initialized (handles incluster vs out-of-cluster)
-        await self._get_api_client_async()
+    def _build_pod_manifest(self, session_spec: dict) -> dict:
+        """Build a Kubernetes Pod manifest from a session spec.
 
+        Extracted from _k8s_launch_session so it can be unit-tested without
+        requiring a live K8s API client.
+        """
         session_id = session_spec.get("session_id", 0)
         session_type = session_spec.get("session_type", "jupyter")
         user_id = session_spec.get("user_id", 0)
         namespace = DEFAULT_NOTEBOOK_NAMESPACE
 
-        await self.ensure_notebook_namespace(namespace, gcp_sa_email=session_spec.get("notebook_runner_sa_email", ""))
-
         pod_name = f"bioaf-notebook-{session_id}"
-        service_name = f"bioaf-notebook-svc-{session_id}"
         working_bucket = session_spec.get("working_bucket", "bioaf-working")
         gcs_home_prefix = f"gs://{working_bucket}/notebooks/{user_id}/"
 
@@ -507,6 +505,9 @@ class KubernetesNotebookProvider(NotebookProvider):
             volumes.append({"name": "data", "emptyDir": {"sizeLimit": "50Gi"}})
             volume_mounts.append({"name": "data", "mountPath": "/data", "readOnly": True})
 
+        # Track whether any GCS FUSE CSI volumes are used
+        has_fuse_volumes = False
+
         # SSH work nodes get additional volumes: scratch and data mounts
         if session_type == "ssh":
             volume_mounts.append({"name": "scratch", "mountPath": "/scratch"})
@@ -514,6 +515,8 @@ class KubernetesNotebookProvider(NotebookProvider):
 
             # GCS FUSE data mounts (read-only)
             data_mount_paths = session_spec.get("data_mount_paths", [])
+            if data_mount_paths:
+                has_fuse_volumes = True
             for i, mount_path in enumerate(data_mount_paths):
                 vol_name = f"data-{i}"
                 volume_mounts.append(
@@ -530,7 +533,7 @@ class KubernetesNotebookProvider(NotebookProvider):
                             "driver": "gcsfuse.csi.storage.gke.io",
                             "readOnly": True,
                             "volumeAttributes": {
-                                "bucketName": "bioaf-data",
+                                "bucketName": working_bucket,
                                 "mountOptions": "implicit-dirs,file-cache:max-size-mb:-1",
                                 "gcsfuseLoggingSeverity": "warning",
                             },
@@ -600,20 +603,29 @@ class KubernetesNotebookProvider(NotebookProvider):
                 }
             )
 
+        # Pod annotations -- GCS FUSE CSI driver requires this for sidecar injection
+        annotations: dict[str, str] = {}
+        if has_fuse_volumes:
+            annotations["gke-gcsfuse/volumes"] = "true"
+
         # Pod manifest
+        metadata: dict = {
+            "name": pod_name,
+            "namespace": namespace,
+            "labels": {
+                "bioaf.io/session": str(session_id),
+                "bioaf.io/user": str(user_id),
+                "bioaf.io/type": session_type,
+                "bioaf.io/pool": node_pool,
+            },
+        }
+        if annotations:
+            metadata["annotations"] = annotations
+
         pod_manifest = {
             "apiVersion": "v1",
             "kind": "Pod",
-            "metadata": {
-                "name": pod_name,
-                "namespace": namespace,
-                "labels": {
-                    "bioaf.io/session": str(session_id),
-                    "bioaf.io/user": str(user_id),
-                    "bioaf.io/type": session_type,
-                    "bioaf.io/pool": node_pool,
-                },
-            },
+            "metadata": metadata,
             "spec": {
                 "nodeSelector": {"bioaf.io/pool": node_pool},
                 "tolerations": [
@@ -630,6 +642,34 @@ class KubernetesNotebookProvider(NotebookProvider):
                 "restartPolicy": "Never",
             },
         }
+
+        # Stash gcs_home_prefix on the manifest for the caller to use
+        pod_manifest["_gcs_home_prefix"] = gcs_home_prefix
+
+        return pod_manifest
+
+    async def _k8s_launch_session(self, session_spec: dict) -> dict:
+        """Launch a notebook pod on the GKE interactive node pool."""
+        await self._get_api_client_async()
+
+        session_id = session_spec.get("session_id", 0)
+        namespace = DEFAULT_NOTEBOOK_NAMESPACE
+
+        await self.ensure_notebook_namespace(namespace, gcp_sa_email=session_spec.get("notebook_runner_sa_email", ""))
+
+        pod_manifest = self._build_pod_manifest(session_spec)
+        gcs_home_prefix = pod_manifest.pop("_gcs_home_prefix")
+
+        pod_name = pod_manifest["metadata"]["name"]
+        service_name = f"bioaf-notebook-svc-{session_id}"
+
+        session_type = session_spec.get("session_type", "jupyter")
+        if session_type == "jupyter":
+            container_port = 8888
+        elif session_type == "ssh":
+            container_port = 22
+        else:
+            container_port = 8787
 
         core_client = self._get_k8s_core_client()
         core_client.create_namespaced_pod(namespace=namespace, body=pod_manifest)

--- a/backend/app/adapters/notebooks/kubernetes.py
+++ b/backend/app/adapters/notebooks/kubernetes.py
@@ -24,9 +24,6 @@ from app.adapters.base import NotebookProvider
 from app.services.session_persistence import (
     generate_sync_in_command,
     generate_sync_out_command,
-    generate_outputs_sync_command,
-    generate_script_capture_command,
-    generate_list_outputs_command,
 )
 
 logger = logging.getLogger("bioaf.adapters.notebooks.k8s")
@@ -684,6 +681,27 @@ class KubernetesNotebookProvider(NotebookProvider):
             notebook_container["volumeMounts"].append(gcs_vol_mount)
             volumes.append({"name": "gcp-sa-key", "secret": {"secretName": "bioaf-gcs-sa-key"}})
 
+        # GCS sync sidecar: sleeps until exec'd at shutdown to sync /outputs/
+        # and capture scripts. Uses google/cloud-sdk:slim which has gsutil.
+        gcs_sync_mounts = [
+            {"name": "outputs", "mountPath": "/outputs"},
+            {"name": "home", "mountPath": home_dir},
+        ]
+        gcs_sync_env: list[dict] = []
+        if has_gcs_secret:
+            gcs_sync_mounts.append({"name": "gcp-sa-key", "mountPath": "/secrets/gcp", "readOnly": True})
+            gcs_sync_env.append({"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": _GCS_KEY_PATH})
+        containers.append(
+            {
+                "name": "gcs-sync",
+                "image": "google/cloud-sdk:slim",
+                "command": ["/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 3600; done"],
+                "volumeMounts": gcs_sync_mounts,
+                "env": gcs_sync_env,
+                "resources": {"requests": {"cpu": "50m", "memory": "128Mi"}},
+            }
+        )
+
         # Pod annotations -- GCS FUSE CSI driver requires this for sidecar injection
         annotations: dict[str, str] = {}
         if has_fuse_volumes:
@@ -996,7 +1014,12 @@ class KubernetesNotebookProvider(NotebookProvider):
             except Exception as e:
                 logger.warning("GCS sync-out failed for pod %s: %s", pod_name, e)
 
-        # Sync /outputs/ and capture scripts to GCS (ADR-040)
+        # Sync /outputs/ and capture scripts to GCS via the gcs-sync sidecar (ADR-040).
+        # The sidecar has google/cloud-sdk:slim with gsutil; the main container may not.
+        _SYNC_CONTAINER = "gcs-sync"
+        _GCS_KEY = "/secrets/gcp/key.json"
+        _AUTH_CMD = f"gcloud auth activate-service-account --key-file={_GCS_KEY} 2>/dev/null; "
+
         output_files: list[dict] = []
         gcs_output_prefix = ""
         if working_bucket and pod_name:
@@ -1005,19 +1028,23 @@ class KubernetesNotebookProvider(NotebookProvider):
 
             # Determine home directory based on session type
             if session_type == "ssh":
-                # SSH sessions create a user-specific home; fall back to generic
                 exec_home = "/home"
             else:
                 exec_home = HOME_DIR
 
             # 1. Sync /outputs/ to working bucket
             try:
-                outputs_cmd = generate_outputs_sync_command("/outputs", gcs_output_prefix)
+                outputs_shell = (
+                    f"{_AUTH_CMD}"
+                    f'if [ -d /outputs ] && [ "$(ls -A /outputs)" ]; then '
+                    f"gsutil -m rsync -r /outputs {gcs_output_prefix}; fi"
+                )
                 stream(
                     core_client.connect_get_namespaced_pod_exec,
                     name=pod_name,
                     namespace=namespace,
-                    command=outputs_cmd,
+                    container=_SYNC_CONTAINER,
+                    command=["/bin/sh", "-c", outputs_shell],
                     stderr=True,
                     stdin=False,
                     stdout=True,
@@ -1030,12 +1057,19 @@ class KubernetesNotebookProvider(NotebookProvider):
 
             # 2. Capture notebook/script files
             try:
-                scripts_cmd = generate_script_capture_command(exec_home, gcs_scripts_prefix)
+                scripts_shell = (
+                    f"{_AUTH_CMD}"
+                    f"find {exec_home} -maxdepth 3 "
+                    r"\( -name '*.ipynb' -o -name '*.Rmd' -o -name '*.R' -o -name '*.py' \) "
+                    "-type f "
+                    f'| while read f; do gsutil cp "$f" {gcs_scripts_prefix}"$(basename "$f")"; done'
+                )
                 stream(
                     core_client.connect_get_namespaced_pod_exec,
                     name=pod_name,
                     namespace=namespace,
-                    command=scripts_cmd,
+                    container=_SYNC_CONTAINER,
+                    command=["/bin/sh", "-c", scripts_shell],
                     stderr=True,
                     stdin=False,
                     stdout=True,
@@ -1049,12 +1083,13 @@ class KubernetesNotebookProvider(NotebookProvider):
             # 3. List all output files for registration
             try:
                 list_prefix = f"gs://{working_bucket}/sessions/{session_id}/"
-                list_cmd = generate_list_outputs_command(list_prefix)
+                list_shell = f"{_AUTH_CMD}gsutil ls -l -r {list_prefix}** 2>/dev/null || true"
                 raw_output = stream(
                     core_client.connect_get_namespaced_pod_exec,
                     name=pod_name,
                     namespace=namespace,
-                    command=list_cmd,
+                    container=_SYNC_CONTAINER,
+                    command=["/bin/sh", "-c", list_shell],
                     stderr=True,
                     stdin=False,
                     stdout=True,

--- a/backend/app/api/environments.py
+++ b/backend/app/api/environments.py
@@ -25,6 +25,7 @@ def _version_response(version) -> VersionResponse:
         id=version.id,
         environment_id=version.environment_id,
         version_number=version.version_number,
+        build_number=version.build_number,
         status=version.status,
         definition_format=version.definition_format,
         definition_content=version.definition_content,
@@ -50,6 +51,7 @@ def _env_response(env) -> EnvironmentResponse:
         latest = EnvironmentVersionSummary(
             id=v.id,
             version_number=v.version_number,
+            build_number=v.build_number,
             status=v.status,
             definition_format=v.definition_format,
             image_uri=v.image_uri,
@@ -137,6 +139,7 @@ async def get_environment(
             EnvironmentVersionSummary(
                 id=v.id,
                 version_number=v.version_number,
+                build_number=v.build_number,
                 status=v.status,
                 definition_format=v.definition_format,
                 image_uri=v.image_uri,
@@ -292,6 +295,27 @@ async def get_build_logs(
         status=version.status,
         logs_url=logs_url,
     )
+
+
+@router.post("/{environment_id}/versions/{version_id}/rebuild", response_model=VersionResponse)
+async def rebuild_version(
+    environment_id: int,
+    version_id: int,
+    current_user: dict = require_permission("environments", "build"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Create a rebuild of an existing version (v1 -> v1.2, v1.3, etc.)."""
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+
+    try:
+        rebuild = await EnvironmentService.rebuild_version(session, org_id, user_id, environment_id, version_id)
+        await session.commit()
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+    rebuild = await EnvironmentService.get_version(session, org_id, environment_id, rebuild.id)
+    return _version_response(rebuild)
 
 
 @router.delete("/{environment_id}/versions/{version_id}", status_code=204)

--- a/backend/app/api/notebook_sessions.py
+++ b/backend/app/api/notebook_sessions.py
@@ -32,6 +32,7 @@ class NotebookLaunchRequest(BaseModel):
     resource_profile: str = "small"
     experiment_id: int | None = None
     input_file_ids: list[int] = []
+    environment_version_id: int | None = None
 
 
 class NotebookSettings(BaseModel):
@@ -73,6 +74,7 @@ def _session_response(ns) -> SessionResponse:
         created_at=ns.created_at,
         git_branch_name=ns.git_branch_name,
         git_commit_hash=ns.git_commit_hash,
+        environment_version_id=ns.environment_version_id,
     )
 
 
@@ -237,20 +239,43 @@ async def launch_session(
             "Compute infrastructure is not deployed. Deploy it from Infrastructure > Components first.",
         )
 
-    scrna_image = await _get_config_value(session, "bioaf_scrna_image")
-    if not scrna_image or scrna_image == "null":
-        build_status = await _get_config_value(session, "notebook_image_build_status")
-        if build_status in ("QUEUED", "WORKING"):
+    # Resolve image: prefer environment_version_id, fall back to global scrna_image
+    image: str | None = None
+    environment_version_id = body.environment_version_id
+
+    if environment_version_id:
+        from app.models.environment_version import EnvironmentVersion
+        from sqlalchemy import select as sa_select
+
+        ev_result = await session.execute(
+            sa_select(EnvironmentVersion).where(EnvironmentVersion.id == environment_version_id)
+        )
+        env_version = ev_result.scalar_one_or_none()
+        if not env_version:
+            raise HTTPException(400, "Environment version not found")
+        if env_version.status != "ready":
             raise HTTPException(
                 400,
-                "The notebook image is currently building. "
-                "This one-time setup can take up to an hour. Check progress in Infrastructure > Components.",
+                f"Environment version must be in ready status (current: {env_version.status}). "
+                "Build the environment first.",
             )
-        raise HTTPException(
-            400,
-            "The notebook image has not been built yet. "
-            "Enable RStudio or JupyterHub in Infrastructure > Components to start the build.",
-        )
+        image = env_version.image_uri
+    else:
+        scrna_image = await _get_config_value(session, "bioaf_scrna_image")
+        if not scrna_image or scrna_image == "null":
+            build_status = await _get_config_value(session, "notebook_image_build_status")
+            if build_status in ("QUEUED", "WORKING"):
+                raise HTTPException(
+                    400,
+                    "The notebook image is currently building. "
+                    "This one-time setup can take up to an hour. Check progress in Infrastructure > Components.",
+                )
+            raise HTTPException(
+                400,
+                "The notebook image has not been built yet. "
+                "Enable RStudio or JupyterHub in Infrastructure > Components to start the build.",
+            )
+        image = scrna_image
 
     try:
         notebook_session = await NotebookService.launch_session(
@@ -260,8 +285,9 @@ async def launch_session(
             session_type=body.session_type,
             resource_profile=body.resource_profile,
             experiment_id=body.experiment_id,
-            image=scrna_image,
+            image=image,
             input_file_ids=body.input_file_ids or None,
+            environment_version_id=environment_version_id,
         )
     except ValueError as e:
         logger.warning("Session launch failed: %s", e)
@@ -339,6 +365,88 @@ async def sync_session(
             pass  # Best effort in local/test mode
 
     return {"status": "ok", "message": "Sync triggered"}
+
+
+@router.get("/sessions/{session_id}/provenance")
+async def get_session_provenance(
+    session_id: int,
+    current_user: dict = require_permission("notebooks", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Return full provenance for a session: inputs, outputs, environment, user."""
+    notebook_session = await NotebookService.get_session(session, session_id)
+    if not notebook_session:
+        raise HTTPException(404, "Session not found")
+
+    from app.models.notebook_session_file import NotebookSessionFile
+    from app.models.file import File
+    from sqlalchemy import select as sa_select
+
+    # Gather input and output files
+    nsf_result = await session.execute(
+        sa_select(NotebookSessionFile, File)
+        .join(File, File.id == NotebookSessionFile.file_id)
+        .where(NotebookSessionFile.session_id == session_id)
+    )
+    input_files = []
+    output_files = []
+    for nsf, f in nsf_result.all():
+        file_info = {
+            "id": f.id,
+            "filename": f.filename,
+            "gcs_uri": f.gcs_uri,
+            "file_type": f.file_type,
+            "size_bytes": f.size_bytes,
+        }
+        if nsf.access_type == "input":
+            input_files.append(file_info)
+        else:
+            output_files.append(file_info)
+
+    # Gather environment version info
+    environment = None
+    if notebook_session.environment_version_id:
+        from app.models.environment_version import EnvironmentVersion
+        from app.models.environment import Environment
+
+        ev_result = await session.execute(
+            sa_select(EnvironmentVersion, Environment)
+            .join(Environment, Environment.id == EnvironmentVersion.environment_id)
+            .where(EnvironmentVersion.id == notebook_session.environment_version_id)
+        )
+        row = ev_result.first()
+        if row:
+            ev, env = row
+            environment = {
+                "environment_id": env.id,
+                "environment_name": env.name,
+                "version_id": ev.id,
+                "version_number": ev.version_number,
+                "build_number": ev.build_number,
+                "image_uri": ev.image_uri,
+                "definition_format": ev.definition_format,
+            }
+
+    return {
+        "session_id": notebook_session.id,
+        "session_type": notebook_session.session_type,
+        "status": notebook_session.status,
+        "user": {
+            "id": notebook_session.user.id,
+            "name": notebook_session.user.name,
+            "email": notebook_session.user.email,
+        }
+        if notebook_session.user
+        else None,
+        "project_id": notebook_session.project_id,
+        "experiment_id": notebook_session.experiment_id,
+        "environment": environment,
+        "input_files": input_files,
+        "output_files": output_files,
+        "gcs_output_prefix": notebook_session.gcs_output_prefix,
+        "started_at": notebook_session.started_at.isoformat() if notebook_session.started_at else None,
+        "stopped_at": notebook_session.stopped_at.isoformat() if notebook_session.stopped_at else None,
+    }
 
 
 # System files and directories to exclude from output registration

--- a/backend/app/models/environment_version.py
+++ b/backend/app/models/environment_version.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -8,10 +8,14 @@ from app.database import Base
 
 class EnvironmentVersion(Base):
     __tablename__ = "environment_versions"
+    __table_args__ = (
+        UniqueConstraint("environment_id", "version_number", "build_number", name="uq_env_version_build"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     environment_id: Mapped[int] = mapped_column(Integer, ForeignKey("environments.id"), nullable=False)
     version_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    build_number: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
     status: Mapped[str] = mapped_column(String(50), nullable=False, server_default="draft")
     definition_format: Mapped[str] = mapped_column(String(50), nullable=False)
     definition_content: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/models/notebook_session.py
+++ b/backend/app/models/notebook_session.py
@@ -41,6 +41,7 @@ class ComputeSession(Base):
     heartbeat_token: Mapped[str | None] = mapped_column(String(255), nullable=True)
     git_branch_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     git_commit_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    gcs_output_prefix: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     user = relationship("User")
     organization = relationship("Organization")

--- a/backend/app/schemas/environment.py
+++ b/backend/app/schemas/environment.py
@@ -27,6 +27,7 @@ class EnvironmentUpdateRequest(BaseModel):
 class EnvironmentVersionSummary(BaseModel):
     id: int
     version_number: int
+    build_number: int = 1
     status: str
     definition_format: str
     image_uri: str | None = None
@@ -79,6 +80,7 @@ class VersionResponse(BaseModel):
     id: int
     environment_id: int
     version_number: int
+    build_number: int = 1
     status: str
     definition_format: str
     definition_content: str

--- a/backend/app/schemas/notebook_session.py
+++ b/backend/app/schemas/notebook_session.py
@@ -42,6 +42,7 @@ class SessionResponse(BaseModel):
     created_at: datetime
     git_branch_name: str | None = None
     git_commit_hash: str | None = None
+    environment_version_id: int | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -44,11 +44,12 @@ WORKDIR /home
 """
 
 
-def _get_image_uri(project_id: str, region: str, env_name: str, version_number: int) -> str:
-    """Construct Artifact Registry image URI with version tag."""
+def _get_image_uri(project_id: str, region: str, env_name: str, version_number: int, build_number: int = 1) -> str:
+    """Construct Artifact Registry image URI with version.build tag."""
     # Sanitize env_name for use in image tag (lowercase, hyphens only)
     safe_name = env_name.lower().replace(" ", "-").replace("_", "-")
-    return f"{region}-docker.pkg.dev/{project_id}/{AR_REPO_ID}/{safe_name}:{version_number}"
+    tag = f"v{version_number}.{build_number}"
+    return f"{region}-docker.pkg.dev/{project_id}/{AR_REPO_ID}/{safe_name}:{tag}"
 
 
 def _build_conda_dockerfile(definition_content: str, env_name: str) -> tuple[str, str]:
@@ -166,7 +167,7 @@ class EnvironmentBuildService:
         object_path = await _upload_version_build_context(session, project_id, working_bucket, version, env.name)
 
         # Build image URI
-        image_uri = _get_image_uri(project_id, region, env.name, version.version_number)
+        image_uri = _get_image_uri(project_id, region, env.name, version.version_number, version.build_number)
 
         # Submit Cloud Build
         credentials = await _get_credentials(session)

--- a/backend/app/services/environment_service.py
+++ b/backend/app/services/environment_service.py
@@ -223,6 +223,60 @@ class EnvironmentService:
         await session.flush()
 
     @staticmethod
+    async def rebuild_version(
+        session: AsyncSession,
+        org_id: int,
+        user_id: int,
+        environment_id: int,
+        version_id: int,
+    ) -> EnvironmentVersion:
+        """Create a new build of an existing version (v1.1 -> v1.2)."""
+        env = await EnvironmentService.get_environment(session, org_id, environment_id)
+        if not env:
+            raise ValueError("Environment not found")
+
+        original = await EnvironmentService.get_version(session, org_id, environment_id, version_id)
+        if not original:
+            raise ValueError("Version not found")
+
+        # Find the max build_number for this version_number
+        result = await session.execute(
+            select(func.coalesce(func.max(EnvironmentVersion.build_number), 0)).where(
+                EnvironmentVersion.environment_id == environment_id,
+                EnvironmentVersion.version_number == original.version_number,
+            )
+        )
+        max_build = result.scalar() or 0
+        next_build = max_build + 1
+
+        rebuild = EnvironmentVersion(
+            environment_id=environment_id,
+            version_number=original.version_number,
+            build_number=next_build,
+            status="draft",
+            definition_format=original.definition_format,
+            definition_content=original.definition_content,
+            created_by_user_id=user_id,
+        )
+        session.add(rebuild)
+        await session.flush()
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="environment_version",
+            entity_id=rebuild.id,
+            action="rebuild",
+            details={
+                "environment_id": environment_id,
+                "version_number": original.version_number,
+                "build_number": next_build,
+                "original_version_id": version_id,
+            },
+        )
+        return rebuild
+
+    @staticmethod
     async def get_in_progress_builds(session: AsyncSession) -> list[EnvironmentVersion]:
         """Get all versions currently in 'building' status."""
         result = await session.execute(select(EnvironmentVersion).where(EnvironmentVersion.status == "building"))

--- a/backend/app/services/notebook_service.py
+++ b/backend/app/services/notebook_service.py
@@ -46,6 +46,7 @@ class NotebookService:
         project_id: int | None = None,
         image: str | None = None,
         input_file_ids: list[int] | None = None,
+        environment_version_id: int | None = None,
     ) -> NotebookSession:
         # Check quota
         allowed, message = await QuotaService.check_quota(session, user_id, estimated_hours=1.0)
@@ -60,6 +61,7 @@ class NotebookService:
             session_type=session_type,
             experiment_id=experiment_id,
             project_id=project_id,
+            environment_version_id=environment_version_id,
             resource_profile=resource_profile,
             cpu_cores=cpu_cores,
             memory_gb=memory_gb,

--- a/backend/app/services/notebook_service.py
+++ b/backend/app/services/notebook_service.py
@@ -213,18 +213,56 @@ class NotebookService:
 
         old_status = notebook_session.status
 
+        # Look up working bucket for output sync
+        from sqlalchemy import text as sa_text
+
+        bucket_row = await session.execute(
+            sa_text("SELECT value FROM platform_config WHERE key = 'working_bucket_name'")
+        )
+        working_bucket = ""
+        row = bucket_row.first()
+        if row:
+            val = (row[0] or "").strip()
+            if val and val != "null":
+                working_bucket = val
+
         # Terminate via the notebook adapter
+        terminate_result: dict = {}
         if notebook_session.slurm_job_id or notebook_session.k8s_pod_name:
             try:
                 notebook_adapter = get_notebook_adapter()
-                await notebook_adapter.terminate_session(
+                terminate_result = await notebook_adapter.terminate_session(
                     notebook_session.slurm_job_id or "",
                     pod_name=notebook_session.k8s_pod_name or "",
                     namespace=notebook_session.k8s_namespace or "bioaf-notebooks",
                     gcs_home_prefix=notebook_session.gcs_home_prefix or "",
+                    working_bucket=working_bucket,
+                    session_type=notebook_session.session_type,
                 )
             except Exception as e:
                 logger.warning("Failed to terminate session %s: %s", notebook_session.slurm_job_id, e)
+
+        # Register output files (ADR-040)
+        output_files = terminate_result.get("output_files", [])
+        if output_files:
+            try:
+                from app.services.session_output_service import SessionOutputService
+
+                await SessionOutputService.register_outputs(
+                    session,
+                    session_id=notebook_session.id,
+                    organization_id=notebook_session.organization_id,
+                    project_id=notebook_session.project_id,
+                    experiment_id=notebook_session.experiment_id,
+                    user_id=notebook_session.user_id,
+                    gcs_files=output_files,
+                )
+            except Exception as e:
+                logger.warning("Output registration failed for session %d: %s", session_id, e)
+
+        gcs_output_prefix = terminate_result.get("gcs_output_prefix", "")
+        if gcs_output_prefix:
+            notebook_session.gcs_output_prefix = gcs_output_prefix
 
         notebook_session.status = "stopped"
         notebook_session.stopped_at = datetime.now(timezone.utc)

--- a/backend/app/services/notebook_service.py
+++ b/backend/app/services/notebook_service.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
+
+if TYPE_CHECKING:
+    from app.models.file import File
 
 from app.models.notebook_session import NotebookSession
 from app.services.audit_service import log_action
@@ -117,7 +123,7 @@ class NotebookService:
                 if cred.ssh_private_key:
                     spec["ssh_private_key"] = cred.ssh_private_key
 
-            # Validate and build input file list
+            # Validate and build input file list with hierarchical paths
             input_files_spec: list[dict] = []
             if input_file_ids:
                 from app.models.file import File
@@ -125,15 +131,19 @@ class NotebookService:
                 file_results = await session.execute(select(File).where(File.id.in_(input_file_ids)))
                 found_files = {f.id: f for f in file_results.scalars().all()}
 
+                # Resolve names for hierarchy: project, experiment, sample, pipeline
+                name_cache = await _resolve_input_file_context(session, found_files)
+
                 for fid in input_file_ids:
                     f = found_files.get(fid)
                     if not f or f.organization_id != org_id:
                         raise ValueError(f"File {fid} not found or not accessible")
+                    rel_path = _build_relative_path(f, name_cache)
                     input_files_spec.append(
                         {
                             "file_id": f.id,
                             "gcs_uri": f.gcs_uri,
-                            "relative_path": f.filename,
+                            "relative_path": rel_path,
                         }
                     )
 
@@ -327,3 +337,93 @@ class NotebookService:
 
         except Exception as e:
             logger.error("Idle session check failed: %s", e)
+
+
+def _slugify(name: str) -> str:
+    """Convert a display name to a filesystem-safe slug."""
+    import re
+
+    slug = re.sub(r"[^\w\s-]", "", name.lower())
+    return re.sub(r"[\s_]+", "-", slug).strip("-") or "unknown"
+
+
+async def _resolve_input_file_context(
+    session: "AsyncSession",
+    files: dict[int, "File"],
+) -> dict:
+    """Resolve project, experiment, sample, and pipeline names for input files."""
+    from sqlalchemy import text as sa_text
+
+    project_ids = {f.project_id for f in files.values() if f.project_id}
+    experiment_ids = {f.experiment_id for f in files.values() if f.experiment_id}
+    pipeline_run_ids = {f.source_pipeline_run_id for f in files.values() if f.source_pipeline_run_id}
+    file_ids = list(files.keys())
+
+    cache: dict = {"projects": {}, "experiments": {}, "pipelines": {}, "file_samples": {}}
+
+    if project_ids:
+        rows = await session.execute(
+            sa_text("SELECT id, name FROM projects WHERE id = ANY(:ids)"),
+            {"ids": list(project_ids)},
+        )
+        cache["projects"] = {r[0]: r[1] for r in rows.fetchall()}
+
+    if experiment_ids:
+        rows = await session.execute(
+            sa_text("SELECT id, name FROM experiments WHERE id = ANY(:ids)"),
+            {"ids": list(experiment_ids)},
+        )
+        cache["experiments"] = {r[0]: r[1] for r in rows.fetchall()}
+
+    if pipeline_run_ids:
+        rows = await session.execute(
+            sa_text("SELECT id, pipeline_name FROM pipeline_runs WHERE id = ANY(:ids)"),
+            {"ids": list(pipeline_run_ids)},
+        )
+        cache["pipelines"] = {r[0]: r[1] for r in rows.fetchall()}
+
+    # Resolve sample identifiers for files via sample_files junction
+    if file_ids:
+        rows = await session.execute(
+            sa_text(
+                "SELECT sf.file_id, COALESCE(s.sample_id_external, CAST(s.id AS TEXT)) "
+                "FROM sample_files sf "
+                "JOIN samples s ON s.id = sf.sample_id "
+                "WHERE sf.file_id = ANY(:ids)"
+            ),
+            {"ids": file_ids},
+        )
+        for r in rows.fetchall():
+            cache["file_samples"][r[0]] = r[1]
+
+    return cache
+
+
+def _build_relative_path(f: "File", cache: dict) -> str:
+    """Build a hierarchical relative path for a file based on its associations.
+
+    Structure: {project}/{experiment}/{sample}/{tool}/filename
+    Falls back gracefully when associations are missing.
+    """
+    parts: list[str] = []
+
+    project_name = cache["projects"].get(f.project_id) if f.project_id else None
+    if project_name:
+        parts.append(_slugify(project_name))
+
+    experiment_name = cache["experiments"].get(f.experiment_id) if f.experiment_id else None
+    if experiment_name:
+        parts.append(_slugify(experiment_name))
+
+    sample_name = cache["file_samples"].get(f.id)
+    if sample_name:
+        parts.append(_slugify(sample_name))
+
+    pipeline_name = cache["pipelines"].get(f.source_pipeline_run_id) if f.source_pipeline_run_id else None
+    if pipeline_name:
+        parts.append(_slugify(pipeline_name))
+    elif f.source_type == "upload":
+        parts.append("uploads")
+
+    parts.append(f.filename)
+    return "/".join(parts)

--- a/backend/app/services/notebook_service.py
+++ b/backend/app/services/notebook_service.py
@@ -266,6 +266,27 @@ class NotebookService:
         if gcs_output_prefix:
             notebook_session.gcs_output_prefix = gcs_output_prefix
 
+        # Move outputs from working to results bucket (ADR-040: two-phase)
+        if working_bucket and output_files:
+            try:
+                results_row = await session.execute(
+                    sa_text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'")
+                )
+                r_row = results_row.first()
+                results_bucket = (r_row[0] or "").strip() if r_row else ""
+                if results_bucket and results_bucket != "null":
+                    from app.services.session_output_service import SessionOutputService
+
+                    final_prefix = await SessionOutputService.move_outputs_to_results_bucket(
+                        session,
+                        session_id=notebook_session.id,
+                        working_bucket=working_bucket,
+                        results_bucket=results_bucket,
+                    )
+                    notebook_session.gcs_output_prefix = final_prefix
+            except Exception as e:
+                logger.warning("Failed to move outputs to results bucket for session %d: %s", session_id, e)
+
         notebook_session.status = "stopped"
         notebook_session.stopped_at = datetime.now(timezone.utc)
         await session.flush()

--- a/backend/app/services/provenance/data_gatherer.py
+++ b/backend/app/services/provenance/data_gatherer.py
@@ -825,8 +825,57 @@ class ProvenanceDataGatherer:
                     "id": source_ns.id,
                     "session_type": source_ns.session_type,
                     "status": source_ns.status,
+                    "resource_profile": source_ns.resource_profile,
+                    "cpu_cores": source_ns.cpu_cores,
+                    "memory_gb": source_ns.memory_gb,
                     "started_at": _dt(source_ns.started_at),
+                    "stopped_at": _dt(source_ns.stopped_at),
+                    "git_branch_name": source_ns.git_branch_name,
+                    "git_commit_hash": source_ns.git_commit_hash,
                 }
+
+                # Resolve environment version
+                if source_ns.environment_version_id:
+                    from app.models.environment_version import EnvironmentVersion
+                    from app.models.environment import Environment
+
+                    ev_result = await session.execute(
+                        select(EnvironmentVersion, Environment)
+                        .join(Environment, Environment.id == EnvironmentVersion.environment_id)
+                        .where(EnvironmentVersion.id == source_ns.environment_version_id)
+                    )
+                    ev_row = ev_result.first()
+                    if ev_row:
+                        ev, env = ev_row
+                        source_notebook_session_data["environment"] = {
+                            "environment_name": env.name,
+                            "version_number": ev.version_number,
+                            "build_number": ev.build_number,
+                            "image_uri": ev.image_uri,
+                            "definition_format": ev.definition_format,
+                        }
+
+                # Resolve input files for this session
+                input_result = await session.execute(
+                    select(NotebookSessionFile, File)
+                    .join(File, File.id == NotebookSessionFile.file_id)
+                    .where(
+                        NotebookSessionFile.session_id == source_ns.id,
+                        NotebookSessionFile.access_type == "input",
+                    )
+                )
+                session_inputs = []
+                for nsf, inp_file in input_result.all():
+                    session_inputs.append(
+                        {
+                            "id": inp_file.id,
+                            "filename": inp_file.filename,
+                            "file_type": inp_file.file_type,
+                            "gcs_uri": inp_file.gcs_uri,
+                        }
+                    )
+                if session_inputs:
+                    source_notebook_session_data["input_files"] = session_inputs
 
         # Source pipeline run
         source_run_data = None

--- a/backend/app/services/provenance/markdown_renderer.py
+++ b/backend/app/services/provenance/markdown_renderer.py
@@ -416,6 +416,119 @@ def _render_artifact_md(report: dict[str, Any]) -> str:
     )
     parts.append("")
 
+    # Source information
+    source = entity.get("source", {})
+    source_type = source.get("type", "unknown")
+    parts.append("## Source")
+    parts.append("")
+
+    if source_type == "notebook_output" and source.get("notebook_session"):
+        ns = source["notebook_session"]
+        parts.append(
+            _table(
+                ["Field", "Value"],
+                [
+                    ["Source Type", "Notebook session output"],
+                    ["Session ID", ns.get("id")],
+                    ["Session Type", ns.get("session_type")],
+                    ["Status", ns.get("status")],
+                    ["Resources", f"{ns.get('cpu_cores')} CPU, {ns.get('memory_gb')} GB"],
+                    ["Started", ns.get("started_at")],
+                    ["Stopped", ns.get("stopped_at")],
+                    ["Git Branch", ns.get("git_branch_name")],
+                    ["Git Commit", ns.get("git_commit_hash")],
+                ],
+            )
+        )
+        parts.append("")
+
+        env = ns.get("environment")
+        if env:
+            parts.append("### Environment")
+            parts.append("")
+            parts.append(
+                _table(
+                    ["Field", "Value"],
+                    [
+                        ["Environment", env.get("environment_name")],
+                        ["Version", f"v{env.get('version_number')}.{env.get('build_number')}"],
+                        ["Format", env.get("definition_format")],
+                        ["Image URI", env.get("image_uri")],
+                    ],
+                )
+            )
+            parts.append("")
+
+        input_files = ns.get("input_files", [])
+        if input_files:
+            parts.append("### Input Files")
+            parts.append("")
+            parts.append(
+                _table(
+                    ["ID", "Filename", "Type"],
+                    [[f.get("id"), f.get("filename"), f.get("file_type")] for f in input_files],
+                )
+            )
+            parts.append("")
+
+    elif source_type == "pipeline_output" and source.get("pipeline_run"):
+        pr = source["pipeline_run"]
+        parts.append(
+            _table(
+                ["Field", "Value"],
+                [
+                    ["Source Type", "Pipeline output"],
+                    ["Pipeline", pr.get("pipeline_name")],
+                    ["Version", pr.get("pipeline_version")],
+                    ["Run ID", pr.get("id")],
+                    ["Status", pr.get("status")],
+                    [
+                        "Submitted By",
+                        pr.get("submitted_by", {}).get("name")
+                        if isinstance(pr.get("submitted_by"), dict)
+                        else pr.get("submitted_by"),
+                    ],
+                ],
+            )
+        )
+        parts.append("")
+    else:
+        parts.append(f"Source type: {source_type}")
+        parts.append("")
+        uploader = entity.get("uploader")
+        if uploader:
+            name = uploader.get("name") if isinstance(uploader, dict) else uploader
+            parts.append(f"Uploaded by: {name}")
+            parts.append("")
+
+    # Related data
+    related = report.get("related_data", {})
+    linked_samples = related.get("linked_samples", [])
+    if linked_samples:
+        parts.append("## Linked Samples")
+        parts.append("")
+        parts.append(
+            _table(
+                ["ID", "External ID", "Organism"],
+                [[s.get("id"), s.get("external_id"), s.get("organism")] for s in linked_samples],
+            )
+        )
+        parts.append("")
+
+    downstream = related.get("downstream_usage", [])
+    if downstream:
+        parts.append("## Downstream Usage")
+        parts.append("")
+        rows = []
+        for d in downstream:
+            if "pipeline_run_id" in d:
+                rows.append([f"Pipeline run {d['pipeline_run_id']}", d.get("pipeline_name")])
+            elif "notebook_session_id" in d:
+                rows.append([f"Notebook session {d['notebook_session_id']}", d.get("session_type")])
+        if rows:
+            parts.append(_table(["Consumer", "Name/Type"], rows))
+            parts.append("")
+
     _append_audit_trail(parts, report.get("audit_trail", []))
     return "\n".join(parts)
 

--- a/backend/app/services/session_output_service.py
+++ b/backend/app/services/session_output_service.py
@@ -1,0 +1,128 @@
+"""Session output registration service (ADR-040).
+
+Registers files discovered in GCS after a notebook/SSH session shuts down.
+Creates File records with source_type=notebook_output and links them to the
+session via NotebookSessionFile with access_type=output.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger("bioaf.session_outputs")
+
+# System/hidden files to skip during output registration
+_EXCLUDED_FILENAMES = {
+    ".bash_history",
+    ".Rhistory",
+    ".bash_logout",
+    ".bashrc",
+    ".profile",
+    ".gitconfig",
+    ".DS_Store",
+}
+_EXCLUDED_PREFIXES = (".git/", "__pycache__/", ".ipynb_checkpoints/", ".cache/", ".local/")
+
+
+def parse_gsutil_ls_output(raw_output: str) -> list[dict]:
+    """Parse gsutil ls -l -r output into a list of {gcs_uri, size_bytes}.
+
+    Each line looks like:
+       1234567  2026-04-04T12:00:00Z  gs://bucket/path/to/file.txt
+    The final summary line starts with TOTAL: and is skipped.
+    """
+    files: list[dict] = []
+    for line in raw_output.strip().splitlines():
+        line = line.strip()
+        if not line or line.startswith("TOTAL:"):
+            continue
+        match = re.match(r"^\s*(\d+)\s+\S+\s+(gs://.+)$", line)
+        if match:
+            size_bytes = int(match.group(1))
+            gcs_uri = match.group(2)
+            filename = gcs_uri.rsplit("/", 1)[-1] if "/" in gcs_uri else gcs_uri
+            if not filename or filename in _EXCLUDED_FILENAMES:
+                continue
+            if any(filename.startswith(p.rstrip("/")) for p in _EXCLUDED_PREFIXES):
+                continue
+            files.append({"gcs_uri": gcs_uri, "size_bytes": size_bytes, "filename": filename})
+    return files
+
+
+def _file_type_from_extension(filename: str) -> str:
+    """Derive file_type from filename extension."""
+    if filename.lower().endswith(".fastq.gz"):
+        return "fastq"
+    parts = filename.rsplit(".", 1)
+    if len(parts) < 2:
+        return "unknown"
+    return parts[1].lower()
+
+
+class SessionOutputService:
+    @staticmethod
+    async def register_outputs(
+        session: AsyncSession,
+        session_id: int,
+        organization_id: int,
+        project_id: int | None,
+        experiment_id: int | None,
+        user_id: int,
+        gcs_files: list[dict],
+    ) -> int:
+        """Register output files from a completed session.
+
+        Creates File records with source_type=notebook_output and
+        NotebookSessionFile records with access_type=output.
+
+        Returns the number of files registered.
+        """
+        from app.models.file import File
+        from app.models.notebook_session_file import NotebookSessionFile
+
+        registered = 0
+        for f in gcs_files:
+            filename = f["filename"]
+            # Skip excluded files
+            if filename in _EXCLUDED_FILENAMES or filename.startswith("."):
+                if filename in _EXCLUDED_FILENAMES:
+                    continue
+                base = filename.lstrip(".")
+                if not base or "." not in base:
+                    continue
+            if any(filename.startswith(p.rstrip("/")) for p in _EXCLUDED_PREFIXES):
+                continue
+
+            file_record = File(
+                organization_id=organization_id,
+                gcs_uri=f["gcs_uri"],
+                filename=filename,
+                size_bytes=f.get("size_bytes"),
+                file_type=_file_type_from_extension(filename),
+                experiment_id=experiment_id,
+                project_id=project_id,
+                source_type="notebook_output",
+                source_notebook_session_id=session_id,
+                uploader_user_id=user_id,
+            )
+            session.add(file_record)
+            await session.flush()
+
+            session.add(
+                NotebookSessionFile(
+                    session_id=session_id,
+                    file_id=file_record.id,
+                    access_type="output",
+                )
+            )
+            registered += 1
+
+        if registered:
+            logger.info("Registered %d output files for session %d", registered, session_id)
+
+        return registered

--- a/backend/app/services/session_output_service.py
+++ b/backend/app/services/session_output_service.py
@@ -126,3 +126,76 @@ class SessionOutputService:
             logger.info("Registered %d output files for session %d", registered, session_id)
 
         return registered
+
+    @staticmethod
+    async def move_outputs_to_results_bucket(
+        db: AsyncSession,
+        session_id: int,
+        working_bucket: str,
+        results_bucket: str,
+    ) -> str:
+        """Copy session outputs from working to results bucket, then delete from working.
+
+        Updates File.gcs_uri for all output files to point to the results bucket.
+        Returns the new GCS output prefix in the results bucket.
+        """
+        from google.cloud import storage
+        from sqlalchemy import text as sa_text
+
+        # Load GCS credentials
+        config_result = await db.execute(
+            sa_text(
+                "SELECT key, value FROM platform_config "
+                "WHERE key IN ('gcp_credential_source', 'gcp_service_account_key')"
+            )
+        )
+        config = {r[0]: r[1] for r in config_result.fetchall()}
+
+        from app.services.credential_injector import load_gcp_credentials
+
+        credentials = load_gcp_credentials(config)
+        client = storage.Client(credentials=credentials)
+
+        src_prefix = f"sessions/{session_id}/"
+        dst_prefix = f"sessions/{session_id}/"
+
+        src_bucket = client.bucket(working_bucket)
+        dst_bucket = client.bucket(results_bucket)
+
+        copied = 0
+        blobs = list(src_bucket.list_blobs(prefix=src_prefix))
+        for blob in blobs:
+            dst_name = dst_prefix + blob.name[len(src_prefix) :]
+            src_bucket.copy_blob(blob, dst_bucket, new_name=dst_name)
+            copied += 1
+
+        # Update File.gcs_uri to point to results bucket
+        if copied:
+            old_uri_prefix = f"gs://{working_bucket}/{src_prefix}"
+            new_uri_prefix = f"gs://{results_bucket}/{dst_prefix}"
+            await db.execute(
+                sa_text(
+                    "UPDATE files SET gcs_uri = REPLACE(gcs_uri, :old, :new) "
+                    "WHERE source_notebook_session_id = :sid AND gcs_uri LIKE :pattern"
+                ),
+                {
+                    "old": old_uri_prefix,
+                    "new": new_uri_prefix,
+                    "sid": session_id,
+                    "pattern": f"{old_uri_prefix}%",
+                },
+            )
+
+        # Delete from working bucket
+        for blob in blobs:
+            blob.delete()
+
+        logger.info(
+            "Moved %d output files for session %d from %s to %s",
+            copied,
+            session_id,
+            working_bucket,
+            results_bucket,
+        )
+
+        return f"gs://{results_bucket}/{dst_prefix}"

--- a/backend/app/services/session_persistence.py
+++ b/backend/app/services/session_persistence.py
@@ -28,6 +28,36 @@ def generate_sync_out_command(local_dir: str, gcs_prefix: str) -> list[str]:
     ]
 
 
+def generate_outputs_sync_command(local_dir: str, gcs_prefix: str) -> list[str]:
+    """Return shell command to sync /outputs/ to GCS (working bucket)."""
+    return [
+        "/bin/sh",
+        "-c",
+        f'if [ -d {local_dir} ] && [ "$(ls -A {local_dir})" ]; then gsutil -m rsync -r {local_dir} {gcs_prefix}; fi',
+    ]
+
+
+def generate_script_capture_command(home_dir: str, gcs_prefix: str) -> list[str]:
+    """Return shell command to find and copy notebook/script files to GCS."""
+    return [
+        "/bin/sh",
+        "-c",
+        f"find {home_dir} -maxdepth 3 "
+        r"\( -name '*.ipynb' -o -name '*.Rmd' -o -name '*.R' -o -name '*.py' \) "
+        "-type f "
+        f'| while read f; do gsutil cp "$f" {gcs_prefix}"$(basename "$f")"; done',
+    ]
+
+
+def generate_list_outputs_command(gcs_prefix: str) -> list[str]:
+    """Return shell command to list all files at a GCS prefix with sizes."""
+    return [
+        "/bin/sh",
+        "-c",
+        f"gsutil ls -l -r {gcs_prefix}** 2>/dev/null || true",
+    ]
+
+
 def _get_k8s_core_client():
     """Get a Kubernetes CoreV1Api client. Tests mock this function."""
     from kubernetes import client, config

--- a/backend/app/services/work_node_service.py
+++ b/backend/app/services/work_node_service.py
@@ -108,6 +108,15 @@ class WorkNodeService:
         session.add(compute_session)
         await session.flush()
 
+        # Look up working bucket and SA email for GCS mounts
+        config_rows = await session.execute(
+            text(
+                "SELECT key, value FROM platform_config "
+                "WHERE key IN ('working_bucket_name', 'notebook_runner_sa_email')"
+            )
+        )
+        config_map = {row[0]: row[1] for row in config_rows.all()}
+
         # Launch via adapter
         try:
             adapter = get_notebook_adapter()
@@ -129,6 +138,14 @@ class WorkNodeService:
                     "password_hash": cred.password_hash,
                 },
             }
+
+            bucket_name = (config_map.get("working_bucket_name") or "").strip()
+            if bucket_name and bucket_name != "null":
+                spec["working_bucket"] = bucket_name
+
+            sa_email = (config_map.get("notebook_runner_sa_email") or "").strip()
+            if sa_email and sa_email != "null":
+                spec["notebook_runner_sa_email"] = sa_email
 
             result = await adapter.launch_session(spec)
 

--- a/backend/app/services/work_node_service.py
+++ b/backend/app/services/work_node_service.py
@@ -212,17 +212,53 @@ class WorkNodeService:
 
         old_status = compute_session.status
 
+        # Look up working bucket for output sync
+        working_bucket_row = await session.execute(
+            text("SELECT value FROM platform_config WHERE key = 'working_bucket_name'")
+        )
+        working_bucket = ""
+        wb_row = working_bucket_row.first()
+        if wb_row:
+            val = (wb_row[0] or "").strip()
+            if val and val != "null":
+                working_bucket = val
+
+        terminate_result: dict = {}
         if compute_session.k8s_pod_name:
             try:
                 adapter = get_notebook_adapter()
-                await adapter.terminate_session(
+                terminate_result = await adapter.terminate_session(
                     compute_session.slurm_job_id or "",
                     pod_name=compute_session.k8s_pod_name or "",
                     namespace=compute_session.k8s_namespace or "bioaf-notebooks",
                     gcs_home_prefix=compute_session.gcs_home_prefix or "",
+                    working_bucket=working_bucket,
+                    session_type="ssh",
                 )
             except Exception as e:
                 logger.warning("Failed to terminate work node %d: %s", session_id, e)
+
+        # Register output files (ADR-040)
+        output_files = terminate_result.get("output_files", [])
+        if output_files:
+            try:
+                from app.services.session_output_service import SessionOutputService
+
+                await SessionOutputService.register_outputs(
+                    session,
+                    session_id=compute_session.id,
+                    organization_id=compute_session.organization_id,
+                    project_id=compute_session.project_id,
+                    experiment_id=compute_session.experiment_id,
+                    user_id=compute_session.user_id,
+                    gcs_files=output_files,
+                )
+            except Exception as e:
+                logger.warning("Output registration failed for work node %d: %s", session_id, e)
+
+        gcs_output_prefix = terminate_result.get("gcs_output_prefix", "")
+        if gcs_output_prefix:
+            compute_session.gcs_output_prefix = gcs_output_prefix
 
         compute_session.status = "stopped"
         compute_session.stopped_at = datetime.now(timezone.utc)

--- a/backend/app/services/work_node_service.py
+++ b/backend/app/services/work_node_service.py
@@ -260,6 +260,27 @@ class WorkNodeService:
         if gcs_output_prefix:
             compute_session.gcs_output_prefix = gcs_output_prefix
 
+        # Move outputs from working to results bucket (ADR-040: two-phase)
+        if working_bucket and output_files:
+            try:
+                results_row = await session.execute(
+                    text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'")
+                )
+                r_row = results_row.first()
+                results_bucket = (r_row[0] or "").strip() if r_row else ""
+                if results_bucket and results_bucket != "null":
+                    from app.services.session_output_service import SessionOutputService
+
+                    final_prefix = await SessionOutputService.move_outputs_to_results_bucket(
+                        session,
+                        session_id=compute_session.id,
+                        working_bucket=working_bucket,
+                        results_bucket=results_bucket,
+                    )
+                    compute_session.gcs_output_prefix = final_prefix
+            except Exception as e:
+                logger.warning("Failed to move outputs to results bucket for work node %d: %s", session_id, e)
+
         compute_session.status = "stopped"
         compute_session.stopped_at = datetime.now(timezone.utc)
         await session.flush()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.4.1"
+version = "0.5.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_notebook_gcs_bucket.py
+++ b/backend/tests/test_notebook_gcs_bucket.py
@@ -305,3 +305,66 @@ async def test_k8s_gcsfuse_volume_uses_configured_bucket():
     for vol in csi_volumes:
         bucket = vol["csi"]["volumeAttributes"]["bucketName"]
         assert bucket == "bioaf-working-custom-org", f"Expected configured bucket, got {bucket}"
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_manifest_mounts_gcs_secret():
+    """Pod manifest mounts GCS SA key secret when has_gcs_secret=True."""
+    from app.adapters.notebooks.kubernetes import KubernetesNotebookProvider
+
+    adapter = KubernetesNotebookProvider()
+    manifest = adapter._build_pod_manifest(
+        session_spec={
+            "session_type": "jupyter",
+            "session_id": 996,
+            "user_id": 1,
+            "image": "test-image:latest",
+            "cpu_cores": 2,
+            "memory_gb": 4,
+            "node_pool": "interactive",
+        },
+        has_gcs_secret=True,
+    )
+
+    # Secret volume should be present
+    volumes = manifest["spec"]["volumes"]
+    secret_vols = [v for v in volumes if v.get("secret", {}).get("secretName") == "bioaf-gcs-sa-key"]
+    assert len(secret_vols) == 1
+
+    # Init containers should have the mount and env var
+    for ic in manifest["spec"]["initContainers"]:
+        mount_names = [m["name"] for m in ic.get("volumeMounts", [])]
+        assert "gcp-sa-key" in mount_names, f"Init container {ic['name']} missing GCS secret mount"
+        env_names = [e["name"] for e in ic.get("env", [])]
+        assert "GOOGLE_APPLICATION_CREDENTIALS" in env_names
+
+    # Main container should also have the env var and mount
+    main = manifest["spec"]["containers"][0]
+    mount_names = [m["name"] for m in main.get("volumeMounts", [])]
+    assert "gcp-sa-key" in mount_names
+    env_names = [e["name"] for e in main.get("env", [])]
+    assert "GOOGLE_APPLICATION_CREDENTIALS" in env_names
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_manifest_no_gcs_secret_without_flag():
+    """Pod manifest does not mount GCS secret when has_gcs_secret=False."""
+    from app.adapters.notebooks.kubernetes import KubernetesNotebookProvider
+
+    adapter = KubernetesNotebookProvider()
+    manifest = adapter._build_pod_manifest(
+        session_spec={
+            "session_type": "jupyter",
+            "session_id": 995,
+            "user_id": 1,
+            "image": "test-image:latest",
+            "cpu_cores": 2,
+            "memory_gb": 4,
+            "node_pool": "interactive",
+        },
+        has_gcs_secret=False,
+    )
+
+    volumes = manifest["spec"]["volumes"]
+    secret_vols = [v for v in volumes if "secret" in v]
+    assert len(secret_vols) == 0

--- a/backend/tests/test_notebook_gcs_bucket.py
+++ b/backend/tests/test_notebook_gcs_bucket.py
@@ -1,6 +1,7 @@
-"""Tests for dynamic GCS bucket name in notebook sessions."""
+"""Tests for dynamic GCS bucket name in notebook and work node sessions."""
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import text
 
 from app.services.auth_service import AuthService
@@ -113,3 +114,194 @@ async def test_rstudio_session_uses_configured_working_bucket(session, admin_use
 
     assert ns.gcs_home_prefix is not None
     assert "bioaf-working-rstudio-test" in ns.gcs_home_prefix
+
+
+# -- Work node (SSH) GCS bucket tests --
+
+
+@pytest_asyncio.fixture
+async def seed_env_version(session, admin_user):
+    """Create a ready environment version for work node tests."""
+    from app.models.environment import Environment
+    from app.models.environment_version import EnvironmentVersion
+
+    env = Environment(
+        name="GCS Test Env",
+        description="Environment for GCS bucket tests",
+        organization_id=admin_user.organization_id,
+        created_by_user_id=admin_user.id,
+    )
+    session.add(env)
+    await session.flush()
+
+    version = EnvironmentVersion(
+        environment_id=env.id,
+        version_number=1,
+        status="ready",
+        definition_format="dockerfile",
+        definition_content="FROM ubuntu:22.04",
+        image_uri="us-central1-docker.pkg.dev/test/repo/test-env:v1",
+        created_by_user_id=admin_user.id,
+    )
+    session.add(version)
+    await session.flush()
+    await session.commit()
+    return version
+
+
+@pytest_asyncio.fixture
+async def seed_project(session, admin_user):
+    """Create a project for work node tests."""
+    from app.models.project import Project
+
+    project = Project(
+        name="GCS Test Project",
+        organization_id=admin_user.organization_id,
+        created_by_user_id=admin_user.id,
+    )
+    session.add(project)
+    await session.flush()
+    await session.commit()
+    return project
+
+
+@pytest_asyncio.fixture
+async def seed_admin_credentials(session, admin_user):
+    """Set up session credentials for the admin user."""
+    from app.services.session_credential_service import SessionCredentialService
+
+    await SessionCredentialService.create_or_update(
+        session,
+        user_id=admin_user.id,
+        org_id=admin_user.organization_id,
+        email=admin_user.email,
+        password="testpass",
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_work_node_uses_configured_working_bucket(
+    session, admin_user, seed_env_version, seed_project, seed_admin_credentials
+):
+    """WorkNodeService passes working_bucket from platform_config to the adapter."""
+    from app.services.work_node_service import WorkNodeService
+
+    await session.execute(
+        text("INSERT INTO platform_config (key, value) VALUES (:k, :v) ON CONFLICT (key) DO UPDATE SET value = :v"),
+        {"k": "working_bucket_name", "v": "bioaf-working-myorg-prod"},
+    )
+    await session.flush()
+
+    cs = await WorkNodeService.launch_work_node(
+        session,
+        user_id=admin_user.id,
+        org_id=admin_user.organization_id,
+        project_id=seed_project.id,
+        environment_version_id=seed_env_version.id,
+        machine_type="n2-standard-4",
+    )
+
+    assert cs.gcs_home_prefix is not None
+    assert "bioaf-working-myorg-prod" in cs.gcs_home_prefix
+    assert "bioaf-working/" not in cs.gcs_home_prefix
+
+
+@pytest.mark.asyncio
+async def test_work_node_falls_back_without_working_bucket(
+    session, admin_user, seed_env_version, seed_project, seed_admin_credentials
+):
+    """Without working_bucket_name, work node adapter uses default bucket."""
+    from app.services.work_node_service import WorkNodeService
+
+    cs = await WorkNodeService.launch_work_node(
+        session,
+        user_id=admin_user.id,
+        org_id=admin_user.organization_id,
+        project_id=seed_project.id,
+        environment_version_id=seed_env_version.id,
+        machine_type="n2-standard-4",
+    )
+
+    assert cs.gcs_home_prefix is not None
+    assert "bioaf-working" in cs.gcs_home_prefix
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_manifest_has_gcsfuse_annotation():
+    """Pod manifest includes gke-gcsfuse/volumes annotation when FUSE volumes are used."""
+    from app.adapters.notebooks.kubernetes import KubernetesNotebookProvider
+
+    adapter = KubernetesNotebookProvider()
+    # Build the pod manifest directly via _build_pod_manifest
+    manifest = adapter._build_pod_manifest(
+        session_spec={
+            "session_type": "ssh",
+            "session_id": 999,
+            "user_id": 1,
+            "image": "test-image:latest",
+            "cpu_cores": 4,
+            "memory_gb": 16,
+            "node_pool": "interactive",
+            "data_mount_paths": ["/pipeline-outputs/1"],
+            "session_credentials": {"username": "testuser", "password_hash": "testhash"},
+            "heartbeat_token": "test-token",
+        }
+    )
+
+    annotations = manifest["metadata"].get("annotations", {})
+    assert annotations.get("gke-gcsfuse/volumes") == "true"
+
+
+@pytest.mark.asyncio
+async def test_k8s_pod_manifest_no_gcsfuse_annotation_without_fuse():
+    """Pod manifest omits FUSE annotation when no FUSE volumes are used."""
+    from app.adapters.notebooks.kubernetes import KubernetesNotebookProvider
+
+    adapter = KubernetesNotebookProvider()
+    manifest = adapter._build_pod_manifest(
+        session_spec={
+            "session_type": "jupyter",
+            "session_id": 998,
+            "user_id": 1,
+            "image": "test-image:latest",
+            "cpu_cores": 2,
+            "memory_gb": 4,
+            "node_pool": "interactive",
+        }
+    )
+
+    annotations = manifest["metadata"].get("annotations", {})
+    assert "gke-gcsfuse/volumes" not in annotations
+
+
+@pytest.mark.asyncio
+async def test_k8s_gcsfuse_volume_uses_configured_bucket():
+    """GCS FUSE CSI volume uses the working_bucket from session spec, not hardcoded name."""
+    from app.adapters.notebooks.kubernetes import KubernetesNotebookProvider
+
+    adapter = KubernetesNotebookProvider()
+    manifest = adapter._build_pod_manifest(
+        session_spec={
+            "session_type": "ssh",
+            "session_id": 997,
+            "user_id": 1,
+            "image": "test-image:latest",
+            "cpu_cores": 4,
+            "memory_gb": 16,
+            "node_pool": "interactive",
+            "working_bucket": "bioaf-working-custom-org",
+            "data_mount_paths": ["/pipeline-outputs/1"],
+            "session_credentials": {"username": "testuser", "password_hash": "testhash"},
+            "heartbeat_token": "test-token",
+        }
+    )
+
+    # Find the CSI volume
+    volumes = manifest["spec"]["volumes"]
+    csi_volumes = [v for v in volumes if "csi" in v]
+    assert len(csi_volumes) > 0
+
+    for vol in csi_volumes:
+        bucket = vol["csi"]["volumeAttributes"]["bucketName"]
+        assert bucket == "bioaf-working-custom-org", f"Expected configured bucket, got {bucket}"

--- a/backend/tests/test_notebook_gcs_bucket.py
+++ b/backend/tests/test_notebook_gcs_bucket.py
@@ -331,12 +331,16 @@ async def test_k8s_pod_manifest_mounts_gcs_secret():
     secret_vols = [v for v in volumes if v.get("secret", {}).get("secretName") == "bioaf-gcs-sa-key"]
     assert len(secret_vols) == 1
 
-    # Init containers should have the mount and env var
+    # Init containers should have the mount, env var, and auth activation in command
     for ic in manifest["spec"]["initContainers"]:
         mount_names = [m["name"] for m in ic.get("volumeMounts", [])]
         assert "gcp-sa-key" in mount_names, f"Init container {ic['name']} missing GCS secret mount"
         env_names = [e["name"] for e in ic.get("env", [])]
         assert "GOOGLE_APPLICATION_CREDENTIALS" in env_names
+        # Command should have gcloud auth activation prepended
+        cmd = ic.get("command", [])
+        if len(cmd) >= 3 and cmd[0] == "/bin/sh":
+            assert "gcloud auth activate-service-account" in cmd[2]
 
     # Main container should also have the env var and mount
     main = manifest["spec"]["containers"][0]

--- a/decisions/ADR-040-notebook-file-lifecycle.md
+++ b/decisions/ADR-040-notebook-file-lifecycle.md
@@ -1,0 +1,114 @@
+# ADR-040: Notebook Session File Lifecycle
+
+**Status:** Accepted
+**Date:** 2026-04-04
+**Deciders:** Brent (repository owner)
+
+---
+
+## Context
+
+Notebook and SSH sessions can launch with input files and produce output files, but the current implementation has three gaps that prevent scientists from working effectively with their data:
+
+**Gap 1: Flat input file structure.** Input files are copied to `/data/` with no directory organization. A pipeline run producing `star/001/001.Log.final.out` and `star/001/001.SJ.out.tab` alongside `multiqc/multiqc_report.html` dumps all files into a single flat directory. Scientists cannot navigate files by their logical grouping, and files with the same basename from different subdirectories overwrite each other.
+
+**Gap 2: No designated output directory.** Scientists generate analysis outputs (figures, filtered matrices, exported CSVs) during sessions, but there is no convention for where these files should go. The home directory is synced to GCS on shutdown, but this captures everything (shell history, caches, config files) alongside actual outputs. There is no separation of signal from noise.
+
+**Gap 3: Output files are not persisted to the results bucket.** The home directory sync writes to the working bucket, which is for in-progress data. Finalized session outputs should move to the results bucket so they are discoverable alongside pipeline outputs and uploads. Currently, a figure produced in a notebook session is effectively lost once the session terminates unless the scientist manually uploads it.
+
+ADR-039 established the `NotebookSessionFile` model and `notebook_output` source type for provenance tracking. This ADR defines the file lifecycle that produces and consumes those records.
+
+---
+
+## Decision
+
+### 1. Hierarchical input file organization
+
+Input files mounted at session start are organized under `/data/` using the entity hierarchy:
+
+```text
+/data/{project_name}/{experiment_name}/{sample_name}/{tool_name}/filename
+/data/{project_name}/uploads/filename
+```
+
+The path is derived from each file's associations in the database (project, experiment, sample, and the pipeline or tool that produced it). Uploaded files that are not associated with a specific experiment or sample go into an `uploads/` directory within their project scope.
+
+This structure lets scientists navigate files by the logical units they already think in: "I want the STARsolo output for sample 16 in experiment 2."
+
+The init container commands include `mkdir -p` to create intermediate directories before copying files.
+
+### 2. Designated `/outputs/` directory
+
+All session types (Jupyter, RStudio, SSH) get a writable `/outputs/` directory backed by an `emptyDir` volume. The contract is simple: anything saved to `/outputs/` is persisted to GCS on shutdown and registered as a tracked output file. Everything outside `/outputs/` (except notebook scripts, see below) is ephemeral.
+
+SSH work nodes retain their existing `/scratch/` volume for temporary computation. The `/outputs/` directory is additive.
+
+### 3. Notebook and script capture
+
+On shutdown, the platform captures analysis scripts from the home directory: `.ipynb`, `.Rmd`, `.R`, and `.py` files (up to 3 levels deep). These are the analysis recipes that transform inputs into outputs and are critical for reproducibility. They are persisted alongside other output files.
+
+### 4. Two-phase output persistence
+
+Output files follow a two-phase GCS lifecycle:
+
+- **During the session:** `/outputs/` contents are synced to the working bucket at `gs://{working_bucket}/sessions/{session_id}/outputs/`. This happens periodically or on explicit save. The working bucket is for in-progress data.
+- **On session close:** Output files are copied from the working bucket to the results bucket at `gs://{results_bucket}/sessions/{session_id}/outputs/`. The results bucket is for finalized, discoverable data. Output files are then registered as `File` records with `source_type=notebook_output` and linked to the session's project, experiment, and sample associations via `NotebookSessionFile`.
+
+This separation means the working bucket can have aggressive lifecycle policies (e.g., delete after 30 days) without affecting finalized results.
+
+### 5. Extended shutdown timeout
+
+Large bioinformatics outputs (h5ad files, RDS objects) can be 10GB+. The shutdown flow is extended to a 30-minute timeout to accommodate GCS sync of large files. The UI displays a status indicator during sync so the scientist knows the session is persisting their work, not hung.
+
+### 6. Schema changes
+
+**`compute_sessions` table -- new column:**
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `gcs_output_prefix` | String(500), nullable | GCS prefix where outputs were persisted on shutdown |
+
+No other schema changes are required. The `NotebookSessionFile` model (ADR-039) and `File.source_type=notebook_output` already exist.
+
+---
+
+## Alternatives Considered
+
+**Mount GCS directly via FUSE for outputs:** GCS FUSE would give scientists a live-mounted output directory without a sync step. Rejected because FUSE write performance is poor for the small-file, random-write patterns typical of interactive analysis (creating many small PNGs, CSVs, and intermediate files). The emptyDir + sync-on-close approach provides local-disk write performance with GCS durability.
+
+**Sync the entire home directory as outputs:** This is the current behavior. Rejected because it captures system files (.bash_history, .cache, .local) alongside actual outputs, making provenance noisy and output discovery unreliable.
+
+**Single bucket for working and results:** Simpler, but conflates in-progress session data with finalized outputs. Scientists searching for results would need to filter out incomplete sessions. Rejected in favor of the two-bucket approach which provides a clean boundary.
+
+---
+
+## Consequences
+
+**Positive:**
+
+- Scientists see their data organized by project, experiment, sample, and tool -- matching their mental model
+- The `/outputs/` convention provides a clear, simple contract for what gets persisted
+- Two-phase persistence means working data can be aggressively cleaned without affecting results
+- Notebook scripts are captured automatically, preserving the analysis recipe for reproducibility
+- Output files are registered with full provenance linkage (ADR-039), answering "which session produced this file?"
+
+**Negative:**
+
+- The 30-minute shutdown timeout means session termination is not instant for large outputs. The UI indicator mitigates confusion but does not eliminate the wait.
+- Scientists must remember to save outputs to `/outputs/` rather than their home directory. Training and clear UI messaging are needed. Files saved elsewhere are lost on termination.
+- The two-phase copy (working then results) doubles GCS write operations for output files. Given the relatively small volume of notebook outputs compared to pipeline outputs, this cost is acceptable.
+
+**Neutral:**
+
+- SSH work nodes gain `/outputs/` alongside their existing `/scratch/`. The two directories serve different purposes (persistent vs. ephemeral) and do not conflict.
+- The hierarchical input structure requires resolving file associations at launch time. This adds a few database queries to the launch flow but does not affect session startup latency meaningfully since the queries run while the node is scaling up.
+
+---
+
+## References
+
+- ADR-039 (Notebook output provenance -- `NotebookSessionFile` model and `notebook_output` source type)
+- ADR-037 (Provenance reporting -- artifact lineage requires session input/output tracking)
+- ADR-033 (Versioned compute environments -- environment version linking for sessions)
+- ADR-034 (Custom work nodes -- SSH session architecture, `/scratch/` volume)
+- ADR-022 (GCS storage backend -- bucket architecture and lifecycle policies)

--- a/decisions/ADR-041-environment-build-versioning.md
+++ b/decisions/ADR-041-environment-build-versioning.md
@@ -1,0 +1,107 @@
+# ADR-041: Environment Build Versioning
+
+**Status:** Accepted
+**Date:** 2026-04-04
+**Deciders:** Brent (repository owner)
+
+---
+
+## Context
+
+ADR-033 introduced versioned compute environments where users create named environments, define them via Dockerfile or conda spec, and build versioned container images. Version numbers are integers (v1, v2, v3), and the ADR states: "once a version reaches `ready`, its image is never overwritten."
+
+In practice, scientists sometimes need to rebuild an existing version. The Dockerfile may reference `FROM rocker/rstudio:latest` or install packages without pinning versions. When the base image or package repository is updated upstream, a rebuild of the same Dockerfile produces a different image. Common scenarios:
+
+- A security patch to the base image requires rebuilding all active environments
+- A scientist wants to pick up a bugfix in the bioAF base image without changing their custom packages
+- An environment build failed due to a transient network error and needs to be retried after the version was already marked `ready` from a partial cache hit
+
+The current system has no way to distinguish between "v1 built on March 1" and "v1 rebuilt on April 4 with newer base packages." If the image is overwritten in Artifact Registry, provenance records pointing to `env:v1` silently refer to a different image than the one that produced the original results.
+
+---
+
+## Decision
+
+### 1. Add `build_number` to `EnvironmentVersion`
+
+Each `EnvironmentVersion` row gains a `build_number` column (integer, default 1). The combination of `(environment_id, version_number, build_number)` is unique.
+
+```text
+environment_versions
+  ... existing columns ...
+  build_number  INTEGER  NOT NULL  DEFAULT 1
+
+  UNIQUE (environment_id, version_number, build_number)
+```
+
+### 2. Rebuild creates a new row
+
+Rebuilding v1 does not overwrite the existing row. Instead, it creates a new `EnvironmentVersion` with the same `environment_id` and `version_number` but an incremented `build_number`:
+
+| version_number | build_number | status | image_uri |
+| --- | --- | --- | --- |
+| 1 | 1 | ready | env:v1 |
+| 1 | 2 | building | (pending) |
+
+The original v1 build 1 record and its image remain untouched. The rebuild (build 2) goes through the standard draft/building/ready lifecycle.
+
+### 3. Image tags include build number
+
+Images are tagged as `{env_name}:v{version}.{build}` in Artifact Registry:
+
+```text
+us-central1-docker.pkg.dev/project/bioaf-images/seurat-gpu:v1.1    (original)
+us-central1-docker.pkg.dev/project/bioaf-images/seurat-gpu:v1.2    (rebuild)
+us-central1-docker.pkg.dev/project/bioaf-images/seurat-gpu:v2.1    (new version)
+```
+
+The first build of any version uses build number 1 (tagged `v1.1`). This is a change from the current `v1` tag format but is backward-compatible: existing images in the registry are not renamed, and old `EnvironmentVersion` rows default to `build_number=1`. New builds use the dotted format going forward.
+
+### 4. Minor versions do not collide with major versions
+
+Scientists create major versions (v1, v2, v3) by writing new Dockerfiles or modifying the environment definition. Rebuilds create minor versions (v1.1, v1.2) within the same major. The namespace is separate: rebuilding v1 produces v1.2, never v2. Scientists' intentional version bumps are never trampled by infrastructure rebuilds.
+
+### 5. Provenance links to exact builds
+
+Session records store `environment_version_id` as a foreign key. Since each build is a separate row, the FK naturally points to the exact build used. The provenance system (ADR-037) can report both the version number and build number, answering: "This analysis used seurat-gpu v1, build 2 (rebuilt 2026-04-04)."
+
+---
+
+## Alternatives Considered
+
+**Overwrite the image tag on rebuild:** This is the current behavior. The v1 tag in Artifact Registry points to whatever was built last. Provenance records become unreliable because `env:v1` could refer to different images at different points in time. Rejected because it breaks reproducibility.
+
+**Use content-addressable tags (SHA digest):** Every Docker image has a SHA256 digest. We could store the digest and pull by digest instead of tag. This is maximally precise but unfriendly to humans ("which image is sha256:a3f8c2...?") and makes the UI harder to navigate. Rejected as the primary scheme, though digests could be stored alongside tags as an additional integrity check in the future.
+
+**Treat every rebuild as a new major version:** Rebuilding v1 would create v2. Simple, but misleading: v2 implies a deliberate change to the environment definition, not an infrastructure-level rebuild of the same spec. Scientists would lose the semantic distinction between "I changed my packages" and "the base image was patched." Rejected.
+
+---
+
+## Consequences
+
+**Positive:**
+
+- Every build is immutable and traceable. Provenance records always point to the exact image that was used.
+- Scientists can rebuild environments for security patches or base image updates without losing the original build record.
+- The minor version scheme (v1.1, v1.2) communicates clearly: "same definition, different build." Major versions (v1, v2) communicate: "different definition."
+- Backward-compatible: existing rows get `build_number=1` via server default, no data migration needed.
+
+**Negative:**
+
+- Artifact Registry accumulates more images (one per build instead of one per version). Storage costs increase proportionally. A future cleanup policy for old builds may be needed.
+- The UI must now display build numbers alongside version numbers. The display format `v{version}.{build}` is simple but adds visual complexity to version selectors.
+- Old image tags (`env:v1` without build number) coexist with new tags (`env:v1.1`). The build service must handle both formats during the transition period.
+
+**Neutral:**
+
+- The `UNIQUE(environment_id, version_number, build_number)` constraint prevents accidental duplicate builds at the database level.
+- The rebuild API endpoint (`POST /environments/{id}/versions/{vid}/rebuild`) follows the existing pattern of version lifecycle endpoints.
+
+---
+
+## References
+
+- ADR-033 (Versioned compute environments -- base version system this extends)
+- ADR-031 (Notebook image build pipeline -- Cloud Build integration)
+- ADR-037 (Provenance reporting -- environment details in provenance records)
+- ADR-040 (Notebook file lifecycle -- environment version linking for sessions)

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -41,6 +41,8 @@
 | [ADR-037](ADR-037-provenance-reporting.md) | Provenance Reporting System | Accepted | 2026-03-24 |
 | [ADR-038](ADR-038-pipeline-io-lineage-junction.md) | Pipeline Input File Lineage as a Junction Table | Accepted | 2026-03-25 |
 | [ADR-039](ADR-039-notebook-output-provenance.md) | Notebook Output Provenance | Accepted | 2026-03-25 |
+| [ADR-040](ADR-040-notebook-file-lifecycle.md) | Notebook Session File Lifecycle | Accepted | 2026-04-04 |
+| [ADR-041](ADR-041-environment-build-versioning.md) | Environment Build Versioning | Accepted | 2026-04-04 |
 
 ## How to Use This Directory
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -77,12 +77,7 @@ export default function NotebooksPage() {
   const [sampleNames, setSampleNames] = useState<Record<number, string>>({});
   const [selectedFileIds, setSelectedFileIds] = useState<number[]>([]);
   const [activeBranchCount, setActiveBranchCount] = useState(0);
-  const [showGuide, setShowGuide] = useState(() => {
-    if (typeof window !== "undefined") {
-      return localStorage.getItem("bioaf_notebooks_guide_dismissed") !== "true";
-    }
-    return true;
-  });
+  const [showGuide, setShowGuide] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated()) {
@@ -297,11 +292,19 @@ export default function NotebooksPage() {
           </div>
 
           {/* Quick Start Guide */}
-          {showGuide && (
-            <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 text-sm text-blue-800 space-y-2">
-                  <p className="font-semibold">Working with notebook sessions</p>
+          <div className="mb-6">
+            <button
+              onClick={() => setShowGuide(!showGuide)}
+              className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              How notebook sessions work
+            </button>
+            {showGuide && (
+              <div className="mt-2 rounded-lg border border-blue-200 bg-blue-50 p-4">
+                <div className="text-sm text-blue-800 space-y-2">
                   <ul className="space-y-1.5 text-blue-700">
                     <li><strong>Input files</strong> are mounted at <code className="bg-blue-100 px-1 rounded">/data/</code>, organized by project, experiment, sample, and pipeline. Select files when launching a session.</li>
                     <li><strong>Output files</strong> should be saved to <code className="bg-blue-100 px-1 rounded">/outputs/</code>. Everything in this directory is automatically synced to GCS and registered when you stop the session.</li>
@@ -310,19 +313,9 @@ export default function NotebooksPage() {
                     <li><strong>Session credentials</strong> (username and password for RStudio) are set in your <a href="/profile" className="underline font-medium">Profile Settings</a>.</li>
                   </ul>
                 </div>
-                <button
-                  onClick={() => {
-                    setShowGuide(false);
-                    localStorage.setItem("bioaf_notebooks_guide_dismissed", "true");
-                  }}
-                  className="shrink-0 text-blue-600 hover:text-blue-900 text-lg leading-none"
-                  aria-label="Dismiss guide"
-                >
-                  &times;
-                </button>
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {/* Build Status Banner */}
           {imageBuildStatus?.build_status && ["WORKING", "QUEUED"].includes(imageBuildStatus.build_status) && (

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -14,6 +14,7 @@ import type {
   NotebookSession,
   SessionListResponse,
   SessionLaunchRequest,
+  SessionProvenance,
   ResourceProfile,
   SessionType,
   Experiment,
@@ -68,6 +69,9 @@ export default function NotebooksPage() {
   const [selectedEnvId, setSelectedEnvId] = useState<number | null>(null);
   const [selectedEnvDetail, setSelectedEnvDetail] = useState<EnvironmentDetailResponse | null>(null);
   const [selectedVersionImageUri, setSelectedVersionImageUri] = useState<string | null>(null);
+  const [selectedVersionId, setSelectedVersionId] = useState<number | null>(null);
+  const [stoppingSessions, setStoppingSessions] = useState<Set<number>>(new Set());
+  const [provenance, setProvenance] = useState<SessionProvenance | null>(null);
   const [showFileSelector, setShowFileSelector] = useState(false);
   const [experimentFiles, setExperimentFiles] = useState<FileResponse[]>([]);
   const [sampleNames, setSampleNames] = useState<Record<number, string>>({});
@@ -148,12 +152,14 @@ export default function NotebooksPage() {
   async function handleEnvChange(envId: number) {
     setSelectedEnvId(envId);
     setSelectedVersionImageUri(null);
+    setSelectedVersionId(null);
     try {
       const detail = await api.get<EnvironmentDetailResponse>(`/api/v1/environments/${envId}`);
       setSelectedEnvDetail(detail);
       const readyVersion = detail.versions.find((v) => v.status === "ready" && v.image_uri);
       if (readyVersion) {
         setSelectedVersionImageUri(readyVersion.image_uri);
+        setSelectedVersionId(readyVersion.id);
       }
     } catch {}
   }
@@ -233,6 +239,7 @@ export default function NotebooksPage() {
         experiment_id: scopeType === "experiment" ? selectedExperiment : undefined,
         image_uri: selectedVersionImageUri,
         input_file_ids: selectedFileIds.length > 0 ? selectedFileIds : undefined,
+        environment_version_id: selectedVersionId,
       };
       await api.post("/api/v1/notebooks/sessions", req);
       setShowLaunchModal(false);
@@ -245,11 +252,19 @@ export default function NotebooksPage() {
   }
 
   async function handleStop(sessionId: number) {
-    if (!confirm("Stop this notebook session? Unsaved work may be lost.")) return;
+    if (!confirm("Stop this notebook session? Files in /outputs/ will be synced to GCS before shutdown. This may take a few minutes for large files.")) return;
+    setStoppingSessions((prev) => new Set(prev).add(sessionId));
     try {
       await api.post(`/api/v1/notebooks/sessions/${sessionId}/stop`);
       loadSessions();
-    } catch {}
+    } catch {
+    } finally {
+      setStoppingSessions((prev) => {
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+    }
   }
 
   async function handleSync(sessionId: number) {
@@ -340,7 +355,12 @@ export default function NotebooksPage() {
                         {s.resource_profile} ({s.cpu_cores} CPU, {s.memory_gb}GB)
                       </td>
                       <td className="px-4 py-3">
-                        {s.status === "starting" ? (
+                        {stoppingSessions.has(s.id) ? (
+                          <span className="flex items-center gap-1 text-xs text-orange-700">
+                            <LoadingSpinner size="sm" />
+                            Syncing outputs to GCS...
+                          </span>
+                        ) : s.status === "starting" ? (
                           <span className="flex items-center gap-1 text-xs text-blue-700">
                             <LoadingSpinner size="sm" />
                             Starting... this may take a few minutes
@@ -399,43 +419,109 @@ export default function NotebooksPage() {
 
           {/* Session Detail Modal */}
           {viewingSession && (
-            <DetailModal
-              title={`${viewingSession.session_type.charAt(0).toUpperCase() + viewingSession.session_type.slice(1)} Session`}
-              onClose={() => setViewingSession(null)}
-              fields={[
-                { label: "Type", value: viewingSession.session_type },
-                { label: "Status", value: viewingSession.status },
-                { label: "User", value: viewingSession.user?.name || viewingSession.user?.email },
-                { label: "Resource Profile", value: viewingSession.resource_profile },
-                { label: "CPU Cores", value: viewingSession.cpu_cores },
-                { label: "Memory (GB)", value: viewingSession.memory_gb },
-                { label: "Experiment", value: viewingSession.experiment?.name },
-                { label: "Started", value: viewingSession.started_at ? new Date(viewingSession.started_at).toLocaleString() : null },
-                { label: "Access URL", value: viewingSession.proxy_url || null },
-                { label: "Idle Since", value: viewingSession.idle_since ? new Date(viewingSession.idle_since).toLocaleString() : null },
-                { label: "Git Branch", value: viewingSession.git_branch_name || null },
-                { label: "Git Commit", value: viewingSession.git_commit_hash || null },
-              ]}
-              actions={
-                <>
+            <div className="fixed inset-0 bg-black/30 z-50 flex items-center justify-center" onClick={() => { setViewingSession(null); setProvenance(null); }}>
+              <div className="bg-white rounded-lg shadow-xl w-[600px] max-h-[85vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+                <div className="p-6 border-b flex items-center justify-between">
+                  <h3 className="text-lg font-semibold">
+                    {viewingSession.session_type.charAt(0).toUpperCase() + viewingSession.session_type.slice(1)} Session
+                  </h3>
+                  <button onClick={() => { setViewingSession(null); setProvenance(null); }} className="text-gray-400 hover:text-gray-600 text-xl">&times;</button>
+                </div>
+                <div className="p-6 space-y-3">
+                  {[
+                    { label: "Type", value: viewingSession.session_type },
+                    { label: "Status", value: viewingSession.status },
+                    { label: "User", value: viewingSession.user?.name || viewingSession.user?.email },
+                    { label: "Resource Profile", value: viewingSession.resource_profile },
+                    { label: "CPU Cores", value: viewingSession.cpu_cores },
+                    { label: "Memory (GB)", value: viewingSession.memory_gb },
+                    { label: "Experiment", value: viewingSession.experiment?.name },
+                    { label: "Started", value: viewingSession.started_at ? new Date(viewingSession.started_at).toLocaleString() : null },
+                    { label: "Access URL", value: viewingSession.proxy_url || null },
+                    { label: "Idle Since", value: viewingSession.idle_since ? new Date(viewingSession.idle_since).toLocaleString() : null },
+                    { label: "Git Branch", value: viewingSession.git_branch_name || null },
+                    { label: "Git Commit", value: viewingSession.git_commit_hash || null },
+                  ].filter((f) => f.value != null).map((f) => (
+                    <div key={f.label} className="flex justify-between text-sm">
+                      <span className="text-gray-500">{f.label}</span>
+                      <span className="font-medium">{String(f.value)}</span>
+                    </div>
+                  ))}
+
+                  {/* Provenance section for stopped sessions */}
+                  {viewingSession.status === "stopped" && (
+                    <div className="mt-4 pt-4 border-t">
+                      {!provenance ? (
+                        <button
+                          onClick={async () => {
+                            try {
+                              const p = await api.get<SessionProvenance>(`/api/v1/notebooks/sessions/${viewingSession.id}/provenance`);
+                              setProvenance(p);
+                            } catch {}
+                          }}
+                          className="text-sm text-bioaf-600 hover:underline"
+                        >
+                          View provenance
+                        </button>
+                      ) : (
+                        <div className="space-y-3">
+                          <h4 className="text-sm font-semibold text-gray-700">Provenance</h4>
+                          {provenance.environment && (
+                            <div>
+                              <p className="text-xs text-gray-500 mb-1">Environment</p>
+                              <p className="text-sm">
+                                {provenance.environment.environment_name} v{provenance.environment.version_number}.{provenance.environment.build_number}
+                                <span className="text-gray-400 ml-1">({provenance.environment.definition_format})</span>
+                              </p>
+                            </div>
+                          )}
+                          {provenance.input_files.length > 0 && (
+                            <div>
+                              <p className="text-xs text-gray-500 mb-1">Input files ({provenance.input_files.length})</p>
+                              <ul className="text-sm space-y-0.5 max-h-32 overflow-y-auto">
+                                {provenance.input_files.map((f) => (
+                                  <li key={f.id} className="text-gray-700 truncate" title={f.gcs_uri}>{f.filename}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                          {provenance.output_files.length > 0 && (
+                            <div>
+                              <p className="text-xs text-gray-500 mb-1">Output files ({provenance.output_files.length})</p>
+                              <ul className="text-sm space-y-0.5 max-h-32 overflow-y-auto">
+                                {provenance.output_files.map((f) => (
+                                  <li key={f.id} className="text-gray-700 truncate" title={f.gcs_uri}>{f.filename}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                          {provenance.input_files.length === 0 && provenance.output_files.length === 0 && (
+                            <p className="text-sm text-gray-400">No input or output files recorded</p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+                <div className="p-4 border-t bg-gray-50 flex gap-2 justify-end">
                   {viewingSession.proxy_url && viewingSession.status === "running" && (
                     <a href={viewingSession.proxy_url} target="_blank" rel="noopener noreferrer" className="px-3 py-1.5 border border-bioaf-600 text-bioaf-600 rounded text-sm hover:bg-bioaf-50">
                       Open
                     </a>
                   )}
                   {viewingSession.status === "running" && (
-                    <button onClick={() => { handleSync(viewingSession.id); }} className="px-3 py-1.5 border border-green-600 text-green-600 rounded text-sm hover:bg-green-50">
+                    <button onClick={() => handleSync(viewingSession.id)} className="px-3 py-1.5 border border-green-600 text-green-600 rounded text-sm hover:bg-green-50">
                       Sync
                     </button>
                   )}
                   {["pending", "starting", "running", "idle"].includes(viewingSession.status) && (
-                    <button onClick={() => { handleStop(viewingSession.id); setViewingSession(null); }} className="px-3 py-1.5 border border-red-600 text-red-600 rounded text-sm hover:bg-red-50">
+                    <button onClick={() => { handleStop(viewingSession.id); setViewingSession(null); setProvenance(null); }} className="px-3 py-1.5 border border-red-600 text-red-600 rounded text-sm hover:bg-red-50">
                       Stop
                     </button>
                   )}
-                </>
-              }
-            />
+                </div>
+              </div>
+            </div>
           )}
 
           {/* Launch Modal */}
@@ -490,15 +576,20 @@ export default function NotebooksPage() {
                       </select>
                       {selectedEnvDetail && selectedEnvDetail.versions.filter((v) => v.status === "ready").length > 0 && (
                         <select
-                          value={selectedVersionImageUri || ""}
-                          onChange={(e) => setSelectedVersionImageUri(e.target.value || null)}
+                          value={selectedVersionId || ""}
+                          onChange={(e) => {
+                            const vid = e.target.value ? Number(e.target.value) : null;
+                            setSelectedVersionId(vid);
+                            const v = selectedEnvDetail?.versions.find((ver) => ver.id === vid);
+                            setSelectedVersionImageUri(v?.image_uri || null);
+                          }}
                           className="border rounded px-3 py-2 text-sm flex-1"
                         >
                           {selectedEnvDetail.versions
                             .filter((v) => v.status === "ready" && v.image_uri)
                             .map((v) => (
-                              <option key={v.id} value={v.image_uri || ""}>
-                                v{v.version_number} ({v.definition_format})
+                              <option key={v.id} value={v.id}>
+                                v{v.version_number}.{v.build_number} ({v.definition_format})
                               </option>
                             ))}
                         </select>

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -77,6 +77,12 @@ export default function NotebooksPage() {
   const [sampleNames, setSampleNames] = useState<Record<number, string>>({});
   const [selectedFileIds, setSelectedFileIds] = useState<number[]>([]);
   const [activeBranchCount, setActiveBranchCount] = useState(0);
+  const [showGuide, setShowGuide] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("bioaf_notebooks_guide_dismissed") !== "true";
+    }
+    return true;
+  });
 
   useEffect(() => {
     if (!isAuthenticated()) {
@@ -289,6 +295,34 @@ export default function NotebooksPage() {
               Launch Session
             </button>
           </div>
+
+          {/* Quick Start Guide */}
+          {showGuide && (
+            <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 text-sm text-blue-800 space-y-2">
+                  <p className="font-semibold">Working with notebook sessions</p>
+                  <ul className="space-y-1.5 text-blue-700">
+                    <li><strong>Input files</strong> are mounted at <code className="bg-blue-100 px-1 rounded">/data/</code>, organized by project, experiment, sample, and pipeline. Select files when launching a session.</li>
+                    <li><strong>Output files</strong> should be saved to <code className="bg-blue-100 px-1 rounded">/outputs/</code>. Everything in this directory is automatically synced to GCS and registered when you stop the session.</li>
+                    <li><strong>Environments</strong> control the packages available in your session. Choose an environment and version when launching. Admins can create and build new environments from the <a href="/environments" className="underline font-medium">Environments</a> page.</li>
+                    <li><strong>Git integration</strong> can be configured per-session via SSH keys in your <a href="/profile" className="underline font-medium">Profile Settings</a>. Notebooks are auto-committed every 15 minutes when a git repo is configured.</li>
+                    <li><strong>Session credentials</strong> (username and password for RStudio) are set in your <a href="/profile" className="underline font-medium">Profile Settings</a>.</li>
+                  </ul>
+                </div>
+                <button
+                  onClick={() => {
+                    setShowGuide(false);
+                    localStorage.setItem("bioaf_notebooks_guide_dismissed", "true");
+                  }}
+                  className="shrink-0 text-blue-600 hover:text-blue-900 text-lg leading-none"
+                  aria-label="Dismiss guide"
+                >
+                  &times;
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Build Status Banner */}
           {imageBuildStatus?.build_status && ["WORKING", "QUEUED"].includes(imageBuildStatus.build_status) && (

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -428,20 +428,37 @@ export default function NotebooksPage() {
                   <button onClick={() => { setViewingSession(null); setProvenance(null); }} className="text-gray-400 hover:text-gray-600 text-xl">&times;</button>
                 </div>
                 <div className="p-6 space-y-3">
-                  {[
-                    { label: "Type", value: viewingSession.session_type },
-                    { label: "Status", value: viewingSession.status },
-                    { label: "User", value: viewingSession.user?.name || viewingSession.user?.email },
-                    { label: "Resource Profile", value: viewingSession.resource_profile },
-                    { label: "CPU Cores", value: viewingSession.cpu_cores },
-                    { label: "Memory (GB)", value: viewingSession.memory_gb },
-                    { label: "Experiment", value: viewingSession.experiment?.name },
-                    { label: "Started", value: viewingSession.started_at ? new Date(viewingSession.started_at).toLocaleString() : null },
-                    { label: "Access URL", value: viewingSession.proxy_url || null },
-                    { label: "Idle Since", value: viewingSession.idle_since ? new Date(viewingSession.idle_since).toLocaleString() : null },
-                    { label: "Git Branch", value: viewingSession.git_branch_name || null },
-                    { label: "Git Commit", value: viewingSession.git_commit_hash || null },
-                  ].filter((f) => f.value != null).map((f) => (
+                  {(() => {
+                    // Resolve environment name from loaded environments
+                    let envLabel: string | null = null;
+                    if (viewingSession.environment_version_id) {
+                      for (const env of environments) {
+                        const v = env.latest_version;
+                        if (v && v.id === viewingSession.environment_version_id) {
+                          envLabel = `${env.name} v${v.version_number}.${v.build_number}`;
+                          break;
+                        }
+                      }
+                      if (!envLabel) {
+                        envLabel = `Version ID ${viewingSession.environment_version_id}`;
+                      }
+                    }
+                    return [
+                      { label: "Type", value: viewingSession.session_type },
+                      { label: "Status", value: viewingSession.status },
+                      { label: "User", value: viewingSession.user?.name || viewingSession.user?.email },
+                      { label: "Environment", value: envLabel },
+                      { label: "Resource Profile", value: viewingSession.resource_profile },
+                      { label: "CPU Cores", value: viewingSession.cpu_cores },
+                      { label: "Memory (GB)", value: viewingSession.memory_gb },
+                      { label: "Experiment", value: viewingSession.experiment?.name },
+                      { label: "Started", value: viewingSession.started_at ? new Date(viewingSession.started_at).toLocaleString() : null },
+                      { label: "Access URL", value: viewingSession.proxy_url || null },
+                      { label: "Idle Since", value: viewingSession.idle_since ? new Date(viewingSession.idle_since).toLocaleString() : null },
+                      { label: "Git Branch", value: viewingSession.git_branch_name || null },
+                      { label: "Git Commit", value: viewingSession.git_commit_hash || null },
+                    ];
+                  })().filter((f) => f.value != null).map((f) => (
                     <div key={f.label} className="flex justify-between text-sm">
                       <span className="text-gray-500">{f.label}</span>
                       <span className="font-medium">{String(f.value)}</span>

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -58,6 +58,7 @@ export default function WorkNodesPage() {
   const [selectedMachineType, setSelectedMachineType] = useState<string>("");
   const [launching, setLaunching] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
+  const [stoppingNodes, setStoppingNodes] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
@@ -157,12 +158,20 @@ export default function WorkNodesPage() {
   }
 
   async function handleStop(nodeId: number) {
-    if (!confirm("Stop this work node? Data in /scratch will be lost.")) return;
+    if (!confirm("Stop this work node? Files in /outputs/ will be synced to GCS. Data in /scratch will be lost.")) return;
+    setStoppingNodes((prev) => new Set(prev).add(nodeId));
     try {
       await api.post(`/api/v1/work-nodes/sessions/${nodeId}/stop`);
       loadNodes();
       if (viewingNode?.id === nodeId) setViewingNode(null);
-    } catch {}
+    } catch {
+    } finally {
+      setStoppingNodes((prev) => {
+        const next = new Set(prev);
+        next.delete(nodeId);
+        return next;
+      });
+    }
   }
 
   function formatUptime(startedAt: string | null): string {
@@ -235,9 +244,16 @@ export default function WorkNodesPage() {
                   {nodes.map((node) => (
                     <tr key={node.id} className="hover:bg-gray-50">
                       <td className="px-4 py-3">
-                        <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[node.status] || "bg-gray-100"}`}>
-                          {node.status}
-                        </span>
+                        {stoppingNodes.has(node.id) ? (
+                          <span className="flex items-center gap-1 text-xs text-orange-700">
+                            <LoadingSpinner size="sm" />
+                            Syncing outputs...
+                          </span>
+                        ) : (
+                          <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[node.status] || "bg-gray-100"}`}>
+                            {node.status}
+                          </span>
+                        )}
                       </td>
                       <td className="px-4 py-3 text-sm text-gray-900">{node.machine_type || "-"}</td>
                       <td className="px-4 py-3 text-sm text-gray-600">{node.cpu_cores} CPU / {node.memory_gb} GB</td>
@@ -340,7 +356,7 @@ export default function WorkNodesPage() {
                     >
                       Stop Work Node
                     </button>
-                    <p className="text-xs text-gray-400 mt-1 text-center">Data in /scratch will be lost</p>
+                    <p className="text-xs text-gray-400 mt-1 text-center">Files in /outputs/ will be synced. Data in /scratch will be lost.</p>
                   </div>
                 )}
               </div>
@@ -451,7 +467,7 @@ export default function WorkNodesPage() {
                           {envDetail.versions
                             .filter((v) => v.status === "ready" && v.image_uri)
                             .map((v) => (
-                              <option key={v.id} value={v.id}>v{v.version_number} (ready)</option>
+                              <option key={v.id} value={v.id}>v{v.version_number}.{v.build_number} (ready)</option>
                             ))}
                         </select>
                       </div>

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -59,6 +59,12 @@ export default function WorkNodesPage() {
   const [launching, setLaunching] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
   const [stoppingNodes, setStoppingNodes] = useState<Set<number>>(new Set());
+  const [showGuide, setShowGuide] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("bioaf_worknodes_guide_dismissed") !== "true";
+    }
+    return true;
+  });
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
@@ -219,6 +225,35 @@ export default function WorkNodesPage() {
               </button>
             )}
           </div>
+
+          {/* Quick Start Guide */}
+          {showGuide && (
+            <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 text-sm text-blue-800 space-y-2">
+                  <p className="font-semibold">Working with SSH work nodes</p>
+                  <ul className="space-y-1.5 text-blue-700">
+                    <li><strong>Input files</strong> are mounted at <code className="bg-blue-100 px-1 rounded">/data/</code>. Select data mounts during launch to access pipeline outputs, uploads, and shared results for your project.</li>
+                    <li><strong>Output files</strong> should be saved to <code className="bg-blue-100 px-1 rounded">/outputs/</code>. Everything in this directory is automatically synced to GCS and registered when you stop the node.</li>
+                    <li><strong>Scratch space</strong> at <code className="bg-blue-100 px-1 rounded">/scratch/</code> is for temporary computation. This data is lost when the node stops.</li>
+                    <li><strong>Environments</strong> control the packages and tools available. Choose an environment and version when launching. Admins can create new environments from the <a href="/environments" className="underline font-medium">Environments</a> page.</li>
+                    <li><strong>SSH access</strong> uses the credentials you set in your <a href="/profile" className="underline font-medium">Profile Settings</a>. The connection command appears in the node detail panel after launch.</li>
+                    <li><strong>Machine types</strong> range from standard (4 CPU) to high-memory (128 GB) and GPU. Choose based on your workload.</li>
+                  </ul>
+                </div>
+                <button
+                  onClick={() => {
+                    setShowGuide(false);
+                    localStorage.setItem("bioaf_worknodes_guide_dismissed", "true");
+                  }}
+                  className="shrink-0 text-blue-600 hover:text-blue-900 text-lg leading-none"
+                  aria-label="Dismiss guide"
+                >
+                  &times;
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Node list */}
           {nodes.length === 0 ? (

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -59,12 +59,7 @@ export default function WorkNodesPage() {
   const [launching, setLaunching] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
   const [stoppingNodes, setStoppingNodes] = useState<Set<number>>(new Set());
-  const [showGuide, setShowGuide] = useState(() => {
-    if (typeof window !== "undefined") {
-      return localStorage.getItem("bioaf_worknodes_guide_dismissed") !== "true";
-    }
-    return true;
-  });
+  const [showGuide, setShowGuide] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
@@ -227,11 +222,19 @@ export default function WorkNodesPage() {
           </div>
 
           {/* Quick Start Guide */}
-          {showGuide && (
-            <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 text-sm text-blue-800 space-y-2">
-                  <p className="font-semibold">Working with SSH work nodes</p>
+          <div className="mb-6">
+            <button
+              onClick={() => setShowGuide(!showGuide)}
+              className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              How work nodes work
+            </button>
+            {showGuide && (
+              <div className="mt-2 rounded-lg border border-blue-200 bg-blue-50 p-4">
+                <div className="text-sm text-blue-800 space-y-2">
                   <ul className="space-y-1.5 text-blue-700">
                     <li><strong>Input files</strong> are mounted at <code className="bg-blue-100 px-1 rounded">/data/</code>. Select data mounts during launch to access pipeline outputs, uploads, and shared results for your project.</li>
                     <li><strong>Output files</strong> should be saved to <code className="bg-blue-100 px-1 rounded">/outputs/</code>. Everything in this directory is automatically synced to GCS and registered when you stop the node.</li>
@@ -241,19 +244,9 @@ export default function WorkNodesPage() {
                     <li><strong>Machine types</strong> range from standard (4 CPU) to high-memory (128 GB) and GPU. Choose based on your workload.</li>
                   </ul>
                 </div>
-                <button
-                  onClick={() => {
-                    setShowGuide(false);
-                    localStorage.setItem("bioaf_worknodes_guide_dismissed", "true");
-                  }}
-                  className="shrink-0 text-blue-600 hover:text-blue-900 text-lg leading-none"
-                  aria-label="Dismiss guide"
-                >
-                  &times;
-                </button>
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {/* Node list */}
           {nodes.length === 0 ? (

--- a/frontend/src/components/provenance/ProvenanceReportPanel.tsx
+++ b/frontend/src/components/provenance/ProvenanceReportPanel.tsx
@@ -80,12 +80,13 @@ export function ProvenanceReportPanel({ entityType, entityId, entityName }: Prov
 
         for (const [key, val] of Object.entries(entity)) {
           if (val == null || val === "") continue;
+          // Skip source -- rendered separately below
+          if (key === "source") continue;
 
           if (Array.isArray(val)) {
             const label = key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
             collectionLines.push(`- **${label}:** ${val.length} item${val.length !== 1 ? "s" : ""}`);
           } else if (typeof val === "object") {
-            // Objects: user refs show name/email, nested file groups show counts
             const obj = val as Record<string, unknown>;
             if (obj.email) {
               scalarLines.push(`- **${key}:** ${obj.name || obj.email}`);
@@ -94,7 +95,6 @@ export function ProvenanceReportPanel({ entityType, entityId, entityName }: Prov
               const resCount = Array.isArray(obj.results) ? obj.results.length : 0;
               collectionLines.push(`- **Files:** ${rawCount} raw, ${resCount} results`);
             } else if (obj.files !== undefined || obj.samples !== undefined) {
-              // inputs/outputs groupings
               for (const [subKey, subVal] of Object.entries(obj)) {
                 if (Array.isArray(subVal)) {
                   const label = subKey.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
@@ -112,6 +112,56 @@ export function ProvenanceReportPanel({ entityType, entityId, entityName }: Prov
           lines.push(...scalarLines);
           lines.push("");
         }
+
+        // Render source section for artifacts
+        const source = entity.source as Record<string, unknown> | undefined;
+        if (source) {
+          const sourceType = source.type as string;
+          lines.push("## Source");
+          lines.push(`- **Source Type:** ${sourceType}`);
+
+          const ns = source.notebook_session as Record<string, unknown> | undefined;
+          if (ns) {
+            lines.push(`- **Session ID:** ${ns.id}`);
+            lines.push(`- **Session Type:** ${ns.session_type}`);
+            lines.push(`- **Status:** ${ns.status}`);
+            lines.push(`- **Resources:** ${ns.cpu_cores} CPU, ${ns.memory_gb} GB`);
+            if (ns.started_at) lines.push(`- **Started:** ${ns.started_at}`);
+            if (ns.stopped_at) lines.push(`- **Stopped:** ${ns.stopped_at}`);
+            if (ns.git_branch_name) lines.push(`- **Git Branch:** ${ns.git_branch_name}`);
+            if (ns.git_commit_hash) lines.push(`- **Git Commit:** ${ns.git_commit_hash}`);
+
+            const env = ns.environment as Record<string, unknown> | undefined;
+            if (env) {
+              lines.push("");
+              lines.push("### Environment");
+              lines.push(`- **Name:** ${env.environment_name}`);
+              lines.push(`- **Version:** v${env.version_number}.${env.build_number}`);
+              lines.push(`- **Format:** ${env.definition_format}`);
+              if (env.image_uri) lines.push(`- **Image:** ${env.image_uri}`);
+            }
+
+            const inputFiles = ns.input_files as Array<Record<string, unknown>> | undefined;
+            if (inputFiles && inputFiles.length > 0) {
+              lines.push("");
+              lines.push(`### Input Files (${inputFiles.length})`);
+              for (const f of inputFiles) {
+                lines.push(`- ${f.filename} (${f.file_type})`);
+              }
+            }
+          }
+
+          const pr = source.pipeline_run as Record<string, unknown> | undefined;
+          if (pr) {
+            lines.push(`- **Pipeline:** ${pr.pipeline_name}`);
+            if (pr.pipeline_version) lines.push(`- **Version:** ${pr.pipeline_version}`);
+            lines.push(`- **Run ID:** ${pr.id}`);
+            lines.push(`- **Status:** ${pr.status}`);
+          }
+
+          lines.push("");
+        }
+
         if (collectionLines.length > 0) {
           lines.push("## Related Data");
           lines.push(...collectionLines);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -546,6 +546,7 @@ export interface NotebookSession {
   created_at: string;
   git_branch_name: string | null;
   git_commit_hash: string | null;
+  environment_version_id: number | null;
 }
 
 export interface SessionListResponse {
@@ -559,6 +560,42 @@ export interface SessionLaunchRequest {
   experiment_id?: number | null;
   image_uri?: string | null;
   input_file_ids?: number[];
+  environment_version_id?: number | null;
+}
+
+export interface SessionProvenance {
+  session_id: number;
+  session_type: string;
+  status: string;
+  user: UserSummary | null;
+  project_id: number | null;
+  experiment_id: number | null;
+  environment: {
+    environment_id: number;
+    environment_name: string;
+    version_id: number;
+    version_number: number;
+    build_number: number;
+    image_uri: string | null;
+    definition_format: string;
+  } | null;
+  input_files: {
+    id: number;
+    filename: string;
+    gcs_uri: string;
+    file_type: string;
+    size_bytes: number | null;
+  }[];
+  output_files: {
+    id: number;
+    filename: string;
+    gcs_uri: string;
+    file_type: string;
+    size_bytes: number | null;
+  }[];
+  gcs_output_prefix: string | null;
+  started_at: string | null;
+  stopped_at: string | null;
 }
 
 export interface UserQuota {
@@ -1046,6 +1083,7 @@ export interface InstalledPackage {
 export interface EnvironmentVersionSummary {
   id: number;
   version_number: number;
+  build_number: number;
   status: "draft" | "building" | "ready" | "failed";
   definition_format: "dockerfile" | "conda";
   image_uri: string | null;


### PR DESCRIPTION
## Summary

- Fix GCS bucket mounting for notebook and SSH sessions (working bucket config, FUSE annotation, SA key secret mount, gcloud auth activation)
- Add GCS sync sidecar container for reliable output persistence at shutdown
- Implement notebook file lifecycle (ADR-040): hierarchical input file mounting, /outputs/ directory, script capture, output registration with provenance
- Two-phase output persistence: working bucket during session, move to results bucket on close
- Environment build versioning (ADR-041): build_number on EnvironmentVersion, rebuild endpoint, v{version}.{build} image tags
- Link environment_version_id to notebook session launches
- Session provenance endpoint and full provenance reporting for notebook outputs
- Frontend: shutdown sync indicator, environment version picker, provenance display in session detail modal and preview panel

## Test plan

- [x] Backend: 1613 tests passing
- [x] Frontend: 392 tests passing, tsc clean
- [x] Ruff format, ruff check, mypy: all clean
- [x] Markdownlint: all clean
- [x] Manual testing: GCS mount, file sync on shutdown, output persistence, provenance PDF generation