### PR TITLE
v0.6.3: Infrastructure lifecycle, Cloud Logging, deploy UX

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+## v0.6.3
+
+Infrastructure lifecycle stability, Cloud Logging, and deploy UX improvements.
+
+### Cloud Logging
+
+- Auto-detect GCE and attach Cloud Logging using the app's configured service account
+- Install Ops Agent via `./bioaf start` for Docker container log collection
+- Add `logging.logEntries.create` to GCP validation permission checks
+
+### Infrastructure Lifecycle
+
+- Replace 30-minute hard timeout with in-memory process registry so GKE deploys run to completion
+- Fix lock file deletion to use app credentials instead of ADC
+- Fix orphaned resource cleanup returning 404 for valid resources
+- Expand orphan detection and cleanup to cover IAM service accounts
+- Deduplicate orphaned resource entries across repeated failures
+- Add GKE cluster and service account scanning via GKE/IAM APIs
+- Persist tfvars on each TerraformRun for audit and reproducibility (migration 064)
+
+### Deploy UX
+
+- Show full planned resource list in deploy modal from the start (Queued/Setting up/Done states)
+- Move teardown and storage destroy to background endpoints with polling
+- Add region/zone selection at deploy time with cross-region cost warning
+- Fix empty modal when no active run (idle state with "Starting operation...")
+- Fix modal stuck after operation completes (terminal status persistence)
+- Visible scrollbar on resource list
+
 ## v0.6.2
 
 Audit log coverage gaps and activity feed event fixes.

