### PR TITLE
v0.6.2: Audit log coverage and activity feed fixes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## v0.6.2
+
+Audit log coverage gaps and activity feed event fixes.
+
+### Audit Log Coverage (closes #153)
+
+- Add logout endpoint (POST /api/auth/logout) with audit logging
+- Log failed login attempts with reason (invalid credentials, account deactivated)
+- Log file content serving as download audit entries
+- Change role update audit action from generic "update" to "role_change" with old/new role names
+- Log environment build success and failure from the build poller
+- Log postgres and config backup completion and failure
+- Log quota exceeded events alongside event bus emission
+- Log notebook session access (who opened which session)
+- Normalize download action name from "downloaded" to "download"
+- Update audit log page filters with new entity types and actions
+- Color-code new action badges (failures red, success green, warnings amber, role changes purple)
+
+### Activity Feed Fixes
+
+- Add PIPELINE_STARTED event type, emitted on successful run submission
+- Emit PIPELINE_COMPLETED and PIPELINE_FAILED from pipeline monitor completion handler (event types existed but were never fired)
+- Fix AUTO_RUN_BUDGET_DISABLED payload using wrong key ("organization_id" instead of "org_id"), silently dropped by NotificationRouter
+- Fix AUTO_RUN_LAUNCHED payload missing org_id, user_id, and all display fields
+- Frontend logout now calls backend endpoint so audit log entry is created
+
 ## v0.6.1
 
 Pipeline run cost estimates based on actual GCP instance pricing.

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -30,9 +30,27 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 async def login(body: LoginRequest, session: AsyncSession = Depends(get_session)):
     user = await UserService.get_by_email(session, body.email)
     if not user or not AuthService.verify_password(body.password, user.password_hash):
+        await log_action(
+            session,
+            user_id=user.id if user else None,
+            entity_type="auth",
+            entity_id=user.id if user else 0,
+            action="login_failed",
+            details={"email": body.email, "reason": "invalid_credentials"},
+        )
+        await session.commit()
         raise HTTPException(status_code=401, detail="Invalid email or password")
 
     if user.status == "deactivated":
+        await log_action(
+            session,
+            user_id=user.id,
+            entity_type="auth",
+            entity_id=user.id,
+            action="login_failed",
+            details={"email": body.email, "reason": "account_deactivated"},
+        )
+        await session.commit()
         raise HTTPException(status_code=403, detail="Account deactivated")
 
     if user.status == "invited":
