### PR TITLE
Store pipeline run cost estimates from compute adapter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.6.1
+
+Pipeline run cost estimates based on actual GCP instance pricing.
+
+### Cost Estimates
+
+- Store cost estimate from compute adapter when launching a pipeline run (closes #203)
+- Replace flat-fee stub with actual hourly spot rate for the pipeline node pool (n2-highmem-16)
+- UI column renamed from "Cost" to "Est. $/hr" to clarify that values are hourly node rates, not totals
+
 ## v0.6.0
 
 Automatic pipeline runs triggered by sample completeness, manifest reconciliation fixes, pipeline execution fixes, and UI cleanup.

--- a/backend/app/adapters/compute/kubernetes.py
+++ b/backend/app/adapters/compute/kubernetes.py
@@ -110,15 +110,27 @@ class KubernetesComputeProvider(ComputeProvider):
         return await self._k8s_get_cluster_metrics()
 
     async def get_cost_estimate(self, job_spec: dict) -> dict:
+        # Look up the pipeline node pool's machine type and spot flag
+        status = self._local_cluster_status()
+        pool = next(
+            (p for p in status.get("node_pools", []) if p["name"] == "bioaf-pipelines"),
+            {"machine_type": "n2-standard-4", "spot": False},
+        )
+        machine_type = pool["machine_type"]
+        is_spot = pool.get("spot", False)
+        hourly_rate = self._hourly_rate(machine_type, is_spot)
+
+        # Estimate duration: 1h base + 15min per input file
         input_count = len(job_spec.get("input_files", []))
-        base_cost = 0.50
-        estimated = base_cost + (input_count * 0.10)
+        estimated_hours = 1.0 + input_count * 0.25
+
+        estimated = round(hourly_rate * estimated_hours, 2)
         return {
-            "estimated_cost_usd": round(estimated, 2),
-            "confidence_low": round(estimated * 0.7, 2),
-            "confidence_high": round(estimated * 1.5, 2),
+            "estimated_cost_usd": estimated,
+            "confidence_low": round(estimated * 0.5, 2),
+            "confidence_high": round(estimated * 2.0, 2),
             "currency": "USD",
-            "basis": "input file count heuristic",
+            "basis": f"{machine_type} {'spot' if is_spot else 'on-demand'}, {estimated_hours:.1f}h estimated",
         }
 
     async def get_job_report(self, job_id: str) -> str:

--- a/backend/app/adapters/compute/kubernetes.py
+++ b/backend/app/adapters/compute/kubernetes.py
@@ -110,7 +110,11 @@ class KubernetesComputeProvider(ComputeProvider):
         return await self._k8s_get_cluster_metrics()
 
     async def get_cost_estimate(self, job_spec: dict) -> dict:
-        # Look up the pipeline node pool's machine type and spot flag
+        # Return the hourly node rate for the pipeline pool so the UI
+        # can show $/hr and let the user reason about total cost from
+        # the run duration.  Trying to predict total cost is unreliable
+        # because actual cost depends on node uptime (autoscaler cooldown),
+        # spot preemptions, and shared tenancy.
         status = self._local_cluster_status()
         pool = next(
             (p for p in status.get("node_pools", []) if p["name"] == "bioaf-pipelines"),
@@ -120,17 +124,10 @@ class KubernetesComputeProvider(ComputeProvider):
         is_spot = pool.get("spot", False)
         hourly_rate = self._hourly_rate(machine_type, is_spot)
 
-        # Estimate duration: 1h base + 15min per input file
-        input_count = len(job_spec.get("input_files", []))
-        estimated_hours = 1.0 + input_count * 0.25
-
-        estimated = round(hourly_rate * estimated_hours, 2)
         return {
-            "estimated_cost_usd": estimated,
-            "confidence_low": round(estimated * 0.5, 2),
-            "confidence_high": round(estimated * 2.0, 2),
+            "estimated_cost_usd": hourly_rate,
             "currency": "USD",
-            "basis": f"{machine_type} {'spot' if is_spot else 'on-demand'}, {estimated_hours:.1f}h estimated",
+            "basis": f"{machine_type} {'spot' if is_spot else 'on-demand'} $/hr",
         }
 
     async def get_job_report(self, job_id: str) -> str:

--- a/backend/app/services/pipeline_run_service.py
+++ b/backend/app/services/pipeline_run_service.py
@@ -180,6 +180,10 @@ class PipelineRunService:
             run.k8s_job_name = job_result.get("job_id", "")
             run.k8s_namespace = job_result.get("namespace", "")
 
+            estimated_cost = job_result.get("estimated_cost", {})
+            if estimated_cost:
+                run.cost_estimate = estimated_cost.get("estimated_cost_usd")
+
         except Exception as e:
             run.status = "failed"
             run.error_message = str(e)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.6.0"
+version = "0.6.1"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_k8s_compute_adapter.py
+++ b/backend/tests/test_k8s_compute_adapter.py
@@ -117,33 +117,24 @@ class TestKubernetesComputeClusterMetrics:
 
 class TestKubernetesComputeCostEstimate:
     @pytest.mark.asyncio
-    async def test_cost_estimate_uses_instance_pricing(self, adapter):
-        """Cost estimate should use actual machine type and spot pricing."""
+    async def test_cost_estimate_returns_hourly_rate(self, adapter):
+        """Cost estimate should return the pipeline pool's hourly node rate."""
         result = await adapter.get_cost_estimate({})
-        assert "n2-highmem-16" in result["basis"]
-        assert "spot" in result["basis"]
+        # n2-highmem-16 on-demand $1.0482/hr * 0.35 spot = ~$0.3669/hr
+        assert result["estimated_cost_usd"] == 0.3669
         assert result["currency"] == "USD"
 
     @pytest.mark.asyncio
-    async def test_cost_estimate_base_reflects_hourly_rate(self, adapter):
-        """With no input files, estimate should be ~1h of spot n2-highmem-16."""
+    async def test_cost_estimate_basis_describes_node(self, adapter):
+        """Basis string should identify the machine type and pricing tier."""
         result = await adapter.get_cost_estimate({})
-        # n2-highmem-16 on-demand $1.0482/hr * 0.35 spot = ~$0.37/hr
-        # 1h base duration -> ~$0.37
-        assert result["estimated_cost_usd"] >= 0.30
-        assert result["estimated_cost_usd"] <= 0.50
+        assert "n2-highmem-16" in result["basis"]
+        assert "spot" in result["basis"]
+        assert "$/hr" in result["basis"]
 
     @pytest.mark.asyncio
-    async def test_cost_estimate_scales_with_files(self, adapter):
-        """More input files should increase estimated duration and cost."""
+    async def test_cost_estimate_same_regardless_of_input_count(self, adapter):
+        """Hourly rate doesn't change with input file count."""
         result_0 = await adapter.get_cost_estimate({})
         result_5 = await adapter.get_cost_estimate({"input_files": ["a", "b", "c", "d", "e"]})
-        assert result_5["estimated_cost_usd"] > result_0["estimated_cost_usd"]
-
-    @pytest.mark.asyncio
-    async def test_cost_estimate_has_confidence_interval(self, adapter):
-        result = await adapter.get_cost_estimate({"input_files": ["a"]})
-        assert "confidence_low" in result
-        assert "confidence_high" in result
-        assert result["confidence_low"] <= result["estimated_cost_usd"]
-        assert result["confidence_high"] >= result["estimated_cost_usd"]
+        assert result_0["estimated_cost_usd"] == result_5["estimated_cost_usd"]

--- a/backend/tests/test_k8s_compute_adapter.py
+++ b/backend/tests/test_k8s_compute_adapter.py
@@ -117,17 +117,28 @@ class TestKubernetesComputeClusterMetrics:
 
 class TestKubernetesComputeCostEstimate:
     @pytest.mark.asyncio
-    async def test_cost_estimate_with_no_files(self, adapter):
+    async def test_cost_estimate_uses_instance_pricing(self, adapter):
+        """Cost estimate should use actual machine type and spot pricing."""
         result = await adapter.get_cost_estimate({})
-        assert result["estimated_cost_usd"] == 0.50
-        assert result["confidence_low"] < result["estimated_cost_usd"]
-        assert result["confidence_high"] > result["estimated_cost_usd"]
+        assert "n2-highmem-16" in result["basis"]
+        assert "spot" in result["basis"]
         assert result["currency"] == "USD"
 
     @pytest.mark.asyncio
+    async def test_cost_estimate_base_reflects_hourly_rate(self, adapter):
+        """With no input files, estimate should be ~1h of spot n2-highmem-16."""
+        result = await adapter.get_cost_estimate({})
+        # n2-highmem-16 on-demand $1.0482/hr * 0.35 spot = ~$0.37/hr
+        # 1h base duration -> ~$0.37
+        assert result["estimated_cost_usd"] >= 0.30
+        assert result["estimated_cost_usd"] <= 0.50
+
+    @pytest.mark.asyncio
     async def test_cost_estimate_scales_with_files(self, adapter):
-        result = await adapter.get_cost_estimate({"input_files": ["a", "b", "c", "d", "e"]})
-        assert result["estimated_cost_usd"] == 1.0  # 0.50 + 5 * 0.10
+        """More input files should increase estimated duration and cost."""
+        result_0 = await adapter.get_cost_estimate({})
+        result_5 = await adapter.get_cost_estimate({"input_files": ["a", "b", "c", "d", "e"]})
+        assert result_5["estimated_cost_usd"] > result_0["estimated_cost_usd"]
 
     @pytest.mark.asyncio
     async def test_cost_estimate_has_confidence_interval(self, adapter):

--- a/backend/tests/test_pipeline_launcher.py
+++ b/backend/tests/test_pipeline_launcher.py
@@ -163,3 +163,23 @@ class TestSubmitWritesAuditLog:
         assert row[0] == "launch"
         assert row[1] == "pipeline_run"
         assert row[2] == run.id
+
+
+class TestSubmitStoresCostEstimate:
+    @pytest.mark.asyncio
+    async def test_stores_cost_estimate_from_adapter(self, session, setup_data):
+        """launch_run should store the adapter's estimated_cost on the run."""
+        data = setup_data
+        request = PipelineRunLaunchRequest(
+            pipeline_key="bioaf-system-test",
+            experiment_id=data["experiment"].id,
+        )
+
+        run = await PipelineRunService.launch_run(
+            session, data["org"].id, data["user"].id, request
+        )
+        await session.commit()
+
+        assert run.cost_estimate is not None
+        # Base cost $0.50 + 1 sample * $0.10 = $0.60
+        assert float(run.cost_estimate) == 0.60

--- a/backend/tests/test_pipeline_launcher.py
+++ b/backend/tests/test_pipeline_launcher.py
@@ -181,5 +181,5 @@ class TestSubmitStoresCostEstimate:
         await session.commit()
 
         assert run.cost_estimate is not None
-        # Base cost $0.50 + 1 sample * $0.10 = $0.60
-        assert float(run.cost_estimate) == 0.60
+        # n2-highmem-16 spot ~$0.37/hr * 1.25h (1h base + 1 sample) = $0.46
+        assert float(run.cost_estimate) == 0.46

--- a/backend/tests/test_pipeline_launcher.py
+++ b/backend/tests/test_pipeline_launcher.py
@@ -181,5 +181,5 @@ class TestSubmitStoresCostEstimate:
         await session.commit()
 
         assert run.cost_estimate is not None
-        # n2-highmem-16 spot ~$0.37/hr * 1.25h (1h base + 1 sample) = $0.46
-        assert float(run.cost_estimate) == 0.46
+        # Stores the pipeline pool's hourly node rate (n2-highmem-16 spot)
+        assert float(run.cost_estimate) == 0.3669

--- a/backend/tests/test_pipeline_launcher.py
+++ b/backend/tests/test_pipeline_launcher.py
@@ -175,9 +175,7 @@ class TestSubmitStoresCostEstimate:
             experiment_id=data["experiment"].id,
         )
 
-        run = await PipelineRunService.launch_run(
-            session, data["org"].id, data["user"].id, request
-        )
+        run = await PipelineRunService.launch_run(session, data["org"].id, data["user"].id, request)
         await session.commit()
 
         assert run.cost_estimate is not None

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/pipelines/runs/page.tsx
+++ b/frontend/src/app/pipelines/runs/page.tsx
@@ -116,7 +116,7 @@ export default function PipelineRunsPage() {
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Submitter</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Started</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Duration</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Cost</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Est. $/hr</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
@@ -144,7 +144,7 @@ export default function PipelineRunsPage() {
                     <td className="px-4 py-3 text-sm">{r.submitted_by?.name || r.submitted_by?.email || "—"}</td>
                     <td className="px-4 py-3 text-sm text-gray-500">{formatDateTime(r.started_at)}</td>
                     <td className="px-4 py-3 text-sm text-gray-500">{formatDuration(r.started_at, r.completed_at)}</td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{r.cost_estimate ? `$${r.cost_estimate.toFixed(2)}` : "—"}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{r.cost_estimate ? `$${r.cost_estimate.toFixed(2)}/hr` : "—"}</td>
                   </tr>
                 ))}
                 {runs.length === 0 && (

--- a/frontend/src/app/pipelines/triggers/page.tsx
+++ b/frontend/src/app/pipelines/triggers/page.tsx
@@ -362,7 +362,7 @@ export default function PipelineTriggersPage() {
                         <span className="text-sm text-gray-500 ml-2">Run #{run.id}</span>
                         {run.cost_estimate && (
                           <span className="ml-2 text-sm text-orange-600">
-                            Est. ${Number(run.cost_estimate).toFixed(2)}
+                            ~${Number(run.cost_estimate).toFixed(2)}/hr
                           </span>
                         )}
                       </div>


### PR DESCRIPTION
## Summary

- Store the cost estimate returned by the compute adapter onto `pipeline_runs.cost_estimate` during `launch_run()` (closes #203)
- Replace the flat-fee stub (`$0.50 + $0.10/file`) in `get_cost_estimate()` with the pipeline node pool's actual hourly spot rate (`n2-highmem-16` at ~`$0.37/hr`)
- Rename UI column from "Cost" to "Est. $/hr" and format values with `/hr` suffix on both the pipeline runs list and triggers page

## Test plan

- [ ] Launch a pipeline run and verify `cost_estimate` is populated in the database
- [ ] Confirm the pipeline runs table shows "Est. $/hr" column with `$0.37/hr` values
- [ ] Confirm the triggers page shows `~$0.37/hr` next to triggered runs
- [ ] Verify past runs with NULL cost_estimate still show "--"