### PR TITLE
Replace release workflow with version-based tag and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,46 +2,61 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   release:
-    name: Build & Publish Release
+    name: Tag & Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
-      - name: Extract version from tag
+      - name: Read version from pyproject.toml
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=$(grep '^version' backend/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "TAG=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
-            ghcr.io/${{ github.repository }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.VERSION }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag v${{ steps.version.outputs.VERSION }} already exists, skipping release"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
+      - name: Extract release notes
+        if: steps.check_tag.outputs.exists == 'false'
+        id: notes
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          # Extract everything between "## vX.Y.Z" and the next "## v" heading
+          NOTES=$(awk "BEGIN{p=0} /^## ${TAG}/{p=1; next} /^## v[0-9]/{p=0} p" RELEASE_NOTES.md)
+          if [ -z "$NOTES" ]; then
+            echo "No release notes found for $TAG in RELEASE_NOTES.md"
+            NOTES="Release $TAG"
+          fi
+          echo "$NOTES" > /tmp/release_notes.txt
+          echo "Found release notes for $TAG"
+
+      - name: Create tag and release
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release_notes.txt

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,56 @@
+# Release Notes
+
+## v0.5.0
+
+Notebook file lifecycle and environment build versioning.
+This release introduces a complete file lifecycle for notebook and SSH sessions, fixing GCS storage mounting and adding structured input/output management with full provenance tracking.
+
+### GCS Storage Fixes
+
+- Fix GCS bucket mounting for notebook and SSH sessions: working bucket config, FUSE CSI annotation, SA key secret mount, and gcloud auth activation for Workload Identity environments
+- Fix Workload Identity annotation not applied after namespace was cached
+- Add gcs-sync sidecar container for reliable output persistence at shutdown
+
+### Notebook File Lifecycle (ADR-040)
+
+- Input files now mount with directory structure preserved: `/data/{project}/{experiment}/{sample}/{tool}/filename`
+- Designated `/outputs/` directory on all session types (Jupyter, RStudio, SSH) for persistent analysis outputs
+- On shutdown: outputs synced to GCS, notebook/script files (.ipynb, .Rmd, .R, .py) captured automatically
+- Two-phase output persistence: working bucket during session, moved to results bucket on close
+- Output files registered with full provenance (source_type=notebook_output, linked to project/experiment)
+- 30-minute shutdown timeout for large file sync with UI status indicator
+- Fix FILE_INVENTORY.md shell escaping that broke init container file copying partway through
+
+### Environment Build Versioning (ADR-041)
+
+- Rebuilding an environment version creates a minor version (v1 rebuild produces v1.1) instead of overwriting the image
+- New `build_number` column on EnvironmentVersion with unique constraint
+- Image tags use `v{version}.{build}` format (e.g., `v1.1`, `v1.2`)
+- New rebuild endpoint: `POST /environments/{id}/versions/{vid}/rebuild`
+- Notebook sessions now link to `environment_version_id` for traceability
+
+### Provenance
+
+- Session provenance endpoint: `GET /notebooks/sessions/{id}/provenance`
+- Provenance reports for notebook outputs now include environment version, input files, session resources, and git info
+- Markdown and PDF renderers display full source section for notebook and pipeline outputs
+- Provenance preview panel displays inline source details instead of skipping nested data
+
+### Frontend
+
+- Shutdown sync indicator: spinner with "Syncing outputs to GCS..." while session stops
+- Environment version picker shows `v{version}.{build}` format and passes `environment_version_id` in launch request
+- Session detail modal shows environment version and provenance for stopped sessions
+- Toggleable quick start guide on Notebooks and Work Nodes pages explaining `/data/`, `/outputs/`, environments, git, and credentials
+
+### Schema Changes
+
+- Migration 057: adds `build_number` to `environment_versions`, `gcs_output_prefix` to `compute_sessions`
+
+## v0.4.1
+
+Fix cellxgene adapter, image pipeline, and publish UX (#195)
+
+## v0.4.0
+
+Usability: real backups, service health, version checking (#194)


### PR DESCRIPTION
## Summary

- Replace Docker image build release workflow with automated tag and release from RELEASE_NOTES.md
- Workflow triggers on push to main, reads version from backend/pyproject.toml
- Skips if tag already exists (no duplicates on non-version-bump merges)
- Extracts matching section from RELEASE_NOTES.md for release body
- Add RELEASE_NOTES.md with v0.5.0, v0.4.1, v0.4.0 entries

## Test plan

- [x] Verified awk extraction produces correct section locally
- [x] Existing v0.5.0 tag will cause workflow to skip on first merge (no duplicate)
- [x] Markdownlint clean on RELEASE_NOTES.md