@@ -56,6 +74,21 @@ async def login(body: LoginRequest, session: AsyncSession = Depends(get_session)
     await session.commit()
 
     return LoginResponse(access_token=token)
+
+
+@router.post("/logout")
+async def logout(request: Request, session: AsyncSession = Depends(get_session)):
+    current_user = request.state.current_user
+    user_id = int(current_user["sub"])
+    await log_action(
+        session,
+        user_id=user_id,
+        entity_type="auth",
+        entity_id=user_id,
+        action="logout",
+    )
+    await session.commit()
+    return {"message": "Logged out"}
 
 
 @router.post("/refresh", response_model=LoginResponse)

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -328,11 +328,12 @@ async def download_file(
         user_id=user_id,
         entity_type="file",
         entity_id=file.id,
-        action="downloaded",
+        action="download",
         details={
             "filename": file.filename,
             "file_type": file.file_type,
             "size_bytes": file.size_bytes,
+            "method": "signed_url",
         },
     )
     await session.commit()
@@ -349,12 +350,30 @@ async def file_content(
     """Serve file bytes directly (same-origin proxy for cross-origin GCS content)."""
     current_user = request.state.current_user
     org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
 
     file = await FileService.get_file(session, file_id, org_id)
     if not file:
         raise HTTPException(404, "File not found")
     if file.storage_deleted:
         raise HTTPException(410, "File storage has been deleted")
+
+    from app.services.audit_service import log_action
+
+    await log_action(
+        session,
+        user_id=user_id,
+        entity_type="file",
+        entity_id=file.id,
+        action="download",
+        details={
+            "filename": file.filename,
+            "file_type": file.file_type,
+            "size_bytes": file.size_bytes,
+            "method": "content",
+        },
+    )
+    await session.commit()
 
     try:
         from google.cloud import storage as gcs_storage

--- a/backend/app/api/notebook_sessions.py
+++ b/backend/app/api/notebook_sessions.py
@@ -308,6 +308,23 @@ async def get_session_detail(
     notebook_session = await NotebookService.get_session(session, session_id)
     if not notebook_session:
         raise HTTPException(404, "Session not found")
+
+    from app.services.audit_service import log_action
+
+    user_id = int(current_user["sub"])
+    await log_action(
+        session,
+        user_id=user_id,
+        entity_type="notebook",
+        entity_id=notebook_session.id,
+        action="session_access",
+        details={
+            "session_type": notebook_session.session_type,
+            "status": notebook_session.status,
+        },
+    )
+    await session.commit()
+
     return _session_response(notebook_session)
 
 

--- a/backend/app/services/auto_run_service.py
+++ b/backend/app/services/auto_run_service.py
@@ -312,10 +312,22 @@ class AutoRunService:
                     await event_bus.emit(
                         AUTO_RUN_BUDGET_DISABLED,
                         {
-                            "organization_id": org_id,
-                            "current_spend": float(current_spend),
-                            "monthly_budget": float(budget_config.monthly_budget),
-                            "cancelled_count": len(org_runs),
+                            "event_type": AUTO_RUN_BUDGET_DISABLED,
+                            "org_id": org_id,
+                            "entity_type": "auto_run",
+                            "title": "Auto-run disabled due to budget limit",
+                            "message": (
+                                f"Spend ${float(current_spend):.2f} reached 90% of "
+                                f"${float(budget_config.monthly_budget):.2f} budget. "
+                                f"{len(org_runs)} pending run(s) cancelled."
+                            ),
+                            "severity": "critical",
+                            "summary": f"Auto-run disabled: budget limit reached ({len(org_runs)} runs cancelled)",
+                            "metadata": {
+                                "current_spend": float(current_spend),
+                                "monthly_budget": float(budget_config.monthly_budget),
+                                "cancelled_count": len(org_runs),
+                            },
                         },
                     )
                     processed += len(org_runs)
@@ -356,10 +368,22 @@ class AutoRunService:
                     await event_bus.emit(
                         AUTO_RUN_LAUNCHED,
                         {
-                            "pipeline_run_id": run.id,
-                            "sample_id": pr.sample_id,
-                            "experiment_id": config.experiment_id,
-                            "pipeline_key": config.pipeline_key,
+                            "event_type": AUTO_RUN_LAUNCHED,
+                            "org_id": config.organization_id,
+                            "user_id": config.configured_by_user_id,
+                            "entity_type": "pipeline_run",
+                            "entity_id": run.id,
+                            "title": f"Auto-run launched: {config.pipeline_key}",
+                            "message": (
+                                f"Pipeline '{config.pipeline_key}' auto-launched for experiment {config.experiment_id}"
+                            ),
+                            "summary": f"Auto-run launched pipeline '{config.pipeline_key}' (run {run.id})",
+                            "metadata": {
+                                "pipeline_run_id": run.id,
+                                "sample_id": pr.sample_id,
+                                "experiment_id": config.experiment_id,
+                                "pipeline_key": config.pipeline_key,
+                            },
                         },
                     )
                 except Exception as exc:

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -17,6 +17,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.services.audit_service import log_action
 from app.services.event_bus import event_bus
 from app.services.event_types import BACKUP_FAILURE
 
@@ -454,6 +455,22 @@ class BackupService:
 
             duration = time.monotonic() - start
             logger.info("pg_dump completed: %s (%d bytes, %.1fs)", filename, size, duration)
+
+            await log_action(
+                session,
+                user_id=None,
+                entity_type="backup",
+                entity_id=0,
+                action="backup_completed",
+                details={
+                    "tier": "postgres",
+                    "filename": filename,
+                    "size_bytes": size,
+                    "duration_seconds": round(duration, 1),
+                },
+            )
+            await session.commit()
+
             return {
                 "status": "completed",
                 "filename": filename,
@@ -463,12 +480,30 @@ class BackupService:
 
         except FileNotFoundError:
             logger.error("pg_dump not found. Install postgresql-client in the container.")
+            await log_action(
+                session,
+                user_id=None,
+                entity_type="backup",
+                entity_id=0,
+                action="backup_failed",
+                details={"tier": "postgres", "reason": "pg_dump binary not found"},
+            )
+            await session.commit()
             return {"status": "error", "message": "pg_dump binary not found"}
         except Exception as e:
             logger.error("pg_dump backup failed: %s", e)
             # Clean up temp file on failure
             if os.path.exists(output_path):
                 os.remove(output_path)
+            await log_action(
+                session,
+                user_id=None,
+                entity_type="backup",
+                entity_id=0,
+                action="backup_failed",
+                details={"tier": "postgres", "reason": str(e)[:500]},
+            )
+            await session.commit()
             return {"status": "error", "message": str(e)[:500]}
 
     @staticmethod
@@ -561,12 +596,32 @@ class BackupService:
                 logger.info("Rotated %d old config backups", deleted)
 
             logger.info("Config backup completed: %s (%d bytes)", filename, size)
+
+            await log_action(
+                session,
+                user_id=None,
+                entity_type="backup",
+                entity_id=0,
+                action="backup_completed",
+                details={"tier": "platform_config", "filename": filename, "size_bytes": size},
+            )
+            await session.commit()
+
             return {"status": "completed", "filename": filename, "size_bytes": size}
 
         except Exception as e:
             logger.error("Config backup failed: %s", e)
             if os.path.exists(output_path):
                 os.remove(output_path)
+            await log_action(
+                session,
+                user_id=None,
+                entity_type="backup",
+                entity_id=0,
+                action="backup_failed",
+                details={"tier": "platform_config", "reason": str(e)[:500]},
+            )
+            await session.commit()
             return {"status": "error", "message": str(e)[:500]}
 
     @staticmethod

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -261,6 +261,17 @@ class EnvironmentBuildService:
                     version.build_id,
                     version.id,
                 )
+                await log_action(
+                    session,
+                    user_id=None,
+                    entity_type="environment_version",
+                    entity_id=version.id,
+                    action="build_succeeded",
+                    details={
+                        "build_id": version.build_id,
+                        "version_number": version.version_number,
+                    },
+                )
             elif status in ("FAILURE", "CANCELLED", "TIMEOUT"):
                 version.status = "failed"
                 changed += 1
@@ -269,6 +280,18 @@ class EnvironmentBuildService:
                     version.build_id,
                     status,
                     version.id,
+                )
+                await log_action(
+                    session,
+                    user_id=None,
+                    entity_type="environment_version",
+                    entity_id=version.id,
+                    action="build_failed",
+                    details={
+                        "build_id": version.build_id,
+                        "version_number": version.version_number,
+                        "cloud_build_status": status,
+                    },
                 )
 
         if changed:

--- a/backend/app/services/event_types.py
+++ b/backend/app/services/event_types.py
@@ -1,6 +1,7 @@
 """Event type string constants for the bioAF notification system."""
 
 # Pipeline events
+PIPELINE_STARTED = "pipeline.started"
 PIPELINE_COMPLETED = "pipeline.completed"
 PIPELINE_FAILED = "pipeline.failed"
 PIPELINE_STAGE_ERROR = "pipeline.stage_error"
@@ -88,6 +89,7 @@ AUTO_RUN_CANCELLED = "auto_run.cancelled"
 TERRAFORM_APPLY_FAILURE = "terraform.apply_failure"
 
 ALL_EVENT_TYPES = [
+    PIPELINE_STARTED,
     PIPELINE_COMPLETED,
     PIPELINE_FAILED,
     PIPELINE_STAGE_ERROR,
@@ -137,6 +139,7 @@ ALL_EVENT_TYPES = [
 
 # Severity mapping for event types
 EVENT_SEVERITY = {
+    PIPELINE_STARTED: "info",
     PIPELINE_COMPLETED: "info",
     PIPELINE_FAILED: "critical",
     PIPELINE_STAGE_ERROR: "warning",

--- a/backend/app/services/pipeline_monitor_service.py
+++ b/backend/app/services/pipeline_monitor_service.py
@@ -13,6 +13,8 @@ from sqlalchemy.orm import selectinload
 from app.models.pipeline_process import PipelineProcess
 from app.models.pipeline_run import PipelineRun
 from app.services.audit_service import log_action
+from app.services.event_bus import event_bus
+from app.services.event_types import PIPELINE_COMPLETED, PIPELINE_FAILED
 from app.adapters.registry import get_compute_adapter, get_storage_adapter
 
 if TYPE_CHECKING:
@@ -334,6 +336,45 @@ class PipelineMonitorService:
             action="complete",
             details={"status": run.status, "progress": run.progress_json},
         )
+
+        # Emit event for activity feed / notifications
+        import asyncio
+
+        if run.status == "completed":
+            asyncio.create_task(
+                event_bus.emit(
+                    PIPELINE_COMPLETED,
+                    {
+                        "event_type": PIPELINE_COMPLETED,
+                        "org_id": run.organization_id,
+                        "user_id": run.submitted_by_user_id,
+                        "target_user_id": run.submitted_by_user_id,
+                        "entity_type": "pipeline_run",
+                        "entity_id": run.id,
+                        "title": f"Pipeline '{run.pipeline_name}' completed",
+                        "message": f"Run {run.id} finished successfully",
+                        "summary": f"Pipeline '{run.pipeline_name}' run {run.id} completed",
+                    },
+                )
+            )
+        else:
+            asyncio.create_task(
+                event_bus.emit(
+                    PIPELINE_FAILED,
+                    {
+                        "event_type": PIPELINE_FAILED,
+                        "org_id": run.organization_id,
+                        "user_id": run.submitted_by_user_id,
+                        "target_user_id": run.submitted_by_user_id,
+                        "entity_type": "pipeline_run",
+                        "entity_id": run.id,
+                        "title": f"Pipeline '{run.pipeline_name}' failed",
+                        "message": run.error_message or "Run failed",
+                        "severity": "critical",
+                        "summary": f"Pipeline '{run.pipeline_name}' run {run.id} failed",
+                    },
+                )
+            )
 
         # Auto-generate QC dashboard if component is enabled and run succeeded
         if run.status == "completed":

--- a/backend/app/services/pipeline_run_service.py
+++ b/backend/app/services/pipeline_run_service.py
@@ -13,7 +13,7 @@ from app.models.sample import Sample
 from app.schemas.pipeline_run import PipelineRunLaunchRequest
 from app.services.audit_service import log_action
 from app.services.event_bus import event_bus
-from app.services.event_types import PIPELINE_FAILED
+from app.services.event_types import PIPELINE_FAILED, PIPELINE_STARTED
 from app.services.pipeline_catalog_service import PipelineCatalogService
 from app.services.quota_service import QuotaService
 from app.services.sample_sheet_service import SampleSheetService
@@ -183,6 +183,25 @@ class PipelineRunService:
             estimated_cost = job_result.get("estimated_cost", {})
             if estimated_cost:
                 run.cost_estimate = estimated_cost.get("estimated_cost_usd")
+
+            import asyncio
+
+            asyncio.create_task(
+                event_bus.emit(
+                    PIPELINE_STARTED,
+                    {
+                        "event_type": PIPELINE_STARTED,
+                        "org_id": org_id,
+                        "user_id": user_id,
+                        "target_user_id": user_id,
+                        "entity_type": "pipeline_run",
+                        "entity_id": run.id,
+                        "title": f"Pipeline '{pipeline.name}' started",
+                        "message": f"Run {run.id} submitted for experiment {data.experiment_id}",
+                        "summary": f"Pipeline '{pipeline.name}' run {run.id} started",
+                    },
+                )
+            )
 
         except Exception as e:
             run.status = "failed"

--- a/backend/app/services/quota_service.py
+++ b/backend/app/services/quota_service.py
@@ -89,6 +89,20 @@ class QuotaService:
                     },
                 )
             )
+            await log_action(
+                session,
+                user_id=user_id,
+                entity_type="user_quota",
+                entity_id=quota.id,
+                action="quota_exceeded",
+                details={
+                    "cpu_hours_used": float(quota.cpu_hours_used_current_month),
+                    "cpu_hours_limit": quota.cpu_hours_monthly_limit,
+                    "estimated_hours": estimated_hours,
+                    "projected_total": projected,
+                },
+            )
+            await session.flush()
             return False, (
                 f"Would exceed monthly limit: {float(quota.cpu_hours_used_current_month):.1f} used "
                 f"+ {estimated_hours:.1f} estimated = {projected:.1f} / {quota.cpu_hours_monthly_limit} limit"

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -98,7 +98,14 @@ class UserService:
         new_role_id: int,
         actor_user_id: int,
     ) -> User:
+        from app.services import role_service
+
         old_role_id = user.role_id
+        old_role = await role_service.get_role_by_id(session, old_role_id)
+        new_role = await role_service.get_role_by_id(session, new_role_id)
+        old_role_name = old_role.name if old_role else str(old_role_id)
+        new_role_name = new_role.name if new_role else str(new_role_id)
+
         user.role_id = new_role_id
         await session.flush()
 
@@ -107,13 +114,17 @@ class UserService:
             user_id=actor_user_id,
             entity_type="user",
             entity_id=user.id,
-            action="update",
+            action="role_change",
             details={
-                "field": "role_id",
-                "new_value": new_role_id,
+                "new_role_id": new_role_id,
+                "new_role_name": new_role_name,
                 "target_email": user.email,
+                "description": f"Changed {user.email} role from {old_role_name} to {new_role_name}",
             },
-            previous_value={"field": "role_id", "old_value": old_role_id},
+            previous_value={
+                "old_role_id": old_role_id,
+                "old_role_name": old_role_name,
+            },
         )
         return user
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.6.1"
+version = "0.6.2"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -179,3 +179,125 @@ async def test_login_creates_audit_entry(client, admin_user, session):
         {"id": admin_user.id},
     )
     assert result.fetchone() is not None