--- a/backend/alembic/versions/064_add_terraform_run_tfvars.py
+++ b/backend/alembic/versions/064_add_terraform_run_tfvars.py
@@ -1,0 +1,23 @@
+"""Add tfvars_json column to terraform_runs.
+
+Stores the exact variable inputs used for each Terraform run so
+deploys are reproducible and auditable.
+
+Revision ID: 064
+Revises: 063
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "064"
+down_revision = "063"
+
+
+def upgrade() -> None:
+    op.add_column("terraform_runs", sa.Column("tfvars_json", JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("terraform_runs", "tfvars_json")

--- a/backend/app/api/orphaned_resources.py
+++ b/backend/app/api/orphaned_resources.py
@@ -116,8 +116,11 @@ async def cleanup_orphaned_resource(
         resource = await OrphanedResourceService.cleanup_resource(session, resource_id, user_id)
         await session.commit()
     except ValueError as exc:
-        logger.warning("Orphaned resource cleanup failed for %d: %s", resource_id, exc)
-        raise HTTPException(status_code=404, detail="Resource not found")
+        msg = str(exc)
+        logger.warning("Orphaned resource cleanup failed for %d: %s", resource_id, msg)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
     return OrphanedResourceResponse.model_validate(resource)
 
 

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -288,6 +288,76 @@ async def stack_deploy_background_endpoint(
     return {"message": "Deployment started"}
 
 
+@router.post("/api/v1/infrastructure/stack/teardown-background")
+async def stack_teardown_background_endpoint(
+    body: StackTeardownRequest | None = None,
+    current_user: dict = require_permission("infrastructure", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Start a stack teardown in the background and return immediately."""
+    if body and not body.confirm:
+        raise HTTPException(status_code=400, detail="Confirmation required. Set confirm=true.")
+
+    user_id = int(current_user["sub"])
+    org_id = int(current_user["org_id"]) if current_user.get("org_id") else None
+
+    # Validate compute is deployed
+    compute_deployed = await session.execute(text("SELECT value FROM platform_config WHERE key = 'compute_deployed'"))
+    if compute_deployed.scalar_one_or_none() != "true":
+        raise HTTPException(status_code=400, detail="Compute stack is not deployed")
+
+    async def _run_teardown():
+        async with async_session_factory() as bg_session:
+            try:
+                async for _event in teardown_stack(bg_session, user_id, org_id=org_id):
+                    await bg_session.commit()
+                await bg_session.commit()
+            except Exception:
+                logger.exception("Background teardown failed")
+                await bg_session.rollback()
+
+    asyncio.get_event_loop().create_task(_run_teardown())
+
+    return {"message": "Teardown started"}
+
+
+@router.post("/api/v1/infrastructure/stack/destroy-storage-background")
+async def stack_destroy_storage_background_endpoint(
+    body: StorageDestroyRequest | None = None,
+    current_user: dict = require_permission("infrastructure", "configure"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Start storage destruction in the background and return immediately."""
+    if body is not None and not body.confirm:
+        raise HTTPException(status_code=400, detail="Confirmation required. Set confirm=true.")
+
+    user_id = int(current_user["sub"])
+    org_id = int(current_user["org_id"]) if current_user.get("org_id") else None
+
+    # Validate storage is deployed and compute is not
+    compute_deployed = await session.execute(text("SELECT value FROM platform_config WHERE key = 'compute_deployed'"))
+    if compute_deployed.scalar_one_or_none() == "true":
+        raise HTTPException(status_code=400, detail="Teardown compute stack before destroying storage")
+
+    storage_deployed = await session.execute(text("SELECT value FROM platform_config WHERE key = 'storage_deployed'"))
+    if storage_deployed.scalar_one_or_none() != "true":
+        raise HTTPException(status_code=400, detail="Storage is not deployed")
+
+    async def _run_destroy_storage():
+        async with async_session_factory() as bg_session:
+            try:
+                async for _event in destroy_storage(bg_session, user_id, org_id=org_id):
+                    await bg_session.commit()
+                await bg_session.commit()
+            except Exception:
+                logger.exception("Background storage destroy failed")
+                await bg_session.rollback()
+
+    asyncio.get_event_loop().create_task(_run_destroy_storage())
+
+    return {"message": "Storage destruction started"}
+
+
 @router.get(
     "/api/v1/infrastructure/stack/deploy/progress",
     response_model=DeployProgressResponse,

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -211,16 +211,16 @@ async def stack_deploy_endpoint(
     async def event_generator():
         try:
             async for event in deploy_stack(session, stack_type, user_id, org_id=org_id):
-                data = json.dumps(
-                    {
-                        "event_type": event.event_type,
-                        "message": event.message,
-                        "resource_address": event.resource_address,
-                        "resources_completed": event.resources_completed,
-                        "resources_total": event.resources_total,
-                    }
-                )
-                yield f"data: {data}\n\n"
+                payload: dict = {
+                    "event_type": event.event_type,
+                    "message": event.message,
+                    "resource_address": event.resource_address,
+                    "resources_completed": event.resources_completed,
+                    "resources_total": event.resources_total,
+                }
+                if event.extra:
+                    payload["extra"] = event.extra
+                yield f"data: {json.dumps(payload)}\n\n"
         except ValueError as exc:
             error_data = json.dumps({"event_type": "stack_error", "message": str(exc)})
             yield f"data: {error_data}\n\n"
@@ -354,13 +354,16 @@ async def stack_teardown_endpoint(
     async def event_generator():
         try:
             async for event in teardown_stack(session, user_id, org_id=org_id):
-                data = json.dumps(
-                    {
-                        "event_type": event.event_type,
-                        "message": event.message,
-                    }
-                )
-                yield f"data: {data}\n\n"
+                payload: dict = {
+                    "event_type": event.event_type,
+                    "message": event.message,
+                    "resource_address": event.resource_address,
+                    "resources_completed": event.resources_completed,
+                    "resources_total": event.resources_total,
+                }
+                if event.extra:
+                    payload["extra"] = event.extra
+                yield f"data: {json.dumps(payload)}\n\n"
         except ValueError as exc:
             error_data = json.dumps({"event_type": "stack_error", "message": str(exc)})
             yield f"data: {error_data}\n\n"
@@ -396,16 +399,16 @@ async def stack_destroy_storage_endpoint(
     async def event_generator():
         try:
             async for event in destroy_storage(session, user_id, org_id=org_id):
-                data = json.dumps(
-                    {
-                        "event_type": event.event_type,
-                        "message": event.message,
-                        "resource_address": event.resource_address,
-                        "resources_completed": event.resources_completed,
-                        "resources_total": event.resources_total,
-                    }
-                )
-                yield f"data: {data}\n\n"
+                payload: dict = {
+                    "event_type": event.event_type,
+                    "message": event.message,
+                    "resource_address": event.resource_address,
+                    "resources_completed": event.resources_completed,
+                    "resources_total": event.resources_total,
+                }
+                if event.extra:
+                    payload["extra"] = event.extra
+                yield f"data: {json.dumps(payload)}\n\n"
         except ValueError as exc:
             error_data = json.dumps({"event_type": "stack_error", "message": str(exc)})
             yield f"data: {error_data}\n\n"

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -111,6 +111,7 @@ class DeployProgressResponse(BaseModel):
     resources_completed: int = 0
     resources_total: int = 0
     completed_resources: list[str] = []
+    planned_resources: list[str] = []
     error_message: str | None = None
     run_id: int | None = None
 
@@ -326,6 +327,12 @@ async def stack_deploy_progress(
 
     is_active = run.status in ("planning", "applying", "awaiting_confirmation")
 
+    # Extract planned resource addresses from plan_json so the frontend
+    # can show the full list with queued/done status from the start.
+    planned = []
+    if run.plan_json and run.plan_json.get("resources"):
+        planned = [r["address"] for r in run.plan_json["resources"] if not r["address"].startswith("data.")]
+
     return DeployProgressResponse(
         active=is_active,
         status=run.status,
@@ -333,6 +340,7 @@ async def stack_deploy_progress(
         resources_completed=run.resources_completed,
         resources_total=run.resources_planned or 0,
         completed_resources=run.completed_resources or [],
+        planned_resources=planned,
         error_message=run.error_message,
         run_id=run.id,
     )

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -327,19 +327,22 @@ async def stack_deploy_progress(
 
     is_active = run.status in ("planning", "applying", "awaiting_confirmation")
 
-    # Extract planned resource addresses from plan_json so the frontend
-    # can show the full list with queued/done status from the start.
+    # Only include planned/completed resource lists for active runs.
+    # Stale data from previous runs confuses the frontend.
     planned = []
-    if run.plan_json and run.plan_json.get("resources"):
-        planned = [r["address"] for r in run.plan_json["resources"] if not r["address"].startswith("data.")]
+    completed = []
+    if is_active:
+        if run.plan_json and run.plan_json.get("resources"):
+            planned = [r["address"] for r in run.plan_json["resources"] if not r["address"].startswith("data.")]
+        completed = run.completed_resources or []
 
     return DeployProgressResponse(
         active=is_active,
         status=run.status,
         phase=run.deploy_phase,
-        resources_completed=run.resources_completed,
-        resources_total=run.resources_planned or 0,
-        completed_resources=run.completed_resources or [],
+        resources_completed=run.resources_completed if is_active else 0,
+        resources_total=(run.resources_planned or 0) if is_active else 0,
+        completed_resources=completed,
         planned_resources=planned,
         error_message=run.error_message,
         run_id=run.id,

--- a/backend/app/api/stack_deploy.py
+++ b/backend/app/api/stack_deploy.py
@@ -54,6 +54,8 @@ router = APIRouter(tags=["stack_deploy"])
 
 class StackDeployRequest(BaseModel):
     stack_type: str = "kubernetes"
+    compute_region: str | None = None
+    compute_zone: str | None = None
 
 
 class StackTeardownRequest(BaseModel):
@@ -250,6 +252,8 @@ async def stack_deploy_background_endpoint(
     user_id = int(current_user["sub"])
     org_id = int(current_user["org_id"]) if current_user.get("org_id") else None
     stack_type = body.stack_type if body else "kubernetes"
+    compute_region = body.compute_region if body else None
+    compute_zone = body.compute_zone if body else None
 
     # Validate preconditions synchronously so we can return a clear error.
     gcp_configured = await session.execute(
@@ -267,16 +271,17 @@ async def stack_deploy_background_endpoint(
         raise HTTPException(status_code=400, detail="Terraform has not been initialized")
 
     async def _run_deploy():
-        """Drain the deploy_stack generator in the background with its own session.
-
-        Commits after each event so the progress polling endpoint can see
-        intermediate state (resource counts, phase, completed_resources).
-        Without per-event commits, all flush() calls stay invisible to
-        other sessions under PostgreSQL READ COMMITTED isolation.
-        """
+        """Drain the deploy_stack generator in the background with its own session."""
         async with async_session_factory() as bg_session:
             try:
-                async for _event in deploy_stack(bg_session, stack_type, user_id, org_id=org_id):
+                async for _event in deploy_stack(
+                    bg_session,
+                    stack_type,
+                    user_id,
+                    org_id=org_id,
+                    compute_region=compute_region,
+                    compute_zone=compute_zone,
+                ):
                     await bg_session.commit()
                 await bg_session.commit()
             except Exception:

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,63 @@
+"""Logging configuration with automatic GCE Cloud Logging detection.
+
+On GCE instances, attaches a Google Cloud Logging handler so logs
+appear in the Cloud Console alongside the standard stdout handler.
+Non-GCE environments get stdout only -- no configuration required.
+"""
+
+import logging
+import sys
+import urllib.request
+
+try:
+    import google.cloud.logging as cloud_logging
+except ImportError:  # pragma: no cover
+    cloud_logging = None  # type: ignore[assignment]
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+_GCE_METADATA_URL = "http://169.254.169.254/computeMetadata/v1/project/project-id"
+_METADATA_HEADERS = {"Metadata-Flavor": "Google"}
+
+
+def is_running_on_gce() -> bool:
+    """Return True if the process is running on a GCE instance."""
+    try:
+        req = urllib.request.Request(_GCE_METADATA_URL, headers=_METADATA_HEADERS)
+        with urllib.request.urlopen(req, timeout=1) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def get_gce_project_id() -> str:
+    """Fetch the GCP project ID from the GCE metadata server."""
+    req = urllib.request.Request(_GCE_METADATA_URL, headers=_METADATA_HEADERS)
+    with urllib.request.urlopen(req, timeout=2) as resp:
+        return resp.read().decode().strip()
+
+
+def configure_logging(*, debug: bool) -> None:
+    """Set up the ``bioaf`` logger with stdout and optional Cloud Logging.
+
+    Cloud Logging is enabled automatically when running on GCE.
+    """
+    bioaf_logger = logging.getLogger("bioaf")
+    bioaf_logger.setLevel(logging.DEBUG if debug else logging.INFO)
+    bioaf_logger.handlers.clear()
+
+    # Stdout -- always present so ./bioaf logs keeps working
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    bioaf_logger.addHandler(stdout_handler)
+
+    # Cloud Logging -- auto-enabled on GCE
+    if is_running_on_gce() and cloud_logging is not None:
+        try:
+            project_id = get_gce_project_id()
+            client = cloud_logging.Client(project=project_id)
+            cloud_handler = client.get_default_handler()
+            cloud_handler.setLevel(logging.DEBUG if debug else logging.INFO)
+            bioaf_logger.addHandler(cloud_handler)
+            bioaf_logger.info("Cloud Logging enabled (project=%s)", project_id)
+        except Exception as exc:
+            bioaf_logger.warning("Cloud Logging unavailable, stdout only: %s", exc)

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,13 +1,15 @@
-"""Logging configuration with automatic GCE Cloud Logging detection.
+"""Logging configuration with Cloud Logging support.
 
-On GCE instances, attaches a Google Cloud Logging handler so logs
-appear in the Cloud Console alongside the standard stdout handler.
-Non-GCE environments get stdout only -- no configuration required.
+Sets up stdout logging at import time.  After the database is available,
+``attach_cloud_logging`` can be called with the app's configured GCP
+credentials so structured logs flow to Cloud Console using the same
+service account the rest of the platform uses.
 """
 
 import logging
 import sys
 import urllib.request
+from typing import Any
 
 try:
     import google.cloud.logging as cloud_logging
@@ -37,27 +39,42 @@ def get_gce_project_id() -> str:
 
 
 def configure_logging(*, debug: bool) -> None:
-    """Set up the ``bioaf`` logger with stdout and optional Cloud Logging.
+    """Set up the ``bioaf`` logger with stdout only.
 
-    Cloud Logging is enabled automatically when running on GCE.
+    Cloud Logging is attached later via ``attach_cloud_logging`` once the
+    database is available and GCP credentials can be loaded.
     """
     bioaf_logger = logging.getLogger("bioaf")
     bioaf_logger.setLevel(logging.DEBUG if debug else logging.INFO)
     bioaf_logger.handlers.clear()
 
-    # Stdout -- always present so ./bioaf logs keeps working
     stdout_handler = logging.StreamHandler(sys.stdout)
     stdout_handler.setFormatter(logging.Formatter(LOG_FORMAT))
     bioaf_logger.addHandler(stdout_handler)
 
-    # Cloud Logging -- auto-enabled on GCE
-    if is_running_on_gce() and cloud_logging is not None:
-        try:
-            project_id = get_gce_project_id()
-            client = cloud_logging.Client(project=project_id)
-            cloud_handler = client.get_default_handler()
-            cloud_handler.setLevel(logging.DEBUG if debug else logging.INFO)
-            bioaf_logger.addHandler(cloud_handler)
-            bioaf_logger.info("Cloud Logging enabled (project=%s)", project_id)
-        except Exception as exc:
-            bioaf_logger.warning("Cloud Logging unavailable, stdout only: %s", exc)
+
+def attach_cloud_logging(
+    project_id: str,
+    credentials: Any = None,
+    *,
+    debug: bool = False,
+) -> None:
+    """Attach a Cloud Logging handler to the ``bioaf`` logger.
+
+    Uses the provided *credentials* (typically the app's configured service
+    account).  When *credentials* is ``None``, the client falls back to
+    Application Default Credentials.
+    """
+    if cloud_logging is None:
+        logging.getLogger("bioaf").warning("google-cloud-logging not installed, Cloud Logging unavailable")
+        return
+
+    bioaf_logger = logging.getLogger("bioaf")
+    try:
+        client = cloud_logging.Client(project=project_id, credentials=credentials)
+        cloud_handler = client.get_default_handler()
+        cloud_handler.setLevel(logging.DEBUG if debug else logging.INFO)
+        bioaf_logger.addHandler(cloud_handler)
+        bioaf_logger.info("Cloud Logging enabled (project=%s)", project_id)
+    except Exception as exc:
+        bioaf_logger.warning("Cloud Logging unavailable, stdout only: %s", exc)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,15 +6,13 @@ from fastapi import FastAPI
 
 from app.config import settings
 from app.database import engine
+from app.logging_config import configure_logging
 from app.middleware.auth_middleware import AuthMiddleware
 from app.middleware.logging_middleware import LoggingMiddleware
 from app.middleware.rate_limit import RateLimitMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 
-logging.basicConfig(
-    level=logging.DEBUG if settings.debug else logging.INFO,
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-)
+configure_logging(debug=settings.debug)
 logger = logging.getLogger("bioaf")
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 
 from app.config import settings
 from app.database import engine
-from app.logging_config import configure_logging
+from app.logging_config import attach_cloud_logging, configure_logging
 from app.middleware.auth_middleware import AuthMiddleware
 from app.middleware.logging_middleware import LoggingMiddleware
 from app.middleware.rate_limit import RateLimitMiddleware
@@ -54,6 +54,22 @@ async def lifespan(app: FastAPI):
     async with engine.begin() as conn:
         await conn.execute(text("SELECT 1"))
     logger.info("Database connection verified")
+
+    # Attach Cloud Logging using the app's configured GCP credentials
+    try:
+        from app.database import async_session_factory as cl_session_factory
+        from app.services.gcs_storage import GcsStorageService
+
+        async with cl_session_factory() as cl_session:
+            result = await cl_session.execute(text("SELECT value FROM platform_config WHERE key = 'gcp_project_id'"))
+            row = result.fetchone()
+            gcp_project_id = row[0] if row and row[0] and row[0] != "null" else ""
+
+            if gcp_project_id:
+                credentials = await GcsStorageService.get_credentials(cl_session)
+                attach_cloud_logging(gcp_project_id, credentials, debug=settings.debug)
+    except Exception as e:
+        logger.info("Cloud Logging not configured: %s", e)
 
     # Load persisted SMTP settings from database (gracefully skip if columns
     # don't exist yet, e.g. before migration 040 has run)

--- a/backend/app/models/component.py
+++ b/backend/app/models/component.py
@@ -42,6 +42,7 @@ class TerraformRun(Base):
     completed_resources: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     apply_log: Mapped[str | None] = mapped_column(Text, nullable=True)
     terraform_state_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    tfvars_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
 
 class VerificationCode(Base):

--- a/backend/app/services/gcp_config.py
+++ b/backend/app/services/gcp_config.py
@@ -44,6 +44,7 @@ _PERMISSION_ROLE_MAP: dict[str, str] = {
     "bigquery.jobs.create": "roles/bigquery.dataEditor",
     "artifactregistry.repositories.create": "roles/artifactregistry.admin",
     "cloudbuild.builds.create": "roles/cloudbuild.builds.editor",
+    "logging.logEntries.create": "roles/logging.logWriter",
 }
 
 # Deduplicated, stable-order list of recommended roles.

--- a/backend/app/services/orphaned_resource_service.py
+++ b/backend/app/services/orphaned_resource_service.py
@@ -61,7 +61,18 @@ class OrphanedResourceService:
         gcp_zone: str | None = None,
         terraform_run_id: int | None = None,
     ) -> OrphanedResource:
-        """Record a detected orphaned resource."""
+        """Record a detected orphaned resource (skips if already tracked)."""
+        result = await session.execute(
+            select(OrphanedResource).where(
+                OrphanedResource.resource_type == resource_type,
+                OrphanedResource.resource_name == resource_name,
+                OrphanedResource.status.in_({"detected", "failed", "cleaning"}),
+            )
+        )
+        existing = result.scalar_one_or_none()
+        if existing:
+            return existing
+
         resource = OrphanedResource(
             resource_type=resource_type,
             resource_name=resource_name,

--- a/backend/app/services/orphaned_resource_service.py
+++ b/backend/app/services/orphaned_resource_service.py
@@ -222,16 +222,88 @@ class OrphanedResourceService:
             return "NOT_FOUND", None
 
     @staticmethod
+    async def scan_for_orphans(session: AsyncSession) -> int:
+        """Scan GKE API for bioaf-* clusters not tracked by the platform.
+
+        Compares live clusters against the active cluster in platform_config
+        and existing orphan records. Any untracked clusters are logged as
+        new orphaned resources. Returns the number of newly detected orphans.
+        """
+        config_result = await session.execute(
+            text(
+                "SELECT key, value FROM platform_config WHERE key IN ('gcp_project_id', 'gcp_zone', 'gke_cluster_name')"
+            )
+        )
+        config = {r[0]: r[1] for r in config_result.fetchall()}
+
+        project_id = config.get("gcp_project_id", "")
+        zone = config.get("gcp_zone", "")
+        active_cluster = config.get("gke_cluster_name", "")
+        if active_cluster == "null":
+            active_cluster = ""
+
+        if not project_id or not zone:
+            return 0
+
+        # Get existing orphan names so we don't duplicate
+        existing_result = await session.execute(
+            select(OrphanedResource.resource_name).where(
+                OrphanedResource.resource_type == "gke_cluster",
+                OrphanedResource.status.in_({"detected", "failed", "cleaning"}),
+            )
+        )
+        known_names = {r[0] for r in existing_result.fetchall()}
+
+        # Query GKE for all clusters in the zone
+        try:
+            credentials = await _get_gke_credentials(session)
+            client = _get_gke_client(credentials)
+            parent = f"projects/{project_id}/locations/{zone}"
+            response = client.list_clusters(parent=parent)
+            live_clusters = list(response.clusters) if response.clusters else []
+        except Exception as exc:
+            logger.warning("Failed to scan GKE clusters: %s", exc)
+            return 0
+
+        detected = 0
+        for cluster in live_clusters:
+            name = cluster.name
+            if not name.startswith("bioaf-"):
+                continue
+            if name == active_cluster:
+                continue
+            if name in known_names:
+                continue
+
+            await OrphanedResourceService.log_resource(
+                session,
+                resource_type="gke_cluster",
+                resource_name=name,
+                gcp_project_id=project_id,
+                gcp_zone=zone,
+                stack_uid=name,
+            )
+            detected += 1
+            logger.info("Detected untracked GKE cluster: %s", name)
+
+        if detected:
+            await session.flush()
+        return detected
+
+    @staticmethod
     async def recovery_check(
         session: AsyncSession,
     ) -> dict[str, list[dict]]:
-        """Check all unresolved orphaned GKE clusters and classify them.
+        """Scan for new orphans, then classify all unresolved GKE clusters.
 
         Returns a dict with three lists:
         - recoverable: clusters in RUNNING/RECONCILING state (can be adopted)
         - provisioning: clusters still being created
         - dead: clusters in ERROR state or not found in GCP
         """
+        # Scan GKE API for clusters the platform doesn't know about
+        await OrphanedResourceService.scan_for_orphans(session)
+
         unresolved = {"detected", "failed"}
         stmt = (
             select(OrphanedResource)

--- a/backend/app/services/orphaned_resource_service.py
+++ b/backend/app/services/orphaned_resource_service.py
@@ -125,6 +125,8 @@ class OrphanedResourceService:
                 await OrphanedResourceService._cleanup_gke_cluster(session, resource)
             elif resource.resource_type == "gcs_bucket":
                 await OrphanedResourceService._cleanup_gcs_bucket(session, resource)
+            elif resource.resource_type == "service_account":
+                await OrphanedResourceService._cleanup_service_account(session, resource)
             else:
                 raise ValueError(f"Unknown resource type: {resource.resource_type}")
 
@@ -177,6 +179,19 @@ class OrphanedResourceService:
         bucket.delete(force=True)
 
     @staticmethod
+    async def _cleanup_service_account(
+        session: AsyncSession,
+        resource: OrphanedResource,
+    ) -> None:
+        """Delete a GCP service account using the SA credentials."""
+        from google.cloud import iam_admin_v1
+
+        credentials = await _get_gke_credentials(session)
+        client = iam_admin_v1.IAMClient(credentials=credentials) if credentials else iam_admin_v1.IAMClient()
+        sa_name = f"projects/{resource.gcp_project_id}/serviceAccounts/{resource.resource_name}@{resource.gcp_project_id}.iam.gserviceaccount.com"
+        client.delete_service_account(name=sa_name)
+
+    @staticmethod
     async def dismiss_resource(
         session: AsyncSession,
         resource_id: int,
@@ -223,11 +238,11 @@ class OrphanedResourceService:
 
     @staticmethod
     async def scan_for_orphans(session: AsyncSession) -> int:
-        """Scan GKE API for bioaf-* clusters not tracked by the platform.
+        """Scan GCP for bioaf-* resources not tracked by the platform.
 
-        Compares live clusters against the active cluster in platform_config
-        and existing orphan records. Any untracked clusters are logged as
-        new orphaned resources. Returns the number of newly detected orphans.
+        Checks GKE clusters and IAM service accounts against
+        platform_config and existing orphan records. Returns the number
+        of newly detected orphans.
         """
         config_result = await session.execute(
             text(
@@ -247,32 +262,32 @@ class OrphanedResourceService:
 
         # Get existing orphan names so we don't duplicate
         existing_result = await session.execute(
-            select(OrphanedResource.resource_name).where(
-                OrphanedResource.resource_type == "gke_cluster",
+            select(OrphanedResource.resource_name, OrphanedResource.resource_type).where(
                 OrphanedResource.status.in_({"detected", "failed", "cleaning"}),
             )
         )
-        known_names = {r[0] for r in existing_result.fetchall()}
+        known = {(r[0], r[1]) for r in existing_result.fetchall()}
 
-        # Query GKE for all clusters in the zone
+        credentials = await _get_gke_credentials(session)
+        detected = 0
+
+        # Scan GKE clusters
         try:
-            credentials = await _get_gke_credentials(session)
             client = _get_gke_client(credentials)
             parent = f"projects/{project_id}/locations/{zone}"
             response = client.list_clusters(parent=parent)
             live_clusters = list(response.clusters) if response.clusters else []
         except Exception as exc:
             logger.warning("Failed to scan GKE clusters: %s", exc)
-            return 0
+            live_clusters = []
 
-        detected = 0
         for cluster in live_clusters:
             name = cluster.name
             if not name.startswith("bioaf-"):
                 continue
             if name == active_cluster:
                 continue
-            if name in known_names:
+            if (name, "gke_cluster") in known:
                 continue
 
             await OrphanedResourceService.log_resource(
@@ -285,6 +300,35 @@ class OrphanedResourceService:
             )
             detected += 1
             logger.info("Detected untracked GKE cluster: %s", name)
+
+        # Scan IAM service accounts created by the compute module
+        _COMPUTE_SA_IDS = {"bioaf-notebook-runner"}
+        try:
+            from google.cloud import iam_admin_v1
+
+            iam_client = iam_admin_v1.IAMClient(credentials=credentials) if credentials else iam_admin_v1.IAMClient()
+            sa_list = iam_client.list_service_accounts(name=f"projects/{project_id}")
+            for sa in sa_list:
+                sa_id = sa.email.split("@")[0]
+                if sa_id not in _COMPUTE_SA_IDS:
+                    continue
+                # Only orphaned if no compute stack is deployed
+                if active_cluster:
+                    continue
+                if (sa_id, "service_account") in known:
+                    continue
+
+                await OrphanedResourceService.log_resource(
+                    session,
+                    resource_type="service_account",
+                    resource_name=sa_id,
+                    gcp_project_id=project_id,
+                    stack_uid=sa_id,
+                )
+                detected += 1
+                logger.info("Detected untracked service account: %s", sa_id)
+        except Exception as exc:
+            logger.warning("Failed to scan service accounts: %s", exc)
 
         if detected:
             await session.flush()
@@ -429,17 +473,16 @@ class OrphanedResourceService:
         session: AsyncSession,
         user_id: int,
     ) -> dict[str, int]:
-        """Clean up all orphaned GKE clusters that are dead (ERROR or NOT_FOUND).
+        """Clean up all orphaned resources that are dead or no longer needed.
 
-        Skips clusters that are RUNNING (should be adopted) or PROVISIONING
-        (still starting). For NOT_FOUND clusters, just marks them dismissed.
-        For ERROR clusters, attempts to delete then marks cleaned.
+        For GKE clusters: skips RUNNING (should be adopted) or PROVISIONING.
+        For service accounts: deletes directly.
+        For NOT_FOUND resources: marks cleaned (already gone).
 
         Returns counts: {"cleaned": N, "skipped": N, "failed": N}.
         """
         unresolved = {"detected", "failed"}
         stmt = select(OrphanedResource).where(
-            OrphanedResource.resource_type == "gke_cluster",
             OrphanedResource.status.in_(unresolved),
         )
         result = await session.execute(stmt)
@@ -450,43 +493,64 @@ class OrphanedResourceService:
         failed = 0
 
         for resource in resources:
-            gke_status, _cluster = await OrphanedResourceService._query_gke_status(session, resource)
+            if resource.resource_type == "gke_cluster":
+                gke_status, _cluster = await OrphanedResourceService._query_gke_status(session, resource)
 
-            if gke_status in _RECOVERABLE_STATUSES or gke_status in _PROVISIONING_STATUSES:
-                skipped += 1
-                continue
+                if gke_status in _RECOVERABLE_STATUSES or gke_status in _PROVISIONING_STATUSES:
+                    skipped += 1
+                    continue
 
-            if gke_status == "NOT_FOUND":
-                # Cluster is already gone, just dismiss the record
-                resource.status = "cleaned"
-                resource.resolved_at = datetime.now(timezone.utc)
-                resource.resolved_by_user_id = user_id
-                cleaned += 1
-                continue
+                if gke_status == "NOT_FOUND":
+                    resource.status = "cleaned"
+                    resource.resolved_at = datetime.now(timezone.utc)
+                    resource.resolved_by_user_id = user_id
+                    cleaned += 1
+                    continue
 
-            # Cluster exists but is in a bad state -- try to delete it
-            try:
-                credentials = await _get_gke_credentials(session)
-                client = _get_gke_client(credentials)
-                cluster_path = (
-                    f"projects/{resource.gcp_project_id}"
-                    f"/locations/{resource.gcp_zone}"
-                    f"/clusters/{resource.resource_name}"
-                )
-                client.delete_cluster(name=cluster_path)
-                resource.status = "cleaned"
-                resource.resolved_at = datetime.now(timezone.utc)
-                resource.resolved_by_user_id = user_id
-                cleaned += 1
-            except Exception as exc:
-                resource.status = "failed"
-                resource.error_message = str(exc)
-                failed += 1
-                logger.warning(
-                    "Failed to delete orphaned cluster %s: %s",
-                    resource.resource_name,
-                    exc,
-                )
+                try:
+                    credentials = await _get_gke_credentials(session)
+                    client = _get_gke_client(credentials)
+                    cluster_path = (
+                        f"projects/{resource.gcp_project_id}"
+                        f"/locations/{resource.gcp_zone}"
+                        f"/clusters/{resource.resource_name}"
+                    )
+                    client.delete_cluster(name=cluster_path)
+                    resource.status = "cleaned"
+                    resource.resolved_at = datetime.now(timezone.utc)
+                    resource.resolved_by_user_id = user_id
+                    cleaned += 1
+                except Exception as exc:
+                    resource.status = "failed"
+                    resource.error_message = str(exc)
+                    failed += 1
+                    logger.warning("Failed to delete orphaned cluster %s: %s", resource.resource_name, exc)
+
+            elif resource.resource_type == "service_account":
+                try:
+                    await OrphanedResourceService._cleanup_service_account(session, resource)
+                    resource.status = "cleaned"
+                    resource.resolved_at = datetime.now(timezone.utc)
+                    resource.resolved_by_user_id = user_id
+                    cleaned += 1
+                except Exception as exc:
+                    if "NOT_FOUND" in str(exc) or "does not exist" in str(exc):
+                        resource.status = "cleaned"
+                        resource.resolved_at = datetime.now(timezone.utc)
+                        resource.resolved_by_user_id = user_id
+                        cleaned += 1
+                    else:
+                        resource.status = "failed"
+                        resource.error_message = str(exc)
+                        failed += 1
+                        logger.warning("Failed to delete orphaned SA %s: %s", resource.resource_name, exc)
+
+            else:
+                try:
+                    await OrphanedResourceService.cleanup_resource(session, resource.id, user_id)
+                    cleaned += 1
+                except Exception:
+                    failed += 1
 
         await session.flush()
         return {"cleaned": cleaned, "skipped": skipped, "failed": failed}

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -288,11 +288,17 @@ async def deploy_stack(
     stack_type: str,
     user_id: int,
     org_id: int | None = None,
+    compute_region: str | None = None,
+    compute_zone: str | None = None,
 ) -> AsyncGenerator[TerraformProgressEvent, None]:
     """Deploy a full compute stack (storage + compute).
 
     Validates pre-conditions, runs storage (if needed), then compute.
     Yields progress events throughout.
+
+    When *compute_region* or *compute_zone* are provided, the compute
+    module uses those values instead of the defaults from platform_config.
+    Storage always uses the default region.
     """
     # Validate pre-conditions
     gcp_configured = await _read_config(session, "gcp_credentials_configured")
@@ -403,6 +409,20 @@ async def deploy_stack(
             return
 
     # Step 2: Deploy compute
+    # If the user chose a different region/zone for compute, temporarily
+    # override the config so _write_tfvars picks up the override values.
+    # Restore defaults after deploy completes (success or failure).
+    original_region = None
+    original_zone = None
+    if compute_region:
+        original_region = await _read_config(session, "gcp_region")
+        await _set_config(session, "gcp_region", compute_region)
+        if not compute_zone:
+            compute_zone = f"{compute_region}-a"
+    if compute_zone:
+        original_zone = await _read_config(session, "gcp_zone")
+        await _set_config(session, "gcp_zone", compute_zone)
+
     await _set_config(session, "deploy_suffix", secrets.token_hex(3))
     await session.flush()
     yield TerraformProgressEvent(
@@ -492,6 +512,12 @@ async def deploy_stack(
                 log_line=event.log_line,
                 extra=event.extra,
             )
+
+    # Restore default region/zone if we overrode them for compute
+    if original_region is not None:
+        await _set_config(session, "gcp_region", original_region)
+    if original_zone is not None:
+        await _set_config(session, "gcp_zone", original_zone)
 
     if compute_failed:
         # Log the expected cluster and its service accounts as orphaned

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -494,19 +494,28 @@ async def deploy_stack(
             )
 
     if compute_failed:
-        # Log the expected cluster as an orphaned resource
+        # Log the expected cluster and its service accounts as orphaned
         project_id = await _read_config(session, "gcp_project_id")
         region = await _read_config(session, "gcp_region") or "us-central1"
         org_slug = await _read_config(session, "org_slug")
         suffix = await _read_config(session, "deploy_suffix")
         if suffix and suffix != "null" and org_slug and org_slug != "null":
             cluster_name = f"bioaf-{org_slug}-{suffix}"
+            pid = project_id if project_id != "null" else ""
             await OrphanedResourceService.log_resource(
                 session,
                 resource_type="gke_cluster",
                 resource_name=cluster_name,
-                gcp_project_id=project_id if project_id != "null" else "",
+                gcp_project_id=pid,
                 gcp_zone=region,
+                stack_uid=suffix,
+            )
+            # The compute module also creates a service account
+            await OrphanedResourceService.log_resource(
+                session,
+                resource_type="service_account",
+                resource_name="bioaf-notebook-runner",
+                gcp_project_id=pid,
                 stack_uid=suffix,
             )
             await session.flush()
@@ -550,18 +559,27 @@ async def teardown_stack(
             teardown_failed = True
 
     if teardown_failed:
-        # Log the cluster as orphaned for later cleanup
+        # Log the cluster and its service accounts as orphaned
         project_id = await _read_config(session, "gcp_project_id")
         region = await _read_config(session, "gcp_region") or "us-central1"
         cluster_name = await _read_config(session, "gke_cluster_name")
         if cluster_name and cluster_name != "null":
+            pid = project_id if project_id != "null" else ""
+            uid = cluster_name.rsplit("-", 1)[-1]
             await OrphanedResourceService.log_resource(
                 session,
                 resource_type="gke_cluster",
                 resource_name=cluster_name,
-                gcp_project_id=project_id if project_id != "null" else "",
+                gcp_project_id=pid,
                 gcp_zone=region,
-                stack_uid=cluster_name.rsplit("-", 1)[-1],
+                stack_uid=uid,
+            )
+            await OrphanedResourceService.log_resource(
+                session,
+                resource_type="service_account",
+                resource_name="bioaf-notebook-runner",
+                gcp_project_id=pid,
+                stack_uid=uid,
             )
             await session.flush()
 

--- a/backend/app/services/terraform_executor.py
+++ b/backend/app/services/terraform_executor.py
@@ -162,6 +162,18 @@ class TerraformExecutor:
         resources_total = run.resources_planned or 0
         resources_completed = 0
 
+        # Emit the full resource list from the plan so the frontend can
+        # show all resources upfront with "Queued" status.
+        if run.plan_json and run.plan_json.get("resources"):
+            planned_addrs = [r["address"] for r in run.plan_json["resources"] if not r["address"].startswith("data.")]
+            yield TerraformProgressEvent(
+                event_type="planned_resources",
+                message="Resources planned",
+                resources_completed=0,
+                resources_total=resources_total,
+                extra={"addresses": planned_addrs},
+            )
+
         env, cleanup = await GCPCredentialInjector.build_env(config)
         log_lines: list[str] = []
         process = None

--- a/backend/app/services/terraform_executor.py
+++ b/backend/app/services/terraform_executor.py
@@ -103,7 +103,8 @@ class TerraformExecutor:
 
         try:
             work_dir = await asyncio.to_thread(TerraformExecutor._prepare_work_dir, module_name)
-            TerraformExecutor._write_tfvars(work_dir, module_name, config)
+            tfvars = TerraformExecutor._write_tfvars(work_dir, module_name, config)
+            run.tfvars_json = tfvars
 
             env, cleanup = await GCPCredentialInjector.build_env(config)
             try:
@@ -166,7 +167,9 @@ class TerraformExecutor:
         process = None
         try:
             work_dir = await asyncio.to_thread(TerraformExecutor._prepare_work_dir, module_name)
-            TerraformExecutor._write_tfvars(work_dir, module_name, config)
+            tfvars = TerraformExecutor._write_tfvars(work_dir, module_name, config)
+            if not run.tfvars_json:
+                run.tfvars_json = tfvars
             await TerraformExecutor._run_init(work_dir, env, config, module_name=module_name)
 
             process = await asyncio.create_subprocess_exec(
@@ -604,7 +607,8 @@ class TerraformExecutor:
         process = None
         try:
             work_dir = await asyncio.to_thread(TerraformExecutor._prepare_work_dir, module_name)
-            TerraformExecutor._write_tfvars(work_dir, module_name, config)
+            tfvars = TerraformExecutor._write_tfvars(work_dir, module_name, config)
+            run.tfvars_json = tfvars
             await TerraformExecutor._run_init(work_dir, env, config, module_name=module_name)
 
             process = await asyncio.create_subprocess_exec(
@@ -828,8 +832,11 @@ class TerraformExecutor:
         return tmp
 
     @staticmethod
-    def _write_tfvars(work_dir: Path, module_name: str, config: dict) -> None:
-        """Write terraform.tfvars.json into work_dir from platform_config values."""
+    def _write_tfvars(work_dir: Path, module_name: str, config: dict) -> dict:
+        """Write terraform.tfvars.json into work_dir from platform_config values.
+
+        Returns the tfvars dict so callers can persist it on the run record.
+        """
         project_id = config.get("gcp_project_id") or ""
         region = config.get("gcp_region") or "us-central1"
         zone = config.get("gcp_zone") or f"{region}-a"
@@ -879,6 +886,7 @@ class TerraformExecutor:
 
         tfvars_path = work_dir / "terraform.tfvars.json"
         tfvars_path.write_text(json.dumps(tfvars, indent=2))
+        return tfvars
 
     @staticmethod
     async def _run_init(

--- a/backend/app/services/terraform_executor.py
+++ b/backend/app/services/terraform_executor.py
@@ -35,10 +35,19 @@ logger = logging.getLogger("bioaf.terraform_executor")
 
 # Path inside the container / local dev where Terraform modules live
 MODULES_DIR = Path("/app/terraform/modules")
-STALE_RUN_THRESHOLD_MINUTES = 30
+
+# Safety ceiling: if a process runs longer than this, mark failed regardless.
+# This is a last-resort safeguard, not the primary recovery mechanism.
+SAFETY_TIMEOUT_HOURS = 4
 
 # Global asyncio lock - one Terraform operation at a time
 _tf_lock = asyncio.Lock()
+
+# In-memory registry of active Terraform processes.
+# Maps run_id -> asyncio.subprocess.Process.
+# Resets on container restart, which is the desired behavior: any
+# "applying" run left in the DB after restart has a dead process.
+_active_processes: dict[int, asyncio.subprocess.Process] = {}
 
 
 @dataclass
@@ -171,6 +180,7 @@ class TerraformExecutor:
                 stderr=asyncio.subprocess.PIPE,
                 env={**TerraformExecutor._base_env(), **env},
             )
+            _active_processes[run_id] = process
 
             while True:
                 try:
@@ -340,6 +350,7 @@ class TerraformExecutor:
                 resources_total=resources_total,
             )
         finally:
+            _active_processes.pop(run_id, None)
             await cleanup()
             if run.status == "failed":
                 await TerraformExecutor._auto_cleanup_lock(session, module_name)
@@ -607,6 +618,7 @@ class TerraformExecutor:
                 stderr=asyncio.subprocess.PIPE,
                 env={**TerraformExecutor._base_env(), **env},
             )
+            _active_processes[run.id] = process
 
             while True:
                 try:
@@ -723,6 +735,7 @@ class TerraformExecutor:
                 resources_total=resources_total,
             )
         finally:
+            _active_processes.pop(run.id, None)
             await cleanup()
             if run.status == "failed":
                 await TerraformExecutor._auto_cleanup_lock(session, module_name)
@@ -967,42 +980,81 @@ class TerraformExecutor:
         state_bucket = config.get("terraform_state_bucket", "")
         if state_bucket:
             lock_path = f"{module_name}/default.tflock"
-            await TerraformExecutor._delete_gcs_lock_file(state_bucket, lock_path)
+            credentials = await TerraformExecutor._load_gcs_credentials(session)
+            await TerraformExecutor._delete_gcs_lock_file(state_bucket, lock_path, credentials)
+
+    @staticmethod
+    async def _load_gcs_credentials(session: AsyncSession):
+        """Load GCS credentials from platform_config (same SA the app uses)."""
+        from app.services.gcs_storage import GcsStorageService
+
+        return await GcsStorageService.get_credentials(session)
 
     @staticmethod
     async def _recover_stale_runs(session: AsyncSession) -> None:
-        """Mark runs stuck in planning/applying/awaiting_confirmation for >30 min as failed."""
-        cutoff = datetime.now(timezone.utc) - timedelta(minutes=STALE_RUN_THRESHOLD_MINUTES)
+        """Recover runs whose Terraform process is no longer alive.
 
-        # Find stale runs first so we can clean up their lock files
-        stale_result = await session.execute(
+        Uses the in-memory process registry to determine whether a run
+        has a live process. After a container restart the registry is
+        empty, so all leftover "applying" rows are immediately recoverable.
+        A safety ceiling of SAFETY_TIMEOUT_HOURS catches processes that
+        are technically alive but have been running unreasonably long.
+        """
+        safety_cutoff = datetime.now(timezone.utc) - timedelta(hours=SAFETY_TIMEOUT_HOURS)
+
+        result = await session.execute(
             text("""
-            SELECT id, module_name FROM terraform_runs
+            SELECT id, module_name, started_at FROM terraform_runs
             WHERE status IN ('planning', 'applying', 'awaiting_confirmation')
-              AND started_at < :cutoff
-            """).bindparams(cutoff=cutoff)
+            """)
         )
-        stale_runs = stale_result.fetchall()
+        active_rows = result.fetchall()
 
-        if stale_runs:
+        runs_to_fail: list[tuple[int, str | None]] = []
+        for run_id, module_name, started_at in active_rows:
+            process = _active_processes.get(run_id)
+
+            if process is not None and process.returncode is None:
+                # Process is alive in this container
+                if started_at < safety_cutoff:
+                    # But has exceeded the safety ceiling
+                    logger.warning(
+                        "Run %d has been running for >%d hours, marking failed",
+                        run_id,
+                        SAFETY_TIMEOUT_HOURS,
+                    )
+                    process.terminate()
+                    _active_processes.pop(run_id, None)
+                    runs_to_fail.append((run_id, module_name))
+                else:
+                    # Still within limits, leave it alone
+                    continue
+            else:
+                # No live process -- container restarted or process exited
+                # without proper cleanup
+                _active_processes.pop(run_id, None)
+                runs_to_fail.append((run_id, module_name))
+
+        if runs_to_fail:
+            credentials = await TerraformExecutor._load_gcs_credentials(session)
             config = await TerraformExecutor._read_gcp_config(session)
             state_bucket = config.get("terraform_state_bucket", "")
-            if state_bucket:
-                for _run_id, module_name in stale_runs:
-                    if module_name:
-                        lock_path = f"{module_name}/default.tflock"
-                        await TerraformExecutor._delete_gcs_lock_file(state_bucket, lock_path)
 
-            await session.execute(
-                text("""
-                UPDATE terraform_runs
-                SET status = 'failed',
-                    error_message = 'Run timed out and was recovered',
-                    completed_at = now()
-                WHERE status IN ('planning', 'applying', 'awaiting_confirmation')
-                  AND started_at < :cutoff
-                """).bindparams(cutoff=cutoff)
-            )
+            for run_id, module_name in runs_to_fail:
+                if state_bucket and module_name:
+                    lock_path = f"{module_name}/default.tflock"
+                    await TerraformExecutor._delete_gcs_lock_file(state_bucket, lock_path, credentials)
+                await session.execute(
+                    text("""
+                    UPDATE terraform_runs
+                    SET status = 'failed',
+                        error_message = 'Process no longer running (recovered)',
+                        completed_at = now()
+                    WHERE id = :run_id
+                      AND status IN ('planning', 'applying', 'awaiting_confirmation')
+                    """).bindparams(run_id=run_id)
+                )
+
         await session.flush()
 
     @staticmethod
@@ -1033,7 +1085,13 @@ class TerraformExecutor:
         lock_path = f"{module_name}/default.tflock"
 
         if state_bucket:
-            await TerraformExecutor._delete_gcs_lock_file(state_bucket, lock_path)
+            credentials = await TerraformExecutor._load_gcs_credentials(session)
+            await TerraformExecutor._delete_gcs_lock_file(state_bucket, lock_path, credentials)
+
+        # Kill the process if it's still running in this container
+        process = _active_processes.pop(run_id, None)
+        if process and process.returncode is None:
+            process.terminate()
 
         run.status = "cancelled"
         run.error_message = "Abandoned by user"
@@ -1052,15 +1110,20 @@ class TerraformExecutor:
         return run
 
     @staticmethod
-    async def _delete_gcs_lock_file(bucket_name: str, lock_path: str) -> None:
+    async def _delete_gcs_lock_file(
+        bucket_name: str,
+        lock_path: str,
+        credentials=None,
+    ) -> None:
         """Delete a Terraform lock file from a GCS bucket.
 
-        Uses google-cloud-storage Python client. Failures are logged but not
-        raised since the run is already marked cancelled.
+        Uses the app's configured credentials when available; falls back
+        to ADC. Failures are logged but not raised since the run is
+        already marked cancelled/failed.
         """
 
         def _delete() -> None:
-            client = storage.Client()
+            client = storage.Client(credentials=credentials) if credentials else storage.Client()
             bucket = client.bucket(bucket_name)
             blob = bucket.blob(lock_path)
             blob.delete()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.6.2"
+version = "0.6.3"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_cloud_logging.py
+++ b/backend/tests/test_cloud_logging.py
@@ -1,8 +1,8 @@
-"""Tests for Google Cloud Logging auto-configuration.
+"""Tests for Google Cloud Logging configuration.
 
-Verifies that the logging configuration module detects GCE, attaches
-a Cloud Logging handler when running on GCE, and falls back to
-stdout-only when off GCE or when credentials are unavailable.
+Verifies that configure_logging sets up stdout, that attach_cloud_logging
+adds a Cloud Logging handler when credentials are provided, and that
+failures fall back gracefully.
 """
 
 import logging
@@ -61,91 +61,107 @@ class TestGetGceProjectId:
 
 
 class TestConfigureLogging:
-    """Test configure_logging()."""
+    """Test configure_logging (stdout only)."""
 
     def setup_method(self):
-        """Clear bioaf logger handlers before each test."""
         logging.getLogger("bioaf").handlers.clear()
 
     def test_stdout_handler_always_present(self):
         from app.logging_config import configure_logging
 
-        with patch("app.logging_config.is_running_on_gce", return_value=False):
-            configure_logging(debug=False)
+        configure_logging(debug=False)
 
         bioaf_logger = logging.getLogger("bioaf")
         stream_handlers = [h for h in bioaf_logger.handlers if isinstance(h, logging.StreamHandler)]
         assert len(stream_handlers) >= 1
 
-    def test_cloud_handler_attached_on_gce(self):
+    def test_no_cloud_handler_from_configure(self):
         from app.logging_config import configure_logging
+
+        configure_logging(debug=False)
+
+        bioaf_logger = logging.getLogger("bioaf")
+        handler_types = [type(h).__name__ for h in bioaf_logger.handlers]
+        assert "CloudLoggingHandler" not in handler_types
+
+    def test_debug_mode_sets_debug_level(self):
+        from app.logging_config import configure_logging
+
+        configure_logging(debug=True)
+        assert logging.getLogger("bioaf").level == logging.DEBUG
+
+    def test_production_mode_sets_info_level(self):
+        from app.logging_config import configure_logging
+
+        configure_logging(debug=False)
+        assert logging.getLogger("bioaf").level == logging.INFO
+
+
+class TestAttachCloudLogging:
+    """Test attach_cloud_logging with explicit credentials."""
+
+    def setup_method(self):
+        logging.getLogger("bioaf").handlers.clear()
+
+    def test_attaches_handler_with_credentials(self):
+        from app.logging_config import attach_cloud_logging, configure_logging
+
+        configure_logging(debug=False)
+
+        mock_client = MagicMock()
+        mock_handler = MagicMock(spec=logging.Handler)
+        mock_handler.level = logging.NOTSET
+        mock_client.get_default_handler.return_value = mock_handler
+        mock_creds = MagicMock()
+
+        with patch("app.logging_config.cloud_logging") as mock_module:
+            mock_module.Client.return_value = mock_client
+            attach_cloud_logging("test-project", mock_creds, debug=False)
+            mock_module.Client.assert_called_once_with(project="test-project", credentials=mock_creds)
+
+        bioaf_logger = logging.getLogger("bioaf")
+        assert mock_handler in bioaf_logger.handlers
+        bioaf_logger.removeHandler(mock_handler)
+
+    def test_attaches_handler_with_none_credentials(self):
+        from app.logging_config import attach_cloud_logging, configure_logging
+
+        configure_logging(debug=False)
 
         mock_client = MagicMock()
         mock_handler = MagicMock(spec=logging.Handler)
         mock_handler.level = logging.NOTSET
         mock_client.get_default_handler.return_value = mock_handler
 
-        with (
-            patch("app.logging_config.is_running_on_gce", return_value=True),
-            patch("app.logging_config.get_gce_project_id", return_value="test-project"),
-            patch("app.logging_config.cloud_logging") as mock_module,
-        ):
+        with patch("app.logging_config.cloud_logging") as mock_module:
             mock_module.Client.return_value = mock_client
-            configure_logging(debug=False)
+            attach_cloud_logging("test-project", None, debug=False)
+            mock_module.Client.assert_called_once_with(project="test-project", credentials=None)
 
         bioaf_logger = logging.getLogger("bioaf")
         assert mock_handler in bioaf_logger.handlers
         bioaf_logger.removeHandler(mock_handler)
 
-    def test_no_cloud_handler_off_gce(self):
-        from app.logging_config import configure_logging
-
-        with patch("app.logging_config.is_running_on_gce", return_value=False):
-            configure_logging(debug=False)
-
-        bioaf_logger = logging.getLogger("bioaf")
-        handler_types = [type(h).__name__ for h in bioaf_logger.handlers]
-        assert "CloudLoggingHandler" not in handler_types
-
     def test_graceful_fallback_on_credential_error(self):
-        from app.logging_config import configure_logging
+        from app.logging_config import attach_cloud_logging, configure_logging
 
-        with (
-            patch("app.logging_config.is_running_on_gce", return_value=True),
-            patch("app.logging_config.get_gce_project_id", return_value="test-project"),
-            patch("app.logging_config.cloud_logging") as mock_module,
-        ):
-            mock_module.Client.side_effect = Exception("No credentials")
-            configure_logging(debug=False)
+        configure_logging(debug=False)
+
+        with patch("app.logging_config.cloud_logging") as mock_module:
+            mock_module.Client.side_effect = Exception("Bad credentials")
+            attach_cloud_logging("test-project", MagicMock(), debug=False)
 
         bioaf_logger = logging.getLogger("bioaf")
         stream_handlers = [h for h in bioaf_logger.handlers if isinstance(h, logging.StreamHandler)]
         assert len(stream_handlers) >= 1
 
-    def test_debug_mode_sets_debug_level(self):
-        from app.logging_config import configure_logging
+    def test_skipped_when_library_missing(self):
+        from app.logging_config import attach_cloud_logging, configure_logging
 
-        with patch("app.logging_config.is_running_on_gce", return_value=False):
-            configure_logging(debug=True)
+        configure_logging(debug=False)
 
-        assert logging.getLogger("bioaf").level == logging.DEBUG
-
-    def test_production_mode_sets_info_level(self):
-        from app.logging_config import configure_logging
-
-        with patch("app.logging_config.is_running_on_gce", return_value=False):
-            configure_logging(debug=False)
-
-        assert logging.getLogger("bioaf").level == logging.INFO
-
-    def test_cloud_logging_skipped_when_library_missing(self):
-        from app.logging_config import configure_logging
-
-        with (
-            patch("app.logging_config.is_running_on_gce", return_value=True),
-            patch("app.logging_config.cloud_logging", None),
-        ):
-            configure_logging(debug=False)
+        with patch("app.logging_config.cloud_logging", None):
+            attach_cloud_logging("test-project", MagicMock(), debug=False)
 
         bioaf_logger = logging.getLogger("bioaf")
         handler_types = [type(h).__name__ for h in bioaf_logger.handlers]

--- a/backend/tests/test_cloud_logging.py
+++ b/backend/tests/test_cloud_logging.py
@@ -1,0 +1,152 @@
+"""Tests for Google Cloud Logging auto-configuration.
+
+Verifies that the logging configuration module detects GCE, attaches
+a Cloud Logging handler when running on GCE, and falls back to
+stdout-only when off GCE or when credentials are unavailable.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+
+class TestGceDetection:
+    """Test GCE metadata server detection."""
+
+    def test_detects_gce_when_metadata_responds(self):
+        from app.logging_config import is_running_on_gce
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = b"test-project"
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("app.logging_config.urllib.request.urlopen", return_value=mock_response):
+            assert is_running_on_gce() is True
+
+    def test_not_gce_when_metadata_unavailable(self):
+        from app.logging_config import is_running_on_gce
+
+        with patch(
+            "app.logging_config.urllib.request.urlopen",
+            side_effect=Exception("Connection refused"),
+        ):
+            assert is_running_on_gce() is False
+
+
+class TestGetGceProjectId:
+    """Test GCE project ID retrieval from metadata."""
+
+    def test_returns_project_id(self):
+        from app.logging_config import get_gce_project_id
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"my-gcp-project"
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("app.logging_config.urllib.request.urlopen", return_value=mock_response):
+            assert get_gce_project_id() == "my-gcp-project"
+
+    def test_strips_whitespace(self):
+        from app.logging_config import get_gce_project_id
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"  my-project \n"
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("app.logging_config.urllib.request.urlopen", return_value=mock_response):
+            assert get_gce_project_id() == "my-project"
+
+
+class TestConfigureLogging:
+    """Test configure_logging()."""
+
+    def setup_method(self):
+        """Clear bioaf logger handlers before each test."""
+        logging.getLogger("bioaf").handlers.clear()
+
+    def test_stdout_handler_always_present(self):
+        from app.logging_config import configure_logging
+
+        with patch("app.logging_config.is_running_on_gce", return_value=False):
+            configure_logging(debug=False)
+
+        bioaf_logger = logging.getLogger("bioaf")
+        stream_handlers = [h for h in bioaf_logger.handlers if isinstance(h, logging.StreamHandler)]
+        assert len(stream_handlers) >= 1
+
+    def test_cloud_handler_attached_on_gce(self):
+        from app.logging_config import configure_logging
+
+        mock_client = MagicMock()
+        mock_handler = MagicMock(spec=logging.Handler)
+        mock_handler.level = logging.NOTSET
+        mock_client.get_default_handler.return_value = mock_handler
+
+        with (
+            patch("app.logging_config.is_running_on_gce", return_value=True),
+            patch("app.logging_config.get_gce_project_id", return_value="test-project"),
+            patch("app.logging_config.cloud_logging") as mock_module,
+        ):
+            mock_module.Client.return_value = mock_client
+            configure_logging(debug=False)
+
+        bioaf_logger = logging.getLogger("bioaf")
+        assert mock_handler in bioaf_logger.handlers
+        bioaf_logger.removeHandler(mock_handler)
+
+    def test_no_cloud_handler_off_gce(self):
+        from app.logging_config import configure_logging
+
+        with patch("app.logging_config.is_running_on_gce", return_value=False):
+            configure_logging(debug=False)
+
+        bioaf_logger = logging.getLogger("bioaf")
+        handler_types = [type(h).__name__ for h in bioaf_logger.handlers]
+        assert "CloudLoggingHandler" not in handler_types
+
+    def test_graceful_fallback_on_credential_error(self):
+        from app.logging_config import configure_logging
+
+        with (
+            patch("app.logging_config.is_running_on_gce", return_value=True),
+            patch("app.logging_config.get_gce_project_id", return_value="test-project"),
+            patch("app.logging_config.cloud_logging") as mock_module,
+        ):
+            mock_module.Client.side_effect = Exception("No credentials")
+            configure_logging(debug=False)
+
+        bioaf_logger = logging.getLogger("bioaf")
+        stream_handlers = [h for h in bioaf_logger.handlers if isinstance(h, logging.StreamHandler)]
+        assert len(stream_handlers) >= 1
+
+    def test_debug_mode_sets_debug_level(self):
+        from app.logging_config import configure_logging
+
+        with patch("app.logging_config.is_running_on_gce", return_value=False):
+            configure_logging(debug=True)
+
+        assert logging.getLogger("bioaf").level == logging.DEBUG
+
+    def test_production_mode_sets_info_level(self):
+        from app.logging_config import configure_logging
+
+        with patch("app.logging_config.is_running_on_gce", return_value=False):
+            configure_logging(debug=False)
+
+        assert logging.getLogger("bioaf").level == logging.INFO
+
+    def test_cloud_logging_skipped_when_library_missing(self):
+        from app.logging_config import configure_logging
+
+        with (
+            patch("app.logging_config.is_running_on_gce", return_value=True),
+            patch("app.logging_config.cloud_logging", None),
+        ):
+            configure_logging(debug=False)
+
+        bioaf_logger = logging.getLogger("bioaf")
+        handler_types = [type(h).__name__ for h in bioaf_logger.handlers]
+        assert "CloudLoggingHandler" not in handler_types

--- a/backend/tests/test_gcp_config_service.py
+++ b/backend/tests/test_gcp_config_service.py
@@ -70,6 +70,7 @@ ALL_REQUIRED_PERMISSIONS = [
     "bigquery.jobs.create",
     "artifactregistry.repositories.create",
     "cloudbuild.builds.create",
+    "logging.logEntries.create",
 ]
 
 

--- a/backend/tests/test_terraform_executor.py
+++ b/backend/tests/test_terraform_executor.py
@@ -376,20 +376,32 @@ async def test_run_apply_handles_failure(session):
 @pytest.mark.asyncio
 async def test_concurrent_run_prevention(session):
     """run_plan raises ValueError if another run is in progress."""
+    from app.services.terraform_executor import _active_processes
+
     user_id = await _seed_user(session)
     await _seed_gcp_config(session, configured=True, initialized=True)
 
     # Insert an active run manually
-    await session.execute(
+    result = await session.execute(
         text("""
         INSERT INTO terraform_runs (triggered_by_user_id, action, status)
         VALUES (:uid, 'plan', 'planning')
+        RETURNING id
         """).bindparams(uid=user_id)
     )
+    run_id = result.fetchone()[0]
     await session.commit()
 
-    with pytest.raises(ValueError, match="in progress"):
-        await TerraformExecutor.run_plan(session=session, user_id=user_id, module_name="foundation")
+    # Register a mock process so stale recovery doesn't clean it up
+    mock_process = MagicMock()
+    mock_process.returncode = None
+    _active_processes[run_id] = mock_process
+
+    try:
+        with pytest.raises(ValueError, match="in progress"):
+            await TerraformExecutor.run_plan(session=session, user_id=user_id, module_name="foundation")
+    finally:
+        _active_processes.pop(run_id, None)
 
 
 # ---------------------------------------------------------------------------
@@ -1232,23 +1244,26 @@ async def test_run_destroy_failure_deletes_lock(session):
 
 
 @pytest.mark.asyncio
-async def test_recover_stale_runs_deletes_locks(session):
-    """_recover_stale_runs deletes lock files for recovered runs."""
+async def test_recover_stale_runs_no_process_marks_failed(session):
+    """Runs with no live process in the registry are marked failed."""
     user_id = await _seed_user(session)
     await _seed_gcp_config(session, configured=True, initialized=True)
 
-    # Insert a stale run (started 60 minutes ago)
+    # Insert a run that has no corresponding process (simulates container restart)
     await session.execute(
         text("""
         INSERT INTO terraform_runs
             (triggered_by_user_id, action, status, module_name, started_at)
-        VALUES (:uid, 'apply', 'applying', 'compute', now() - interval '60 minutes')
+        VALUES (:uid, 'apply', 'applying', 'compute', now() - interval '5 minutes')
         """).bindparams(uid=user_id)
     )
     await session.commit()
 
     mock_delete = AsyncMock()
-    with patch.object(TerraformExecutor, "_delete_gcs_lock_file", new=mock_delete):
+    with (
+        patch.object(TerraformExecutor, "_delete_gcs_lock_file", new=mock_delete),
+        patch.object(TerraformExecutor, "_load_gcs_credentials", new=AsyncMock(return_value=None)),
+    ):
         await TerraformExecutor._recover_stale_runs(session)
 
     mock_delete.assert_called_once()
@@ -1256,6 +1271,47 @@ async def test_recover_stale_runs_deletes_locks(session):
     assert call_args[0][0] == "bioaf-tfstate-test"
     assert "compute/default.tflock" in call_args[0][1]
 
-    # Verify the run was marked failed
     row = (await session.execute(text("SELECT status FROM terraform_runs LIMIT 1"))).fetchone()
     assert row[0] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_runs_skips_live_process(session):
+    """Runs with a live process in the registry are left alone."""
+    from app.services.terraform_executor import _active_processes
+
+    user_id = await _seed_user(session)
+    await _seed_gcp_config(session, configured=True, initialized=True)
+
+    result = await session.execute(
+        text("""
+        INSERT INTO terraform_runs
+            (triggered_by_user_id, action, status, module_name, started_at)
+        VALUES (:uid, 'apply', 'applying', 'compute', now() - interval '10 minutes')
+        RETURNING id
+        """).bindparams(uid=user_id)
+    )
+    run_id = result.fetchone()[0]
+    await session.commit()
+
+    # Register a mock process as alive
+    mock_process = MagicMock()
+    mock_process.returncode = None  # Still running
+    _active_processes[run_id] = mock_process
+
+    try:
+        mock_delete = AsyncMock()
+        with (
+            patch.object(TerraformExecutor, "_delete_gcs_lock_file", new=mock_delete),
+            patch.object(TerraformExecutor, "_load_gcs_credentials", new=AsyncMock(return_value=None)),
+        ):
+            await TerraformExecutor._recover_stale_runs(session)
+
+        mock_delete.assert_not_called()
+
+        row = (
+            await session.execute(text("SELECT status FROM terraform_runs WHERE id = :id").bindparams(id=run_id))
+        ).fetchone()
+        assert row[0] == "applying"  # Still applying, not failed
+    finally:
+        _active_processes.pop(run_id, None)

--- a/bioaf
+++ b/bioaf
@@ -66,35 +66,29 @@ is_gce() {
 ensure_cloud_logging() {
     # Install and configure the Google Cloud Ops Agent on GCE so that
     # all Docker container logs are forwarded to Cloud Logging.
-    # Idempotent -- skips everything if not on GCE or already running.
+    # Idempotent -- safe to call on every start.
 
     if ! is_gce; then
         return 0
     fi
 
-    # Already running -- nothing to do
-    if systemctl is-active --quiet google-cloud-ops-agent 2>/dev/null; then
-        return 0
-    fi
-
-    bold "Setting up Google Cloud Logging (Ops Agent)..."
-
     # Install the Ops Agent if the binary is not present
     if ! command -v google_cloud_ops_agent_engine &>/dev/null; then
+        bold "Installing Google Cloud Ops Agent..."
         curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
         sudo bash add-google-cloud-ops-agent-repo.sh --also-install
         rm -f add-google-cloud-ops-agent-repo.sh
     fi
 
-    # Deploy the Docker log collection config
+    # Deploy the Docker log collection config if not already present
     local ops_config="/etc/google-cloud-ops-agent/config.yaml"
     if [ ! -f "$ops_config" ] || ! grep -q "docker_logs" "$ops_config" 2>/dev/null; then
+        bold "Configuring Ops Agent for Docker log collection..."
         sudo mkdir -p /etc/google-cloud-ops-agent
         sudo cp "$SCRIPT_DIR/docker/ops-agent-config.yaml" "$ops_config"
         sudo systemctl restart google-cloud-ops-agent
+        green "Cloud Logging configured -- logs will appear in Google Cloud Console."
     fi
-
-    green "Cloud Logging configured -- logs will appear in Google Cloud Console."
 }
 
 # ---------------------------------------------------------------------------

--- a/bioaf
+++ b/bioaf
@@ -57,6 +57,46 @@ get_access_url() {
     echo "https://${host}"
 }
 
+is_gce() {
+    curl -sf -m 1 -H "Metadata-Flavor: Google" \
+        "http://169.254.169.254/computeMetadata/v1/project/project-id" \
+        >/dev/null 2>&1
+}
+
+ensure_cloud_logging() {
+    # Install and configure the Google Cloud Ops Agent on GCE so that
+    # all Docker container logs are forwarded to Cloud Logging.
+    # Idempotent -- skips everything if not on GCE or already running.
+
+    if ! is_gce; then
+        return 0
+    fi
+
+    # Already running -- nothing to do
+    if systemctl is-active --quiet google-cloud-ops-agent 2>/dev/null; then
+        return 0
+    fi
+
+    bold "Setting up Google Cloud Logging (Ops Agent)..."
+
+    # Install the Ops Agent if the binary is not present
+    if ! command -v google_cloud_ops_agent_engine &>/dev/null; then
+        curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+        sudo bash add-google-cloud-ops-agent-repo.sh --also-install
+        rm -f add-google-cloud-ops-agent-repo.sh
+    fi
+
+    # Deploy the Docker log collection config
+    local ops_config="/etc/google-cloud-ops-agent/config.yaml"
+    if [ ! -f "$ops_config" ] || ! grep -q "docker_logs" "$ops_config" 2>/dev/null; then
+        sudo mkdir -p /etc/google-cloud-ops-agent
+        sudo cp "$SCRIPT_DIR/docker/ops-agent-config.yaml" "$ops_config"
+        sudo systemctl restart google-cloud-ops-agent
+    fi
+
+    green "Cloud Logging configured -- logs will appear in Google Cloud Console."
+}
+
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
@@ -120,6 +160,9 @@ for v in cfg.get('volumes', {}).values():
         yellow "Removing existing database volume ($vol_name) to avoid password mismatch..."
         $DC down -v 2>/dev/null || true
     fi
+
+    # Cloud Logging (GCE only, idempotent)
+    ensure_cloud_logging
 
     # Build and start
     bold "Building and starting containers..."
@@ -190,6 +233,9 @@ print(json.dumps(result))
 
 cmd_start() {
     bold "=== Starting Services ==="
+
+    # Cloud Logging (GCE only, idempotent)
+    ensure_cloud_logging
 
     for svc in db backend frontend nginx; do
         echo "Starting $svc..."
@@ -305,6 +351,9 @@ cmd_update() {
 
     echo "Pulling latest code..."
     git -C "$SCRIPT_DIR" pull
+
+    # Cloud Logging (GCE only, idempotent)
+    ensure_cloud_logging
 
     echo "Rebuilding containers..."
     $DC_BUILD

--- a/docker/ops-agent-config.yaml
+++ b/docker/ops-agent-config.yaml
@@ -1,0 +1,26 @@
+# Google Cloud Ops Agent -- bioAF Docker log collection
+#
+# Reads Docker container JSON log files and forwards them to
+# Cloud Logging.  Merges with the Ops Agent built-in defaults
+# (syslog, host metrics) so those continue to work.
+#
+# Installed automatically by ./bioaf setup / ./bioaf start on GCE.
+
+logging:
+  receivers:
+    docker_logs:
+      type: files
+      include_paths:
+        - /var/lib/docker/containers/*/*.log
+  processors:
+    parse_docker_json:
+      type: parse_json
+      time_key: time
+      time_format: "%Y-%m-%dT%H:%M:%S.%LZ"
+  service:
+    pipelines:
+      docker:
+        receivers:
+          - docker_logs
+        processors:
+          - parse_docker_json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -174,12 +174,15 @@ export default function InfraComponentsPage() {
     }
   }, [deployProgress.active, deployStarted]);
 
-  // When a tracked deployment finishes, refresh page data
+  // When a tracked operation finishes, refresh page data.
+  // Keep the terminal status visible in the modal for 1 render cycle
+  // before clearing deployStarted so the modal can show Done/Error.
+  const [terminalStatus, setTerminalStatus] = useState<string | null>(null);
   useEffect(() => {
     if (!deployStarted) return;
     if (!deployProgress.active && deployProgress.status !== null) {
-      setDeployStarted(false);
-      setRefreshKey((k) => k + 1);
+      // Capture the terminal status so the modal can display it
+      setTerminalStatus(deployProgress.status);
     }
   }, [deployStarted, deployProgress.active, deployProgress.status]);
 
@@ -339,6 +342,7 @@ export default function InfraComponentsPage() {
   function handleDeployComplete() {
     setShowDeployModal(false);
     setDeployStarted(false);
+    setTerminalStatus(null);
     setRefreshKey((k) => k + 1);
   }
 
@@ -389,11 +393,15 @@ export default function InfraComponentsPage() {
 
   function handleTeardownComplete() {
     setShowTeardownProgress(false);
+    setDeployStarted(false);
+    setTerminalStatus(null);
     setRefreshKey((k) => k + 1);
   }
 
   function handleDestroyStorageComplete() {
     setShowDestroyStorageProgress(false);
+    setDeployStarted(false);
+    setTerminalStatus(null);
     setRefreshKey((k) => k + 1);
   }
 
@@ -1056,7 +1064,7 @@ export default function InfraComponentsPage() {
       {showDeployModal && (
         <DeployProgressModal
           phase={deployProgress.phase}
-          status={deployProgress.status ?? (deployStarted ? "planning" : null)}
+          status={deployProgress.status ?? terminalStatus ?? (deployStarted ? "planning" : null)}
           resourcesCompleted={deployProgress.resources_completed}
           resourcesTotal={deployProgress.resources_total}
           completedResources={deployProgress.completed_resources}
@@ -1212,7 +1220,7 @@ export default function InfraComponentsPage() {
         <DeployProgressModal
           mode="teardown"
           phase={deployProgress.phase}
-          status={deployProgress.status ?? (deployStarted ? "applying" : null)}
+          status={deployProgress.status ?? terminalStatus ?? (deployStarted ? "applying" : null)}
           resourcesCompleted={deployProgress.resources_completed}
           resourcesTotal={deployProgress.resources_total}
           completedResources={deployProgress.completed_resources}
@@ -1303,7 +1311,7 @@ export default function InfraComponentsPage() {
         <DeployProgressModal
           mode="teardown"
           phase={deployProgress.phase}
-          status={deployProgress.status ?? (deployStarted ? "applying" : null)}
+          status={deployProgress.status ?? terminalStatus ?? (deployStarted ? "applying" : null)}
           resourcesCompleted={deployProgress.resources_completed}
           resourcesTotal={deployProgress.resources_total}
           completedResources={deployProgress.completed_resources}

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -1028,6 +1028,7 @@ export default function InfraComponentsPage() {
           resourcesCompleted={deployProgress.resources_completed}
           resourcesTotal={deployProgress.resources_total}
           completedResources={deployProgress.completed_resources}
+          plannedResources={deployProgress.planned_resources}
           errorMessage={deployProgress.error_message}
           onDismiss={() => setShowDeployModal(false)}
           onAbort={() => {

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -13,6 +13,7 @@ import { OrphanedResourcesCard } from "@/components/infrastructure/OrphanedResou
 import { DeployRecoveryModal } from "@/components/infrastructure/DeployRecoveryModal";
 import { useDeploymentProgress } from "@/hooks/useDeploymentProgress";
 import { isAuthenticated } from "@/lib/auth";
+import { GCP_REGIONS, zonesForRegion } from "@/lib/gcp-regions";
 import { api } from "@/lib/api";
 import { invalidateComponentCache } from "@/hooks/useComponents";
 
@@ -152,6 +153,12 @@ export default function InfraComponentsPage() {
   const [showAbandonModal, setShowAbandonModal] = useState(false);
   const [abandonLoading, setAbandonLoading] = useState(false);
   const [showRecoveryModal, setShowRecoveryModal] = useState(false);
+  const [showDeployConfirm, setShowDeployConfirm] = useState(false);
+  const [defaultRegion, setDefaultRegion] = useState("us-central1");
+  const [defaultZone, setDefaultZone] = useState("us-central1-a");
+  const [deployRegion, setDeployRegion] = useState("us-central1");
+  const [deployZone, setDeployZone] = useState("us-central1-a");
+  const [useSpecificZone, setUseSpecificZone] = useState(false);
   const [recoveryCheckedOnLoad, setRecoveryCheckedOnLoad] = useState(false);
 
   const DESTROY_STORAGE_PHRASE = "delete my data";
@@ -186,12 +193,13 @@ export default function InfraComponentsPage() {
 
   async function loadData() {
     // Fetch all data in parallel so the page renders once with complete state
-    const [tfResult, runsResult, ssResult, cdResult, ccResult] = await Promise.allSettled([
+    const [tfResult, runsResult, ssResult, cdResult, ccResult, gcpResult] = await Promise.allSettled([
       api.get<TerraformStatus>("/api/v1/infrastructure/terraform/status"),
       api.get<{ runs: TerraformRun[] }>("/api/v1/infrastructure/terraform/runs"),
       api.get<StackStatus>("/api/v1/infrastructure/stack/status"),
       api.get<ComponentsData>("/api/v1/infrastructure/stack/components"),
       api.get<ClusterConfig>("/api/v1/infrastructure/cluster/config"),
+      api.get<{ gcp_region?: string; gcp_zone?: string }>("/api/v1/settings/gcp"),
     ]);
 
     if (tfResult.status === "fulfilled") setTfStatus(tfResult.value);
@@ -199,6 +207,17 @@ export default function InfraComponentsPage() {
     if (ssResult.status === "fulfilled") setStackStatus(ssResult.value);
     if (cdResult.status === "fulfilled") setComponentsData(cdResult.value);
     if (ccResult.status === "fulfilled") setClusterConfig(ccResult.value);
+    if (gcpResult.status === "fulfilled") {
+      const gcp = gcpResult.value;
+      if (gcp.gcp_region) {
+        setDefaultRegion(gcp.gcp_region);
+        setDeployRegion(gcp.gcp_region);
+      }
+      if (gcp.gcp_zone) {
+        setDefaultZone(gcp.gcp_zone);
+        setDeployZone(gcp.gcp_zone);
+      }
+    }
     setLoading(false);
   }
 
@@ -280,7 +299,7 @@ export default function InfraComponentsPage() {
 
   const [deployLoading, setDeployLoading] = useState(false);
 
-  async function handleStartDeploy() {
+  function handleStartDeploy() {
     if (deployLoading) return;
 
     // Check for orphaned clusters before deploying to prevent duplicates
@@ -289,11 +308,24 @@ export default function InfraComponentsPage() {
       return;
     }
 
+    setDeployRegion(defaultRegion);
+    setDeployZone(defaultZone);
+    setUseSpecificZone(false);
+    setShowDeployConfirm(true);
+  }
+
+  async function handleConfirmDeploy() {
+    setShowDeployConfirm(false);
     setDeployLoading(true);
     try {
-      await api.post("/api/v1/infrastructure/stack/deploy-background", {
-        stack_type: "kubernetes",
-      });
+      const body: Record<string, string> = { stack_type: "kubernetes" };
+      if (deployRegion !== defaultRegion) {
+        body.compute_region = deployRegion;
+      }
+      if (useSpecificZone && deployZone) {
+        body.compute_zone = deployZone;
+      }
+      await api.post("/api/v1/infrastructure/stack/deploy-background", body);
       setDeployStarted(true);
       setShowDeployModal(true);
     } catch (e) {
@@ -1037,6 +1069,92 @@ export default function InfraComponentsPage() {
           }}
           onDone={handleDeployComplete}
         />
+      )}
+
+      {/* Deploy Confirmation Modal - Region/Zone Selection */}
+      {showDeployConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-xl p-6 max-w-md w-full mx-4">
+            <h2 className="text-lg font-semibold mb-4">Deploy Compute Infrastructure</h2>
+
+            {/* Region */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">Region</label>
+              <select
+                value={deployRegion}
+                onChange={(e) => {
+                  setDeployRegion(e.target.value);
+                  setDeployZone(zonesForRegion(e.target.value)[0]);
+                }}
+                className="w-full px-3 py-2 border rounded text-sm"
+              >
+                {GCP_REGIONS.map((r) => (
+                  <option key={r} value={r}>
+                    {r}{r === defaultRegion ? " (default)" : ""}
+                  </option>
+                ))}
+              </select>
+              {deployRegion !== defaultRegion && (
+                <p className="text-xs text-amber-600 mt-1 flex items-start gap-1">
+                  <span className="mt-0.5">&#9888;</span>
+                  Your storage is in {defaultRegion}. Deploying compute in {deployRegion} may
+                  incur cross-region network costs in GCP.
+                </p>
+              )}
+            </div>
+
+            {/* Zone toggle */}
+            <div className="mb-4">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={useSpecificZone}
+                  onChange={(e) => setUseSpecificZone(e.target.checked)}
+                />
+                <span className="text-sm text-gray-700">Deploy to a specific zone</span>
+                <span
+                  className="text-gray-400 cursor-help"
+                  title="Without a specific zone, GKE creates a multi-zonal cluster with nodes distributed across availability zones. This provides better resilience but may cost slightly more."
+                >
+                  &#9432;
+                </span>
+              </label>
+              {useSpecificZone && (
+                <select
+                  value={deployZone}
+                  onChange={(e) => setDeployZone(e.target.value)}
+                  className="w-full px-3 py-2 border rounded text-sm mt-2"
+                >
+                  {zonesForRegion(deployRegion).map((z) => (
+                    <option key={z} value={z}>{z}</option>
+                  ))}
+                </select>
+              )}
+              {!useSpecificZone && (
+                <p className="text-xs text-gray-400 mt-1">
+                  Multi-zonal deployment across {deployRegion}. Greater flexibility,
+                  slightly higher GCP cost.
+                </p>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowDeployConfirm(false)}
+                className="px-4 py-2 text-sm border border-gray-300 rounded hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmDeploy}
+                disabled={deployLoading}
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+              >
+                {deployLoading ? "Starting..." : "Deploy"}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Teardown Confirmation Modal */}

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -1069,9 +1069,16 @@ export default function InfraComponentsPage() {
               </button>
               <button
                 disabled={!teardownChecked}
-                onClick={() => {
+                onClick={async () => {
                   setShowTeardownModal(false);
-                  setShowTeardownProgress(true);
+                  try {
+                    await api.post("/api/v1/infrastructure/stack/teardown-background", { confirm: true });
+                    setDeployStarted(true);
+                    setShowTeardownProgress(true);
+                  } catch (e: unknown) {
+                    const msg = e instanceof Error ? e.message : "Teardown failed to start";
+                    alert(msg);
+                  }
                 }}
                 className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -1084,12 +1091,21 @@ export default function InfraComponentsPage() {
 
       {/* Teardown Progress Modal */}
       {showTeardownProgress && (
-        <TerraformProgressModal
-          title="Teardown Compute Stack"
-          sseUrl="/api/v1/infrastructure/stack/teardown"
+        <DeployProgressModal
           mode="teardown"
-          onComplete={handleTeardownComplete}
-          onClose={() => setShowTeardownProgress(false)}
+          phase={deployProgress.phase}
+          status={deployProgress.status ?? (deployStarted ? "applying" : null)}
+          resourcesCompleted={deployProgress.resources_completed}
+          resourcesTotal={deployProgress.resources_total}
+          completedResources={deployProgress.completed_resources}
+          plannedResources={deployProgress.planned_resources}
+          errorMessage={deployProgress.error_message}
+          onDismiss={() => setShowTeardownProgress(false)}
+          onAbort={() => {
+            setShowTeardownProgress(false);
+            setShowAbortConfirm(true);
+          }}
+          onDone={handleTeardownComplete}
         />
       )}
 
@@ -1144,9 +1160,16 @@ export default function InfraComponentsPage() {
               </button>
               <button
                 disabled={!destroyStorageChecked || destroyStoragePhrase !== DESTROY_STORAGE_PHRASE}
-                onClick={() => {
+                onClick={async () => {
                   setShowDestroyStorageModal(false);
-                  setShowDestroyStorageProgress(true);
+                  try {
+                    await api.post("/api/v1/infrastructure/stack/destroy-storage-background", { confirm: true });
+                    setDeployStarted(true);
+                    setShowDestroyStorageProgress(true);
+                  } catch (e: unknown) {
+                    const msg = e instanceof Error ? e.message : "Storage destroy failed to start";
+                    alert(msg);
+                  }
                 }}
                 className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -1159,12 +1182,21 @@ export default function InfraComponentsPage() {
 
       {/* Destroy Storage Progress Modal */}
       {showDestroyStorageProgress && (
-        <TerraformProgressModal
-          title="Destroy Storage Infrastructure"
-          sseUrl="/api/v1/infrastructure/stack/destroy-storage"
+        <DeployProgressModal
           mode="teardown"
-          onComplete={handleDestroyStorageComplete}
-          onClose={() => setShowDestroyStorageProgress(false)}
+          phase={deployProgress.phase}
+          status={deployProgress.status ?? (deployStarted ? "applying" : null)}
+          resourcesCompleted={deployProgress.resources_completed}
+          resourcesTotal={deployProgress.resources_total}
+          completedResources={deployProgress.completed_resources}
+          plannedResources={deployProgress.planned_resources}
+          errorMessage={deployProgress.error_message}
+          onDismiss={() => setShowDestroyStorageProgress(false)}
+          onAbort={() => {
+            setShowDestroyStorageProgress(false);
+            setShowAbortConfirm(true);
+          }}
+          onDone={handleDestroyStorageComplete}
         />
       )}
 

--- a/frontend/src/components/infrastructure/DeployProgressModal.tsx
+++ b/frontend/src/components/infrastructure/DeployProgressModal.tsx
@@ -212,7 +212,7 @@ export function DeployProgressModal({
   const completedSet = new Set(completedResources);
   let foundInProgress = false;
   const resources: TrackedResource[] =
-    plannedResources.length > 0
+    (plannedResources?.length ?? 0) > 0
       ? plannedResources.map((addr) => {
           if (completedSet.has(addr)) {
             return { address: addr, label: friendlyLabel(addr), status: "complete" as const };

--- a/frontend/src/components/infrastructure/DeployProgressModal.tsx
+++ b/frontend/src/components/infrastructure/DeployProgressModal.tsx
@@ -112,6 +112,7 @@ interface DeployProgressModalProps {
   onDismiss: () => void;
   onAbort: () => void;
   onDone: () => void;
+  mode?: "deploy" | "teardown";
 }
 
 type ResourceStatus = "pending" | "in_progress" | "complete";
@@ -135,7 +136,7 @@ function friendlyLabel(address: string): string {
   return address;
 }
 
-function StatusBadge({ status }: { status: ResourceStatus }) {
+function StatusBadge({ status, mode }: { status: ResourceStatus; mode: "deploy" | "teardown" }) {
   if (status === "complete") {
     return (
       <span className="text-xs font-medium text-green-600 uppercase tracking-wide">
@@ -147,7 +148,7 @@ function StatusBadge({ status }: { status: ResourceStatus }) {
     return (
       <span className="text-xs font-medium text-blue-600 uppercase tracking-wide flex items-center gap-1.5">
         <span className="inline-block h-1.5 w-1.5 bg-blue-600 rounded-full animate-pulse" />
-        Setting up
+        {mode === "teardown" ? "Removing" : "Setting up"}
       </span>
     );
   }
@@ -158,7 +159,12 @@ function StatusBadge({ status }: { status: ResourceStatus }) {
   );
 }
 
-function phaseTitle(phase: string | null, status: string | null): string {
+function phaseTitle(phase: string | null, status: string | null, mode: "deploy" | "teardown"): string {
+  if (mode === "teardown") {
+    if (status === null || status === "planning" || status === "awaiting_confirmation")
+      return "Preparing teardown";
+    return "Tearing down infrastructure";
+  }
   if (status === null || status === "planning" || status === "awaiting_confirmation")
     return "Preparing deployment";
   if (phase === "storage") return "Deploying storage infrastructure";
@@ -181,6 +187,7 @@ export function DeployProgressModal({
   onDismiss,
   onAbort,
   onDone,
+  mode = "deploy",
 }: DeployProgressModalProps) {
   const listRef = useRef<HTMLUListElement | null>(null);
   const [patienceIndex, setPatienceIndex] = useState(0);
@@ -237,7 +244,11 @@ export function DeployProgressModal({
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 p-6">
         <h2 className="text-lg font-semibold mb-1">
-          {isComplete ? "Deployment complete" : isError ? "Deployment failed" : phaseTitle(phase, status)}
+          {isComplete
+            ? (mode === "teardown" ? "Teardown complete" : "Deployment complete")
+            : isError
+              ? (mode === "teardown" ? "Teardown failed" : "Deployment failed")
+              : phaseTitle(phase, status, mode)}
         </h2>
 
         <div data-testid="deploy-modal-status" className="mb-4">
@@ -247,7 +258,7 @@ export function DeployProgressModal({
                 <span className="inline-block h-3 w-3 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
                 {status === null || status === "planning" || status === "awaiting_confirmation"
                   ? "Planning resources..."
-                  : "Applying changes..."}
+                  : mode === "teardown" ? "Removing resources..." : "Applying changes..."}
               </p>
               <div className="mt-2">
                 {showTimingWarning && (
@@ -263,7 +274,7 @@ export function DeployProgressModal({
           )}
           {isComplete && (
             <p className="text-sm text-green-600 font-medium">
-              All systems ready
+              {mode === "teardown" ? "Teardown complete" : "All systems ready"}
             </p>
           )}
           {isError && (
@@ -271,7 +282,7 @@ export function DeployProgressModal({
               data-testid="deploy-modal-error"
               className="text-sm text-red-600 font-medium"
             >
-              Setup failed: {errorMessage}
+              {mode === "teardown" ? "Teardown failed" : "Setup failed"}: {errorMessage}
             </p>
           )}
         </div>
@@ -301,7 +312,7 @@ export function DeployProgressModal({
                 className="flex items-center justify-between py-1.5 px-2 rounded text-sm"
               >
                 <span className="text-gray-700">{r.label}</span>
-                <StatusBadge status={r.status} />
+                <StatusBadge status={r.status} mode={mode} />
               </li>
             ))}
           </ul>
@@ -331,7 +342,7 @@ export function DeployProgressModal({
                 onClick={onAbort}
                 className="px-4 py-2 bg-red-50 text-red-600 rounded-lg text-sm font-medium hover:bg-red-100"
               >
-                Abort Deployment
+                Abort {mode === "teardown" ? "Teardown" : "Deployment"}
               </button>
               <button
                 onClick={onDismiss}

--- a/frontend/src/components/infrastructure/DeployProgressModal.tsx
+++ b/frontend/src/components/infrastructure/DeployProgressModal.tsx
@@ -107,6 +107,7 @@ interface DeployProgressModalProps {
   resourcesCompleted: number;
   resourcesTotal: number;
   completedResources: string[];
+  plannedResources: string[];
   errorMessage: string | null;
   onDismiss: () => void;
   onAbort: () => void;
@@ -167,6 +168,7 @@ export function DeployProgressModal({
   resourcesCompleted,
   resourcesTotal,
   completedResources,
+  plannedResources,
   errorMessage,
   onDismiss,
   onAbort,
@@ -189,12 +191,21 @@ export function DeployProgressModal({
     return () => clearInterval(interval);
   }, [isRunning]);
 
-  // Build resource list from completedResources
-  const resources: TrackedResource[] = completedResources.map((addr) => ({
-    address: addr,
-    label: friendlyLabel(addr),
-    status: "complete" as const,
-  }));
+  // Build the full resource list from plannedResources, marking completed ones.
+  // If plannedResources is empty (older backend), fall back to completedResources only.
+  const completedSet = new Set(completedResources);
+  const resources: TrackedResource[] =
+    plannedResources.length > 0
+      ? plannedResources.map((addr) => ({
+          address: addr,
+          label: friendlyLabel(addr),
+          status: completedSet.has(addr) ? ("complete" as const) : ("pending" as const),
+        }))
+      : completedResources.map((addr) => ({
+          address: addr,
+          label: friendlyLabel(addr),
+          status: "complete" as const,
+        }));
 
   // Auto-scroll resource list
   useEffect(() => {

--- a/frontend/src/components/infrastructure/DeployProgressModal.tsx
+++ b/frontend/src/components/infrastructure/DeployProgressModal.tsx
@@ -192,9 +192,10 @@ export function DeployProgressModal({
   const listRef = useRef<HTMLUListElement | null>(null);
   const [patienceIndex, setPatienceIndex] = useState(0);
 
-  const isRunning = status === null || status === "planning" || status === "applying" || status === "awaiting_confirmation";
+  const isRunning = status === "planning" || status === "applying" || status === "awaiting_confirmation";
   const isComplete = status === "completed";
   const isError = status === "failed";
+  const isIdle = status === null;
   const showTimingWarning = phase === "compute";
 
   // Rotate patience messages every 10 seconds while running
@@ -252,11 +253,17 @@ export function DeployProgressModal({
         </h2>
 
         <div data-testid="deploy-modal-status" className="mb-4">
+          {isIdle && (
+            <p className="text-sm text-gray-500 flex items-center gap-2">
+              <span className="inline-block h-3 w-3 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
+              Starting operation...
+            </p>
+          )}
           {isRunning && (
             <div>
               <p className="text-sm text-blue-600 flex items-center gap-2">
                 <span className="inline-block h-3 w-3 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
-                {status === null || status === "planning" || status === "awaiting_confirmation"
+                {status === "planning" || status === "awaiting_confirmation"
                   ? "Planning resources..."
                   : mode === "teardown" ? "Removing resources..." : "Applying changes..."}
               </p>
@@ -336,7 +343,7 @@ export function DeployProgressModal({
               Close
             </button>
           )}
-          {isRunning && (
+          {(isRunning || isIdle) && (
             <>
               <button
                 onClick={onAbort}

--- a/frontend/src/components/infrastructure/DeployProgressModal.tsx
+++ b/frontend/src/components/infrastructure/DeployProgressModal.tsx
@@ -114,7 +114,7 @@ interface DeployProgressModalProps {
   onDone: () => void;
 }
 
-type ResourceStatus = "pending" | "complete";
+type ResourceStatus = "pending" | "in_progress" | "complete";
 
 interface TrackedResource {
   address: string;
@@ -140,6 +140,14 @@ function StatusBadge({ status }: { status: ResourceStatus }) {
     return (
       <span className="text-xs font-medium text-green-600 uppercase tracking-wide">
         Done
+      </span>
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <span className="text-xs font-medium text-blue-600 uppercase tracking-wide flex items-center gap-1.5">
+        <span className="inline-block h-1.5 w-1.5 bg-blue-600 rounded-full animate-pulse" />
+        Setting up
       </span>
     );
   }
@@ -191,16 +199,22 @@ export function DeployProgressModal({
     return () => clearInterval(interval);
   }, [isRunning]);
 
-  // Build the full resource list from plannedResources, marking completed ones.
-  // If plannedResources is empty (older backend), fall back to completedResources only.
+  // Build the full resource list from plannedResources, marking completed ones
+  // and the first non-completed resource as in_progress.
   const completedSet = new Set(completedResources);
+  let foundInProgress = false;
   const resources: TrackedResource[] =
     plannedResources.length > 0
-      ? plannedResources.map((addr) => ({
-          address: addr,
-          label: friendlyLabel(addr),
-          status: completedSet.has(addr) ? ("complete" as const) : ("pending" as const),
-        }))
+      ? plannedResources.map((addr) => {
+          if (completedSet.has(addr)) {
+            return { address: addr, label: friendlyLabel(addr), status: "complete" as const };
+          }
+          if (!foundInProgress && isRunning) {
+            foundInProgress = true;
+            return { address: addr, label: friendlyLabel(addr), status: "in_progress" as const };
+          }
+          return { address: addr, label: friendlyLabel(addr), status: "pending" as const };
+        })
       : completedResources.map((addr) => ({
           address: addr,
           label: friendlyLabel(addr),
@@ -279,7 +293,7 @@ export function DeployProgressModal({
         {resources.length > 0 && (
           <ul
             ref={listRef}
-            className="space-y-0.5 mb-4 max-h-52 overflow-y-auto"
+            className="space-y-0.5 mb-4 max-h-52 overflow-y-scroll border-b border-gray-100"
           >
             {resources.map((r) => (
               <li

--- a/frontend/src/components/infrastructure/TerraformProgressModal.tsx
+++ b/frontend/src/components/infrastructure/TerraformProgressModal.tsx
@@ -10,6 +10,7 @@ interface TerraformEvent {
   resources_completed?: number;
   resources_total?: number;
   log_line?: string;
+  extra?: { addresses?: string[]; outputs?: Record<string, unknown> };
 }
 
 interface TerraformProgressModalProps {
@@ -295,6 +296,22 @@ export function TerraformProgressModal({
               setPhase((prev) => (prev === "compute" ? "compute" : "storage"));
             }
 
+            // Populate full resource list from the plan
+            if (event.event_type === "planned_resources" && event.extra?.addresses) {
+              const addresses = event.extra.addresses;
+              setResources((prev) => {
+                const existing = new Set(prev.map((r) => r.address));
+                const newResources = addresses
+                  .filter((addr) => !existing.has(addr))
+                  .map((addr) => ({
+                    address: addr,
+                    label: friendlyLabel(addr),
+                    status: "pending" as const,
+                  }));
+                return [...prev, ...newResources];
+              });
+            }
+
             // Track individual resources by address
             if (event.resource_address && event.event_type === "resource_complete") {
               const addr = event.resource_address;
@@ -532,12 +549,20 @@ export function TerraformProgressModal({
             </button>
           )}
           {(status === "connecting" || status === "running") && (
-            <button
-              onClick={onClose}
-              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-300"
-            >
-              Cancel
-            </button>
+            <>
+              <button
+                onClick={onClose}
+                className="px-4 py-2 border border-red-300 text-red-600 rounded-lg text-sm font-medium hover:bg-red-50"
+              >
+                Abort {mode === "teardown" ? "Teardown" : "Deployment"}
+              </button>
+              <button
+                onClick={onClose}
+                className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-300"
+              >
+                Minimize
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/components/settings/GcpSettingsContent.tsx
+++ b/frontend/src/components/settings/GcpSettingsContent.tsx
@@ -244,7 +244,7 @@ ${RECOMMENDED_ROLES.map(({ role }) => `gcloud projects add-iam-policy-binding $P
 
             {/* Region */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Region</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Default Region</label>
               <select
                 data-testid="gcp-region-select"
                 value={region}
@@ -262,7 +262,7 @@ ${RECOMMENDED_ROLES.map(({ role }) => `gcloud projects add-iam-policy-binding $P
 
             {/* Zone */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Zone</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Default Zone</label>
               <select
                 data-testid="gcp-zone-select"
                 value={zone}

--- a/frontend/src/hooks/useDeploymentProgress.ts
+++ b/frontend/src/hooks/useDeploymentProgress.ts
@@ -10,6 +10,7 @@ export interface DeploymentProgress {
   resources_completed: number;
   resources_total: number;
   completed_resources: string[];
+  planned_resources: string[];
   error_message: string | null;
   run_id: number | null;
 }
@@ -21,6 +22,7 @@ const EMPTY: DeploymentProgress = {
   resources_completed: 0,
   resources_total: 0,
   completed_resources: [],
+  planned_resources: [],
   error_message: null,
   run_id: null,
 };

--- a/frontend/src/lib/gcp-regions.ts
+++ b/frontend/src/lib/gcp-regions.ts
@@ -1,0 +1,18 @@
+/** GCP regions and zones available for bioAF deployments. */
+
+export const GCP_REGIONS = [
+  "us-central1", "us-east1", "us-east4", "us-west1", "us-west2", "us-west3", "us-west4",
+  "europe-west1", "europe-west2", "europe-west3", "europe-west4", "europe-west6",
+  "asia-east1", "asia-east2", "asia-northeast1", "asia-south1", "asia-southeast1",
+];
+
+export const GCP_ZONES: Record<string, string[]> = {
+  "us-central1": ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"],
+  "us-east1": ["us-east1-b", "us-east1-c", "us-east1-d"],
+  "us-east4": ["us-east4-a", "us-east4-b", "us-east4-c"],
+  "us-west1": ["us-west1-a", "us-west1-b", "us-west1-c"],
+};
+
+export function zonesForRegion(region: string): string[] {
+  return GCP_ZONES[region] ?? [`${region}-a`, `${region}-b`, `${region}-c`];
+}

--- a/frontend/tests/components/infrastructure/ComponentsPage.test.tsx
+++ b/frontend/tests/components/infrastructure/ComponentsPage.test.tsx
@@ -188,6 +188,7 @@ describe("InfraComponentsPage", () => {
       resources_completed: 0,
       resources_total: 0,
       completed_resources: [],
+      planned_resources: [],
       error_message: null,
       run_id: null,
     };
@@ -199,6 +200,8 @@ describe("InfraComponentsPage", () => {
       if (url.includes("stack/status")) return Promise.resolve(mockStackStatus());
       if (url.includes("stack/components"))
         return Promise.resolve({ compute_stack: null, compute_deployed: false, storage_deployed: false, components: [] });
+      if (url.includes("settings/gcp"))
+        return Promise.resolve({ gcp_region: "us-central1", gcp_zone: "us-central1-a" });
       return Promise.reject(new Error("Not found"));
     });
     mockApiPost.mockResolvedValue({ message: "Deployment started" });
@@ -211,9 +214,20 @@ describe("InfraComponentsPage", () => {
       expect(screen.getByText(/Kubernetes \+ GCS/)).toBeInTheDocument();
     });
 
+    // Click Deploy to open confirmation modal
     const deployButton = screen.getByRole("button", { name: /^Deploy$/i });
     await act(async () => {
       fireEvent.click(deployButton);
+    });
+
+    // Confirm in the region/zone selection modal
+    await waitFor(() => {
+      expect(screen.getByText(/Deploy Compute Infrastructure/)).toBeInTheDocument();
+    });
+    const deployButtons = screen.getAllByRole("button", { name: /^Deploy$/i });
+    const confirmButton = deployButtons[deployButtons.length - 1];
+    await act(async () => {
+      fireEvent.click(confirmButton);
     });
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary

- Auto-detect GCE and enable Cloud Logging using the app's configured service account, with Ops Agent for Docker container logs
- Replace 30-minute hard timeout on Terraform runs with process-alive tracking so GKE deploys run to completion
- Fix lock file deletion, orphaned resource cleanup, and expand orphan detection to IAM service accounts
- Move all infrastructure operations (deploy, teardown, storage destroy) to background endpoints with polling-based progress modal
- Add region/zone selection at deploy time with cross-region cost warning
- Persist tfvars per TerraformRun for audit trail (migration 064)
- Multiple deploy modal UX fixes (full resource list, idle/terminal states, scrollbar visibility)

## Test plan

- [x] Backend ruff format, ruff check, mypy all pass
- [x] Frontend tsc --noEmit passes
- [ ] Manual: deploy compute with default region, verify progress modal shows full resource list
- [ ] Manual: teardown compute, verify modal shows progress and completes without "connection lost"
- [ ] Manual: verify logs appear in Cloud Console under Logs Explorer
- [ ] Manual: deploy with non-default region, verify cross-region warning appears