### PR TITLE
Fix database restore URL parsing and backup page confirm dialogs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v0.5.4
+
+Bug fix for database restore and UI cleanup on the Backup & Recovery page.
+
+- Fix `_build_restore_url()` mangling database credentials when the PostgreSQL username contains "bioaf" (caused auth failures after restore swap)
+- Replace browser `confirm()` dialogs with in-app ConfirmDialog on all backup restore/accept/reject actions
+
 ## v0.5.3
 
 Setup wizard overhaul and installer improvements.

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -665,7 +665,9 @@ _restore_state: dict = {
 
 def _build_restore_url() -> str:
     """Build a SQLAlchemy async URL pointing at bioaf_restore."""
-    return settings.database_url.replace("/bioaf", "/bioaf_restore")
+    parsed = urlparse(settings.database_url)
+    new_path = parsed.path.rstrip("/") + "_restore"
+    return parsed._replace(path=new_path).geturl()
 
 
 async def _run_admin_sql(statements: list[str]) -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.5.3"
+version = "0.5.4"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -278,6 +278,43 @@ async def test_restore_forbidden_for_viewer(client: AsyncClient, viewer_token: s
     assert response.status_code == 403
 
 
+# --- _build_restore_url tests ---
+
+
+def test_build_restore_url_only_replaces_database_name():
+    """_build_restore_url must change only the database path, not the username."""
+    from app.services.backup_service import _build_restore_url
+
+    # Production-style URL where username matches database name
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.database_url = "postgresql+asyncpg://bioaf:secretpass@db:5432/bioaf"
+        result = _build_restore_url()
+
+    assert result == "postgresql+asyncpg://bioaf:secretpass@db:5432/bioaf_restore"
+
+
+def test_build_restore_url_preserves_dev_username():
+    """_build_restore_url must not mangle usernames containing 'bioaf'."""
+    from app.services.backup_service import _build_restore_url
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.database_url = "postgresql+asyncpg://bioaf_app:devpassword@postgres:5432/bioaf"
+        result = _build_restore_url()
+
+    assert result == "postgresql+asyncpg://bioaf_app:devpassword@postgres:5432/bioaf_restore"
+
+
+def test_build_restore_url_preserves_password_containing_bioaf():
+    """_build_restore_url must not mangle passwords that happen to contain 'bioaf'."""
+    from app.services.backup_service import _build_restore_url
+
+    with patch("app.services.backup_service.settings") as mock_settings:
+        mock_settings.database_url = "postgresql+asyncpg://user:bioaf_pass@db:5432/bioaf"
+        result = _build_restore_url()
+
+    assert result == "postgresql+asyncpg://user:bioaf_pass@db:5432/bioaf_restore"
+
+
 # --- GCS backup status tests ---
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/infrastructure/backup/page.tsx
+++ b/frontend/src/app/infrastructure/backup/page.tsx
@@ -7,6 +7,7 @@ import { Header } from "@/components/layout/Header";
 import { isAuthenticated } from "@/lib/auth";
 import { usePermissions } from "@/hooks/usePermissions";
 import { api } from "@/lib/api";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 
 interface BackupTier {
   tier: string;
@@ -90,6 +91,14 @@ export default function InfraBackupPage() {
   const [runningAction, setRunningAction] = useState("");
   const [savingSettings, setSavingSettings] = useState(false);
   const [restoringFile, setRestoringFile] = useState("");
+  const [confirmDialog, setConfirmDialog] = useState<{
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel: string;
+    variant: "danger" | "default";
+    onConfirm: () => void;
+  }>({ open: false, title: "", message: "", confirmLabel: "Confirm", variant: "default", onConfirm: () => {} });
   const pollRef = useRef<NodeJS.Timeout | null>(null);
 
   const loadData = useCallback(async () => {
@@ -141,17 +150,26 @@ export default function InfraBackupPage() {
     }
   }, [restoreStatus.active, loadData]);
 
-  const handleConfigRestore = async () => {
-    if (!confirm("Are you sure you want to initiate a config restore?")) return;
-    try {
-      const data = await api.post<{ status: string; message: string }>(
-        "/api/backups/restore/config",
-        { confirmation_token: "CONFIRM" }
-      );
-      setActionMessage(data.message);
-    } catch (e) {
-      setActionMessage(e instanceof Error ? e.message : "Restore failed");
-    }
+  const handleConfigRestore = () => {
+    setConfirmDialog({
+      open: true,
+      title: "Restore Configuration",
+      message: "Are you sure you want to initiate a config restore?",
+      confirmLabel: "Restore",
+      variant: "danger",
+      onConfirm: async () => {
+        setConfirmDialog((prev) => ({ ...prev, open: false }));
+        try {
+          const data = await api.post<{ status: string; message: string }>(
+            "/api/backups/restore/config",
+            { confirmation_token: "CONFIRM" }
+          );
+          setActionMessage(data.message);
+        } catch (e) {
+          setActionMessage(e instanceof Error ? e.message : "Restore failed");
+        }
+      },
+    });
   };
 
   const handleTriggerBackup = async (type: "postgres" | "config") => {
@@ -171,49 +189,75 @@ export default function InfraBackupPage() {
     }
   };
 
-  const handleStartRestore = async (filename: string) => {
-    const msg = `This will restore the database from "${filename}". The current database will remain available as a fallback. You will have 1 hour to review the restored data before accepting or rejecting.\n\nProceed?`;
-    if (!confirm(msg)) return;
-    setRestoringFile(filename);
-    setActionMessage("");
-    try {
-      const data = await api.post<{ status: string; message: string }>(
-        "/api/backups/restore/postgres",
-        { filename }
-      );
-      setActionMessage(data.message);
-      await loadData();
-    } catch (e) {
-      setActionMessage(e instanceof Error ? e.message : "Restore failed");
-    } finally {
-      setRestoringFile("");
-    }
+  const handleStartRestore = (filename: string) => {
+    setConfirmDialog({
+      open: true,
+      title: "Restore Database",
+      message: `This will restore the database from "${filename}". The current database will remain available as a fallback. You will have 1 hour to review the restored data before accepting or rejecting.`,
+      confirmLabel: "Restore",
+      variant: "danger",
+      onConfirm: async () => {
+        setConfirmDialog((prev) => ({ ...prev, open: false }));
+        setRestoringFile(filename);
+        setActionMessage("");
+        try {
+          const data = await api.post<{ status: string; message: string }>(
+            "/api/backups/restore/postgres",
+            { filename }
+          );
+          setActionMessage(data.message);
+          await loadData();
+        } catch (e) {
+          setActionMessage(e instanceof Error ? e.message : "Restore failed");
+        } finally {
+          setRestoringFile("");
+        }
+      },
+    });
   };
 
-  const handleAcceptRestore = async () => {
-    if (!confirm("Accept this restored database? This will permanently replace the previous database. This cannot be undone.")) return;
-    setActionMessage("");
-    try {
-      const data = await api.post<{ status: string; message: string }>("/api/backups/restore/accept", {});
-      setActionMessage(data.message);
-      setRestoreStatus({ active: false });
-      await loadData();
-    } catch (e) {
-      setActionMessage(e instanceof Error ? e.message : "Accept failed");
-    }
+  const handleAcceptRestore = () => {
+    setConfirmDialog({
+      open: true,
+      title: "Accept Restored Database",
+      message: "This will permanently replace the previous database. This cannot be undone.",
+      confirmLabel: "Accept",
+      variant: "danger",
+      onConfirm: async () => {
+        setConfirmDialog((prev) => ({ ...prev, open: false }));
+        setActionMessage("");
+        try {
+          const data = await api.post<{ status: string; message: string }>("/api/backups/restore/accept", {});
+          setActionMessage(data.message);
+          setRestoreStatus({ active: false });
+          await loadData();
+        } catch (e) {
+          setActionMessage(e instanceof Error ? e.message : "Accept failed");
+        }
+      },
+    });
   };
 
-  const handleRejectRestore = async () => {
-    if (!confirm("Reject this restore and revert to the original database?")) return;
-    setActionMessage("");
-    try {
-      const data = await api.post<{ status: string; message: string }>("/api/backups/restore/reject", {});
-      setActionMessage(data.message);
-      setRestoreStatus({ active: false });
-      await loadData();
-    } catch (e) {
-      setActionMessage(e instanceof Error ? e.message : "Reject failed");
-    }
+  const handleRejectRestore = () => {
+    setConfirmDialog({
+      open: true,
+      title: "Reject Restore",
+      message: "Reject this restore and revert to the original database?",
+      confirmLabel: "Reject",
+      variant: "default",
+      onConfirm: async () => {
+        setConfirmDialog((prev) => ({ ...prev, open: false }));
+        setActionMessage("");
+        try {
+          const data = await api.post<{ status: string; message: string }>("/api/backups/restore/reject", {});
+          setActionMessage(data.message);
+          setRestoreStatus({ active: false });
+          await loadData();
+        } catch (e) {
+          setActionMessage(e instanceof Error ? e.message : "Reject failed");
+        }
+      },
+    });
   };
 
   const handleDownloadTfstate = (filename: string) => {
@@ -558,6 +602,15 @@ export default function InfraBackupPage() {
           )}
         </main>
       </div>
+      <ConfirmDialog
+        open={confirmDialog.open}
+        title={confirmDialog.title}
+        message={confirmDialog.message}
+        confirmLabel={confirmDialog.confirmLabel}
+        variant={confirmDialog.variant}
+        onConfirm={confirmDialog.onConfirm}
+        onCancel={() => setConfirmDialog((prev) => ({ ...prev, open: false }))}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Fix `_build_restore_url()` using naive `.replace("/bioaf", "/bioaf_restore")` which mangled the PostgreSQL username when it contained "bioaf", causing authentication failures after a restore swap
- Replace browser `confirm()` dialogs with the existing `ConfirmDialog` component on the Backup & Recovery page for consistent in-app styling

## Test plan

- [x] 3 new unit tests for `_build_restore_url()` covering production URL, dev URL, and password-containing-bioaf edge case
- [x] All 1693 backend tests pass
- [x] All 406 frontend tests pass
- [x] ruff format, ruff check, mypy, tsc, markdownlint all clean