+
+
+@pytest.mark.asyncio
+async def test_failed_login_creates_audit_entry(client, admin_user, session):
+    """Failed login with wrong password creates login_failed audit entry."""
+    response = await client.post(
+        "/api/auth/login",
+        json={"email": "admin@test.com", "password": "wrongpassword"},
+    )
+    assert response.status_code == 401
+
+    result = await session.execute(
+        text("SELECT details_json FROM audit_log WHERE action = 'login_failed' AND entity_id = :id"),
+        {"id": admin_user.id},
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.details_json["reason"] == "invalid_credentials"
+
+
+@pytest.mark.asyncio
+async def test_failed_login_nonexistent_user_creates_audit_entry(client, session):
+    """Failed login for nonexistent email still creates login_failed audit entry."""
+    response = await client.post(
+        "/api/auth/login",
+        json={"email": "nobody@test.com", "password": "password"},
+    )
+    assert response.status_code == 401
+
+    result = await session.execute(
+        text("SELECT details_json FROM audit_log WHERE action = 'login_failed' AND entity_id = 0"),
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.details_json["email"] == "nobody@test.com"
+
+
+@pytest.mark.asyncio
+async def test_logout_creates_audit_entry(client, admin_token, admin_user, session):
+    """Logout creates an audit entry."""
+    response = await client.post(
+        "/api/auth/logout",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+
+    result = await session.execute(
+        text("SELECT * FROM audit_log WHERE action = 'logout' AND entity_id = :id"),
+        {"id": admin_user.id},
+    )
+    assert result.fetchone() is not None
+
+
+@pytest.mark.asyncio
+async def test_role_change_audit_action(client, admin_token, admin_user, session):
+    """Role change uses 'role_change' action with old/new role details."""
+    from app.models.user import User
+    from app.services.auth_service import AuthService
+
+    role_map = admin_user._test_role_map
+
+    # Create a second user to change role on
+    user2 = User(
+        email="roletest@test.com",
+        password_hash=AuthService.hash_password("pass123"),
+        role_id=role_map["viewer"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user2)
+    await session.flush()
+    await session.commit()
+
+    response = await client.patch(
+        f"/api/users/{user2.id}",
+        json={"role_id": role_map["comp_bio"]},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+
+    result = await session.execute(
+        text(
+            "SELECT details_json, previous_value_json FROM audit_log WHERE action = 'role_change' AND entity_id = :id"
+        ),
+        {"id": user2.id},
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.details_json["new_role_name"] == "comp_bio"
+    assert row.previous_value_json["old_role_name"] == "viewer"
+
+
+@pytest.mark.asyncio
+async def test_quota_exceeded_creates_audit_entry(session, admin_user):
+    """Quota exceeded creates an audit log entry."""
+    from app.services.quota_service import QuotaService
+
+    # Set a low quota
+    await QuotaService.set_quota(
+        session,
+        user_id=admin_user.id,
+        admin_user_id=admin_user.id,
+        org_id=admin_user.organization_id,
+        limit=10,
+    )
+    await session.commit()
+
+    # Use up the quota
+    await QuotaService.update_usage(session, admin_user.id, 9.5)
+    await session.commit()
+
+    # Try to exceed it
+    allowed, _ = await QuotaService.check_quota(session, admin_user.id, 5.0)
+    assert allowed is False
+    await session.commit()
+
+    result = await session.execute(
+        text("SELECT details_json FROM audit_log WHERE action = 'quota_exceeded'"),
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.details_json["cpu_hours_limit"] == 10

--- a/backend/tests/test_file_download.py
+++ b/backend/tests/test_file_download.py
@@ -111,7 +111,7 @@ async def test_single_file_download_creates_audit_log(client, admin_token, admin
             text(
                 "SELECT entity_type, entity_id, action, details_json "
                 "FROM audit_log "
-                "WHERE entity_type = 'file' AND action = 'downloaded' AND entity_id = :fid"
+                "WHERE entity_type = 'file' AND action = 'download' AND entity_id = :fid"
             ).bindparams(fid=sample_file.id)
         )
     ).fetchone()
@@ -119,7 +119,7 @@ async def test_single_file_download_creates_audit_log(client, admin_token, admin
     assert row is not None, "Expected an audit log entry for the download"
     assert row[0] == "file"
     assert row[1] == sample_file.id
-    assert row[2] == "downloaded"
+    assert row[2] == "download"
     import json
 
     details = json.loads(row[3]) if isinstance(row[3], str) else row[3]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/settings/audit-log/page.tsx
+++ b/frontend/src/app/settings/audit-log/page.tsx
@@ -114,13 +114,18 @@ export default function AuditLogPage() {
     "experiment", "sample", "user", "auth", "pipeline_run",
     "pipeline_catalog", "project", "file", "batch", "system",
     "notebook", "reference", "session_credential",
+    "environment_version", "backup", "user_quota",
   ];
 
   const actions = [
-    "create", "update", "delete", "login", "logout", "status_change",
+    "create", "update", "delete", "login", "login_failed", "logout",
+    "status_change", "role_change",
     "launch", "invite", "deactivate", "verify_email",
-    "download", "read", "view", "session",
+    "download", "read", "view", "session", "session_access",
     "change_password", "admin_reset_password", "resend_invite", "lock",
+    "build", "build_succeeded", "build_failed",
+    "backup_completed", "backup_failed",
+    "quota_exceeded",
   ];
 
   return (
@@ -221,9 +226,11 @@ export default function AuditLogPage() {
                       </td>
                       <td className="px-4 py-2.5">
                         <span className={`text-xs px-2 py-0.5 rounded ${
-                          entry.action === "delete" ? "bg-red-100 text-red-700" :
-                          entry.action === "create" ? "bg-green-100 text-green-700" :
-                          entry.action === "login" ? "bg-blue-100 text-blue-700" :
+                          entry.action === "delete" || entry.action === "backup_failed" || entry.action === "build_failed" ? "bg-red-100 text-red-700" :
+                          entry.action === "create" || entry.action === "backup_completed" || entry.action === "build_succeeded" ? "bg-green-100 text-green-700" :
+                          entry.action === "login" || entry.action === "logout" ? "bg-blue-100 text-blue-700" :
+                          entry.action === "login_failed" || entry.action === "quota_exceeded" ? "bg-amber-100 text-amber-700" :
+                          entry.action === "role_change" ? "bg-purple-100 text-purple-700" :
                           "bg-gray-100 text-gray-700"
                         }`}>
                           {entry.action}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getCurrentUser, removeToken } from "@/lib/auth";
 import { clearPermissionsCache } from "@/hooks/usePermissions";
+import { api } from "@/lib/api";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { DeploymentBanner } from "@/components/infrastructure/DeploymentBanner";
 
@@ -15,7 +16,12 @@ export function Header() {
     setUser(getCurrentUser());
   }, []);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      await api.post("/api/auth/logout");
+    } catch {
+      // Best effort -- token may already be expired
+    }
     removeToken();
     clearPermissionsCache();
     router.push("/login");


### PR DESCRIPTION
## Summary

- Close audit log coverage gaps across security, SRE, and platform admin events (closes #153)
- Fix missing and broken activity feed events so the Recent Activity widget reflects pipeline runs and auto-run lifecycle
- Frontend logout now calls the backend so the event is recorded

### Audit Log Coverage

- Logout endpoint with audit logging
- Failed login attempts logged with reason
- File content serving logged as download
- Role changes use specific `role_change` action with old/new role names
- Build lifecycle (success/failure) logged from the build poller
- Backup completion and failure logged
- Quota exceeded logged alongside event bus emission
- Notebook session access logged

### Activity Feed Fixes

- New `PIPELINE_STARTED` event type emitted on run submission
- `PIPELINE_COMPLETED` / `PIPELINE_FAILED` now emitted from the pipeline monitor completion handler
- `AUTO_RUN_BUDGET_DISABLED` payload fixed (used wrong key, silently dropped)
- `AUTO_RUN_LAUNCHED` payload fixed (missing org_id and display fields)

## Test plan

- [ ] All 1728 backend tests pass (verified locally)
- [ ] ruff format, ruff check, mypy all clean
- [ ] Frontend tsc --noEmit clean
- [ ] Login, then logout -- verify both appear in Settings > Audit Log
- [ ] Attempt login with wrong password -- verify `login_failed` entry appears
- [ ] Launch a pipeline run -- verify "started" event in Recent Activity
- [ ] Wait for run completion -- verify "completed" or "failed" event in Recent Activity
- [ ] Change a user's role -- verify `role_change` action with old/new role names in audit log