### PR TITLE
v0.6.4: Plot archive fixes, PDF thumbnails, detail modal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
 # Release Notes
 
+## v0.6.4
+
+Plot archive bug fixes, PDF thumbnail generation, and detail modal improvements.
+
+### Bug Fixes (Issue #151)
+
+- Add unique constraint on `platform_config.key` to prevent duplicate rows that broke the plot archive scanner
+- Fix scanner using bare ADC instead of app service account credentials
+- Add SVG (`image/svg+xml`) and PDF (`application/pdf`) content-type mappings to file content endpoint
+- Preserve click handler on plot thumbnails that fail to load
+
+### PDF Thumbnails
+
+- Render PDF page 1 to PNG thumbnails using PyMuPDF, stored under `_thumbnails/` prefix in the results bucket
+- Scanner auto-generates thumbnails when indexing new PDF plots
+- Add `GET /api/plots/{id}/thumbnail/content` endpoint for serving thumbnail bytes
+- Extend `POST /api/plots/backfill` to generate missing thumbnails for existing PDFs
+- Clean up thumbnail blobs from GCS when associated files are deleted
+- Offload PDF rendering to thread pool to avoid blocking the event loop
+
+### Plot Detail Modal
+
+- Rework modal to match Data & Files detail layout with metadata grid and download button
+- Display project, experiment, pipeline, session, source, and indexed date
+- Add file format badge (PNG, SVG, PDF) to thumbnail cards
+- Standardize card title font sizing
+
 ## v0.6.3
 
 Infrastructure lifecycle stability, Cloud Logging, and deploy UX improvements.

--- a/backend/alembic/versions/065_add_unique_constraint_platform_config_key.py
+++ b/backend/alembic/versions/065_add_unique_constraint_platform_config_key.py
@@ -1,0 +1,36 @@
+"""Add unique constraint to platform_config.key.
+
+Revision ID: 065
+Revises: 064
+Create Date: 2026-04-11
+
+The model declares unique=True on PlatformConfig.key but the original
+migration 001 omitted the constraint. Without it, duplicate keys can
+accumulate and break scalar_one_or_none() queries (see issue #151).
+
+This migration deduplicates any existing rows first (keeping the most
+recently updated value per key), then adds the constraint.
+"""
+
+from alembic import op
+
+revision = "065"
+down_revision = "064"
+
+
+def upgrade() -> None:
+    # Deduplicate: keep the row with the highest id for each key
+    op.execute(
+        """
+        DELETE FROM platform_config
+        WHERE id NOT IN (
+            SELECT MAX(id) FROM platform_config GROUP BY key
+        )
+        """
+    )
+
+    op.create_unique_constraint("uq_platform_config_key", "platform_config", ["key"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_platform_config_key", "platform_config", type_="unique")

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -392,6 +392,10 @@ async def file_content(
             content_type = "image/png"
         elif file.filename.endswith(".jpg") or file.filename.endswith(".jpeg"):
             content_type = "image/jpeg"
+        elif file.filename.endswith(".svg"):
+            content_type = "image/svg+xml"
+        elif file.filename.endswith(".pdf"):
+            content_type = "application/pdf"
 
         return Response(
             content=data,

--- a/backend/app/api/plots.py
+++ b/backend/app/api/plots.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_permission
@@ -129,13 +130,51 @@ async def get_thumbnail(
     return {"thumbnail_url": None}
 
 
+@router.get("/{plot_id}/thumbnail/content")
+async def get_thumbnail_content(
+    plot_id: int,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+):
+    """Serve thumbnail PNG bytes for inline display in <img> tags."""
+    current_user = request.state.current_user
+    org_id = int(current_user["org_id"])
+
+    plot = await PlotArchiveService.get_plot(session, org_id, plot_id)
+    if not plot:
+        raise HTTPException(404, "Plot not found")
+    if not plot.thumbnail_gcs_uri:
+        raise HTTPException(404, "No thumbnail available")
+
+    try:
+        from google.cloud import storage as gcs_storage
+
+        from app.services.gcs_storage import GcsStorageService
+
+        credentials = await GcsStorageService.get_credentials(session)
+        client = gcs_storage.Client(credentials=credentials)
+        parts = plot.thumbnail_gcs_uri.replace("gs://", "").split("/", 1)
+        bucket = client.bucket(parts[0])
+        blob = bucket.blob(parts[1])
+        data = blob.download_as_bytes()
+
+        return Response(
+            content=data,
+            media_type="image/png",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+    except Exception:
+        raise HTTPException(502, "Could not fetch thumbnail content")
+
+
 @router.post("/backfill")
 async def backfill_plot_metadata(
     current_user: dict = require_permission("experiments", "create"),
     session: AsyncSession = Depends(get_session),
 ):
-    updated = await PlotArchiveService.backfill_metadata(session)
-    return {"updated": updated}
+    metadata_updated = await PlotArchiveService.backfill_metadata(session)
+    thumbnails_generated = await PlotArchiveService.backfill_thumbnails(session)
+    return {"metadata_updated": metadata_updated, "thumbnails_generated": thumbnails_generated}
 
 
 @router.patch("/{plot_id}", response_model=PlotArchiveResponse)

--- a/backend/app/api/plots.py
+++ b/backend/app/api/plots.py
@@ -29,13 +29,31 @@ def _plot_response(p) -> PlotArchiveResponse:
             upload_timestamp=p.file.upload_timestamp,
             created_at=p.file.created_at,
         )
+    # Derive source type from associations
+    source_type = None
+    if p.file and p.file.source_type:
+        source_type = p.file.source_type
+    elif p.notebook_session_id:
+        session_type = getattr(p.notebook_session, "session_type", None) if p.notebook_session else None
+        if session_type == "cellxgene":
+            source_type = "cellxgene"
+        else:
+            source_type = "notebook"
+    elif p.pipeline_run_id:
+        source_type = "pipeline"
+
     return PlotArchiveResponse(
         id=p.id,
         title=p.title,
         file=file_resp,
         experiment_id=p.experiment_id,
+        experiment_name=p.experiment.name if p.experiment else None,
+        project_name=p.experiment.project.name if p.experiment and p.experiment.project else None,
         pipeline_run_id=p.pipeline_run_id,
+        pipeline_run_name=p.pipeline_run.pipeline_name if p.pipeline_run else None,
         notebook_session_id=p.notebook_session_id,
+        notebook_session_type=p.notebook_session.session_type if p.notebook_session else None,
+        source_type=source_type,
         tags=p.tags_json if isinstance(p.tags_json, list) else [],
         thumbnail_url=p.thumbnail_gcs_uri,
         indexed_at=p.indexed_at,

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -27,11 +27,12 @@ PUBLIC_PATHS = {
 
 
 _FILE_CONTENT_RE = re.compile(r"^/api/files/\d+/content$")
+_PLOT_THUMBNAIL_CONTENT_RE = re.compile(r"^/api/plots/\d+/thumbnail/content$")
 
 
 def _is_file_content_path(path: str) -> bool:
     """Return True for paths that legitimately need query-param token auth."""
-    return _FILE_CONTENT_RE.match(path) is not None
+    return _FILE_CONTENT_RE.match(path) is not None or _PLOT_THUMBNAIL_CONTENT_RE.match(path) is not None
 
 
 class AuthMiddleware(BaseHTTPMiddleware):

--- a/backend/app/schemas/plot_archive.py
+++ b/backend/app/schemas/plot_archive.py
@@ -10,8 +10,13 @@ class PlotArchiveResponse(BaseModel):
     title: str | None
     file: FileResponse | None = None
     experiment_id: int | None
+    experiment_name: str | None = None
+    project_name: str | None = None
     pipeline_run_id: int | None
+    pipeline_run_name: str | None = None
     notebook_session_id: int | None
+    notebook_session_type: str | None = None
+    source_type: str | None = None
     tags: list[str] = []
     thumbnail_url: str | None = None
     indexed_at: datetime

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -167,6 +167,25 @@ class FileService:
             details={"filename": file.filename},
         )
 
+        # Clean up any associated plot thumbnails from GCS before removing entries
+        plot_entries = (
+            (
+                await session.execute(
+                    select(PlotArchiveEntry.thumbnail_gcs_uri).where(
+                        PlotArchiveEntry.file_id == file_id,
+                        PlotArchiveEntry.thumbnail_gcs_uri.isnot(None),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if plot_entries:
+            from app.services.thumbnail_service import ThumbnailService
+
+            for thumb_uri in plot_entries:
+                await ThumbnailService.delete_thumbnail(session, thumb_uri)
+
         # Remove dependent rows from tables with FK references to files.id
         await session.execute(delete(PlotArchiveEntry).where(PlotArchiveEntry.file_id == file_id))
 

--- a/backend/app/services/plot_archive_service.py
+++ b/backend/app/services/plot_archive_service.py
@@ -10,6 +10,7 @@ from app.models.file import File
 from app.models.plot_archive_entry import PlotArchiveEntry
 from app.services.audit_service import log_action
 from app.services.file_service import FileService
+from app.services.thumbnail_service import THUMBNAIL_PREFIX, ThumbnailService
 
 logger = logging.getLogger("bioaf.plot_archive_service")
 
@@ -173,6 +174,10 @@ class PlotArchiveService:
                     blobs = bucket.list_blobs()
 
                     for blob in blobs:
+                        # Skip generated thumbnails
+                        if blob.name.startswith(THUMBNAIL_PREFIX):
+                            continue
+
                         # Filter image files
                         if not blob.name.lower().endswith((".png", ".svg", ".pdf")):
                             continue
@@ -210,7 +215,7 @@ class PlotArchiveService:
                         )
 
                         # Create archive entry
-                        await PlotArchiveService.index_plot(
+                        entry = await PlotArchiveService.index_plot(
                             session,
                             org_id=org_id,
                             file_id=file.id,
@@ -218,6 +223,13 @@ class PlotArchiveService:
                             pipeline_run_id=pipeline_run_id,
                             title=blob.name.split("/")[-1],
                         )
+
+                        # Generate PDF thumbnail
+                        if ext == "pdf":
+                            thumb_uri = await ThumbnailService.generate_and_upload(session, gcs_uri, entry.id)
+                            if thumb_uri:
+                                entry.thumbnail_gcs_uri = thumb_uri
+
                         indexed += 1
 
                 except Exception as e:
@@ -285,3 +297,29 @@ class PlotArchiveService:
             await session.commit()
             logger.info("Backfilled metadata for %d plot archive entries", updated)
         return updated
+
+    @staticmethod
+    async def backfill_thumbnails(session: AsyncSession) -> int:
+        """Generate missing thumbnails for PDF plot entries."""
+        result = await session.execute(
+            select(PlotArchiveEntry)
+            .options(selectinload(PlotArchiveEntry.file))
+            .where(PlotArchiveEntry.thumbnail_gcs_uri.is_(None))
+        )
+        entries = list(result.scalars().all())
+        generated = 0
+        for entry in entries:
+            if not entry.file or not entry.file.gcs_uri:
+                continue
+            if not entry.file.filename.lower().endswith(".pdf"):
+                continue
+
+            thumb_uri = await ThumbnailService.generate_and_upload(session, entry.file.gcs_uri, entry.id)
+            if thumb_uri:
+                entry.thumbnail_gcs_uri = thumb_uri
+                generated += 1
+
+        if generated > 0:
+            await session.commit()
+            logger.info("Generated thumbnails for %d PDF plot entries", generated)
+        return generated

--- a/backend/app/services/plot_archive_service.py
+++ b/backend/app/services/plot_archive_service.py
@@ -133,9 +133,12 @@ class PlotArchiveService:
         try:
             from google.cloud import storage as gcs_storage
 
-            client = gcs_storage.Client()
+            from app.services.gcs_storage import GcsStorageService
 
-            # Get all organizations (simplified — in practice scope by active orgs)
+            credentials = await GcsStorageService.get_credentials(session)
+            client = gcs_storage.Client(credentials=credentials)
+
+            # Get all organizations (simplified -- in practice scope by active orgs)
             from app.models.organization import Organization
 
             orgs_result = await session.execute(select(Organization))
@@ -144,7 +147,7 @@ class PlotArchiveService:
             cfg_result = await session.execute(
                 text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'")
             )
-            results_bucket = cfg_result.scalar_one_or_none()
+            results_bucket = cfg_result.scalars().first()
             if not results_bucket or results_bucket == "null":
                 logger.warning("results_bucket_name not configured in platform_config, skipping plot scan")
                 return 0

--- a/backend/app/services/plot_archive_service.py
+++ b/backend/app/services/plot_archive_service.py
@@ -5,6 +5,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.experiment import Experiment
 from app.models.file import File
 from app.models.plot_archive_entry import PlotArchiveEntry
 from app.services.audit_service import log_action
@@ -56,7 +57,12 @@ class PlotArchiveService:
     ) -> tuple[list[PlotArchiveEntry], int]:
         base = (
             select(PlotArchiveEntry)
-            .options(selectinload(PlotArchiveEntry.file).selectinload(File.uploader))
+            .options(
+                selectinload(PlotArchiveEntry.file).selectinload(File.uploader),
+                selectinload(PlotArchiveEntry.experiment).selectinload(Experiment.project),
+                selectinload(PlotArchiveEntry.pipeline_run),
+                selectinload(PlotArchiveEntry.notebook_session),
+            )
             .where(PlotArchiveEntry.organization_id == org_id)
         )
         count_base = select(func.count(PlotArchiveEntry.id)).where(PlotArchiveEntry.organization_id == org_id)
@@ -92,7 +98,12 @@ class PlotArchiveService:
     async def get_plot(session: AsyncSession, org_id: int, plot_id: int) -> PlotArchiveEntry | None:
         result = await session.execute(
             select(PlotArchiveEntry)
-            .options(selectinload(PlotArchiveEntry.file).selectinload(File.uploader))
+            .options(
+                selectinload(PlotArchiveEntry.file).selectinload(File.uploader),
+                selectinload(PlotArchiveEntry.experiment).selectinload(Experiment.project),
+                selectinload(PlotArchiveEntry.pipeline_run),
+                selectinload(PlotArchiveEntry.notebook_session),
+            )
             .where(PlotArchiveEntry.id == plot_id, PlotArchiveEntry.organization_id == org_id)
         )
         return result.scalar_one_or_none()

--- a/backend/app/services/plot_archive_service.py
+++ b/backend/app/services/plot_archive_service.py
@@ -300,7 +300,12 @@ class PlotArchiveService:
 
     @staticmethod
     async def backfill_thumbnails(session: AsyncSession) -> int:
-        """Generate missing thumbnails for PDF plot entries."""
+        """Generate missing thumbnails for PDF plot entries.
+
+        Processes one entry at a time with commits every 5 to avoid
+        holding the event loop or accumulating too much work in a
+        single transaction.
+        """
         result = await session.execute(
             select(PlotArchiveEntry)
             .options(selectinload(PlotArchiveEntry.file))
@@ -308,6 +313,7 @@ class PlotArchiveService:
         )
         entries = list(result.scalars().all())
         generated = 0
+        batch = 0
         for entry in entries:
             if not entry.file or not entry.file.gcs_uri:
                 continue
@@ -318,8 +324,15 @@ class PlotArchiveService:
             if thumb_uri:
                 entry.thumbnail_gcs_uri = thumb_uri
                 generated += 1
+                batch += 1
 
-        if generated > 0:
+            # Commit in batches of 5 to keep transactions short
+            if batch >= 5:
+                await session.commit()
+                batch = 0
+
+        if batch > 0:
             await session.commit()
+        if generated > 0:
             logger.info("Generated thumbnails for %d PDF plot entries", generated)
         return generated

--- a/backend/app/services/thumbnail_service.py
+++ b/backend/app/services/thumbnail_service.py
@@ -1,0 +1,118 @@
+"""PDF thumbnail generation and GCS storage.
+
+Renders page 1 of a PDF to a PNG thumbnail and uploads it to a
+dedicated _thumbnails/ prefix in the results bucket so the scanner
+does not re-index it.
+"""
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.gcs_storage import GcsStorageService
+
+logger = logging.getLogger("bioaf.thumbnail_service")
+
+THUMBNAIL_PREFIX = "_thumbnails/"
+THUMBNAIL_MAX_DIM = 1280
+THUMBNAIL_DPI = 150
+
+
+class ThumbnailService:
+    @staticmethod
+    def render_pdf_thumbnail(pdf_bytes: bytes) -> bytes | None:
+        """Render page 1 of a PDF to a PNG image, fit within THUMBNAIL_MAX_DIM.
+
+        Returns PNG bytes, or None if rendering fails.
+        """
+        try:
+            import fitz
+
+            doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+            if doc.page_count == 0:
+                doc.close()
+                return None
+
+            page = doc[0]
+            # Scale so the longest edge fits THUMBNAIL_MAX_DIM
+            rect = page.rect
+            scale = min(THUMBNAIL_MAX_DIM / rect.width, THUMBNAIL_MAX_DIM / rect.height, THUMBNAIL_DPI / 72.0)
+            mat = fitz.Matrix(scale, scale)
+            pixmap = page.get_pixmap(matrix=mat, alpha=False)
+            png_bytes = pixmap.tobytes("png")
+            doc.close()
+            return png_bytes
+        except Exception as e:
+            logger.warning("Failed to render PDF thumbnail: %s", e)
+            return None
+
+    @staticmethod
+    async def generate_and_upload(
+        session: AsyncSession,
+        source_gcs_uri: str,
+        plot_entry_id: int,
+    ) -> str | None:
+        """Download a PDF from GCS, render thumbnail, upload to _thumbnails/.
+
+        Returns the thumbnail GCS URI, or None on failure.
+        """
+        try:
+            from google.cloud import storage as gcs_storage
+
+            credentials = await GcsStorageService.get_credentials(session)
+            client = gcs_storage.Client(credentials=credentials)
+
+            # Download the source PDF
+            parts = source_gcs_uri.replace("gs://", "").split("/", 1)
+            bucket_name = parts[0]
+            blob_path = parts[1]
+            bucket = client.bucket(bucket_name)
+            source_blob = bucket.blob(blob_path)
+            pdf_bytes = source_blob.download_as_bytes()
+
+            # Render thumbnail
+            png_bytes = ThumbnailService.render_pdf_thumbnail(pdf_bytes)
+            if not png_bytes:
+                return None
+
+            # Upload to _thumbnails/ prefix
+            thumb_path = f"{THUMBNAIL_PREFIX}plot_{plot_entry_id}.png"
+            thumb_blob = bucket.blob(thumb_path)
+            thumb_blob.upload_from_string(png_bytes, content_type="image/png")
+
+            thumb_uri = f"gs://{bucket_name}/{thumb_path}"
+            logger.info("Generated thumbnail for plot %d: %s", plot_entry_id, thumb_uri)
+            return thumb_uri
+
+        except Exception as e:
+            logger.warning("Failed to generate thumbnail for plot %d: %s", plot_entry_id, e)
+            return None
+
+    @staticmethod
+    async def delete_thumbnail(session: AsyncSession, thumbnail_gcs_uri: str) -> bool:
+        """Delete a thumbnail blob from GCS."""
+        try:
+            from google.cloud import storage as gcs_storage
+
+            credentials = await GcsStorageService.get_credentials(session)
+            client = gcs_storage.Client(credentials=credentials)
+
+            parts = thumbnail_gcs_uri.replace("gs://", "").split("/", 1)
+            bucket = client.bucket(parts[0])
+            blob = bucket.blob(parts[1])
+            blob.delete()
+            logger.info("Deleted thumbnail: %s", thumbnail_gcs_uri)
+            return True
+        except Exception as e:
+            logger.warning("Failed to delete thumbnail %s: %s", thumbnail_gcs_uri, e)
+            return False
+
+    @staticmethod
+    async def get_results_bucket(session: AsyncSession) -> str | None:
+        """Read results_bucket_name from platform_config."""
+        result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'results_bucket_name'"))
+        val = result.scalars().first()
+        if not val or val == "null":
+            return None
+        return val

--- a/backend/app/services/thumbnail_service.py
+++ b/backend/app/services/thumbnail_service.py
@@ -3,9 +3,14 @@
 Renders page 1 of a PDF to a PNG thumbnail and uploads it to a
 dedicated _thumbnails/ prefix in the results bucket so the scanner
 does not re-index it.
+
+All CPU-heavy rendering is offloaded to a thread pool to avoid
+blocking the async event loop.
 """
 
+import asyncio
 import logging
+from functools import partial
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -48,6 +53,42 @@ class ThumbnailService:
             return None
 
     @staticmethod
+    def _download_render_upload(
+        credentials,
+        source_gcs_uri: str,
+        plot_entry_id: int,
+    ) -> str | None:
+        """Blocking helper that runs in a thread: download PDF, render, upload.
+
+        Returns the thumbnail GCS URI, or None on failure.
+        """
+        from google.cloud import storage as gcs_storage
+
+        client = gcs_storage.Client(credentials=credentials)
+
+        parts = source_gcs_uri.replace("gs://", "").split("/", 1)
+        bucket_name = parts[0]
+        blob_path = parts[1]
+        bucket = client.bucket(bucket_name)
+
+        # Download source PDF
+        pdf_bytes = bucket.blob(blob_path).download_as_bytes()
+
+        # Render thumbnail (CPU-heavy)
+        png_bytes = ThumbnailService.render_pdf_thumbnail(pdf_bytes)
+        if not png_bytes:
+            return None
+
+        # Upload to _thumbnails/ prefix
+        thumb_path = f"{THUMBNAIL_PREFIX}plot_{plot_entry_id}.png"
+        thumb_blob = bucket.blob(thumb_path)
+        thumb_blob.upload_from_string(png_bytes, content_type="image/png")
+
+        thumb_uri = f"gs://{bucket_name}/{thumb_path}"
+        logger.info("Generated thumbnail for plot %d: %s", plot_entry_id, thumb_uri)
+        return thumb_uri
+
+    @staticmethod
     async def generate_and_upload(
         session: AsyncSession,
         source_gcs_uri: str,
@@ -55,36 +96,23 @@ class ThumbnailService:
     ) -> str | None:
         """Download a PDF from GCS, render thumbnail, upload to _thumbnails/.
 
+        All blocking work (GCS I/O + PDF rendering) is offloaded to a
+        thread so the async event loop stays responsive.
+
         Returns the thumbnail GCS URI, or None on failure.
         """
         try:
-            from google.cloud import storage as gcs_storage
-
             credentials = await GcsStorageService.get_credentials(session)
-            client = gcs_storage.Client(credentials=credentials)
-
-            # Download the source PDF
-            parts = source_gcs_uri.replace("gs://", "").split("/", 1)
-            bucket_name = parts[0]
-            blob_path = parts[1]
-            bucket = client.bucket(bucket_name)
-            source_blob = bucket.blob(blob_path)
-            pdf_bytes = source_blob.download_as_bytes()
-
-            # Render thumbnail
-            png_bytes = ThumbnailService.render_pdf_thumbnail(pdf_bytes)
-            if not png_bytes:
-                return None
-
-            # Upload to _thumbnails/ prefix
-            thumb_path = f"{THUMBNAIL_PREFIX}plot_{plot_entry_id}.png"
-            thumb_blob = bucket.blob(thumb_path)
-            thumb_blob.upload_from_string(png_bytes, content_type="image/png")
-
-            thumb_uri = f"gs://{bucket_name}/{thumb_path}"
-            logger.info("Generated thumbnail for plot %d: %s", plot_entry_id, thumb_uri)
-            return thumb_uri
-
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                None,
+                partial(
+                    ThumbnailService._download_render_upload,
+                    credentials,
+                    source_gcs_uri,
+                    plot_entry_id,
+                ),
+            )
         except Exception as e:
             logger.warning("Failed to generate thumbnail for plot %d: %s", plot_entry_id, e)
             return None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pyyaml>=6.0",
     "PyJWT[crypto]>=2.8",
     "h5py>=3.10",
+    "PyMuPDF>=1.24",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.6.3"
+version = "0.6.4"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -40,3 +40,5 @@ PyJWT[crypto]>=2.8
 # Provenance report generation
 weasyprint>=60
 markdown>=3.5
+# PDF thumbnail generation for plot archive
+PyMuPDF>=1.24

--- a/backend/tests/test_plot_archive_fixes.py
+++ b/backend/tests/test_plot_archive_fixes.py
@@ -1,0 +1,170 @@
+"""Tests for plot archive bug fixes (#151 and related).
+
+Covers:
+- platform_config unique constraint enforcement (issue #151)
+- Scanner uses app SA credentials, not bare ADC
+- File content endpoint returns correct content-type for SVG and PDF
+"""
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from sqlalchemy import text
+
+
+@pytest_asyncio.fixture
+async def sample_svg_file(session, admin_user):
+    from app.models.file import File
+
+    f = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri="gs://test-bucket/plots/heatmap.svg",
+        filename="heatmap.svg",
+        size_bytes=8000,
+        file_type="svg",
+        uploader_user_id=admin_user.id,
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+    return f
+
+
+@pytest_asyncio.fixture
+async def sample_pdf_file(session, admin_user):
+    from app.models.file import File
+
+    f = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri="gs://test-bucket/plots/stats_table.pdf",
+        filename="stats_table.pdf",
+        size_bytes=15000,
+        file_type="pdf",
+        uploader_user_id=admin_user.id,
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+    return f
+
+
+# -- Issue #151: platform_config unique constraint --
+
+
+@pytest.mark.asyncio
+async def test_platform_config_rejects_duplicate_keys(session):
+    """After migration 065, inserting a duplicate key into platform_config
+    must raise an IntegrityError."""
+    from sqlalchemy.exc import IntegrityError
+
+    await session.execute(
+        text("INSERT INTO platform_config (key, value) VALUES ('_test_unique_key', 'first') ON CONFLICT DO NOTHING")
+    )
+    await session.commit()
+
+    with pytest.raises(IntegrityError):
+        await session.execute(text("INSERT INTO platform_config (key, value) VALUES ('_test_unique_key', 'second')"))
+        await session.commit()
+
+    await session.rollback()
+
+    # Cleanup
+    await session.execute(text("DELETE FROM platform_config WHERE key = '_test_unique_key'"))
+    await session.commit()
+
+
+# -- Scanner uses app SA credentials --
+
+
+@pytest.mark.asyncio
+async def test_scan_and_index_uses_app_credentials(session):
+    """scan_and_index must use GcsStorageService.get_credentials, not bare
+    ADC, to authenticate with GCS."""
+    from app.services.plot_archive_service import PlotArchiveService
+
+    mock_creds = MagicMock()
+    mock_get_creds = AsyncMock(return_value=mock_creds)
+    mock_client_cls = MagicMock()
+    mock_bucket = mock_client_cls.return_value.bucket.return_value
+    mock_bucket.list_blobs.return_value = []
+
+    # Insert results_bucket_name so the scanner doesn't bail early
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value) "
+            "VALUES ('results_bucket_name', 'test-results-bucket') "
+            "ON CONFLICT (key) DO UPDATE SET value = 'test-results-bucket'"
+        )
+    )
+    await session.commit()
+
+    with (
+        patch("google.cloud.storage.Client", mock_client_cls),
+        patch(
+            "app.services.gcs_storage.GcsStorageService.get_credentials",
+            mock_get_creds,
+        ),
+    ):
+        await PlotArchiveService.scan_and_index(session)
+
+    # Verify get_credentials was called
+    mock_get_creds.assert_called_once()
+
+    # Verify Client was instantiated with those credentials
+    mock_client_cls.assert_called_once_with(credentials=mock_creds)
+
+
+# -- File content endpoint: SVG content type --
+
+
+@pytest.mark.asyncio
+async def test_content_endpoint_returns_svg_content_type(client, admin_token, sample_svg_file):
+    """GET /api/files/{id}/content for an SVG file must return
+    Content-Type: image/svg+xml."""
+    mock_client_cls = MagicMock()
+    mock_blob = mock_client_cls.return_value.bucket.return_value.blob.return_value
+    mock_blob.download_as_bytes.return_value = b"<svg></svg>"
+
+    with (
+        patch("google.cloud.storage.Client", mock_client_cls),
+        patch(
+            "app.services.gcs_storage.GcsStorageService.get_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        resp = await client.get(
+            f"/api/files/{sample_svg_file.id}/content",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/svg+xml"
+
+
+# -- File content endpoint: PDF content type --
+
+
+@pytest.mark.asyncio
+async def test_content_endpoint_returns_pdf_content_type(client, admin_token, sample_pdf_file):
+    """GET /api/files/{id}/content for a PDF file must return
+    Content-Type: application/pdf."""
+    mock_client_cls = MagicMock()
+    mock_blob = mock_client_cls.return_value.bucket.return_value.blob.return_value
+    mock_blob.download_as_bytes.return_value = b"%PDF-1.4 fake"
+
+    with (
+        patch("google.cloud.storage.Client", mock_client_cls),
+        patch(
+            "app.services.gcs_storage.GcsStorageService.get_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        resp = await client.get(
+            f"/api/files/{sample_pdf_file.id}/content",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"

--- a/backend/tests/test_plot_archive_fixes.py
+++ b/backend/tests/test_plot_archive_fixes.py
@@ -4,12 +4,61 @@ Covers:
 - platform_config unique constraint enforcement (issue #151)
 - Scanner uses app SA credentials, not bare ADC
 - File content endpoint returns correct content-type for SVG and PDF
+- PDF thumbnail generation and serving
+- Thumbnail cleanup on file delete
 """
 
 import pytest
 import pytest_asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from sqlalchemy import text
+
+
+@pytest_asyncio.fixture
+async def experiment_for_plots(session, admin_user):
+    from app.models.experiment import Experiment
+
+    exp = Experiment(
+        organization_id=admin_user.organization_id,
+        name="Plot Fix Test Experiment",
+        owner_user_id=admin_user.id,
+        status="analysis",
+    )
+    session.add(exp)
+    await session.flush()
+    await session.commit()
+    return exp
+
+
+@pytest_asyncio.fixture
+async def sample_plot(session, admin_user, experiment_for_plots):
+    from app.models.file import File
+    from app.models.plot_archive_entry import PlotArchiveEntry
+    from datetime import datetime, timezone
+
+    f = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri="gs://test-bucket/plots/umap_fix.png",
+        filename="umap_fix.png",
+        size_bytes=25000,
+        file_type="image",
+        uploader_user_id=admin_user.id,
+    )
+    session.add(f)
+    await session.flush()
+
+    plot = PlotArchiveEntry(
+        organization_id=admin_user.organization_id,
+        file_id=f.id,
+        title="UMAP Fix Test",
+        experiment_id=experiment_for_plots.id,
+        tags_json=["umap"],
+        indexed_at=datetime.now(timezone.utc),
+    )
+    session.add(plot)
+    await session.flush()
+    await session.commit()
+    return plot
 
 
 @pytest_asyncio.fixture
@@ -168,3 +217,224 @@ async def test_content_endpoint_returns_pdf_content_type(client, admin_token, sa
 
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/pdf"
+
+
+# -- Thumbnail generation --
+
+
+@pytest.mark.asyncio
+async def test_render_pdf_thumbnail_returns_png_bytes():
+    """ThumbnailService.render_pdf_thumbnail produces valid PNG bytes from a simple PDF."""
+    from app.services.thumbnail_service import ThumbnailService
+    import fitz
+
+    # Create a minimal one-page PDF in memory
+    doc = fitz.open()
+    page = doc.new_page(width=200, height=200)
+    page.insert_text((50, 100), "Test")
+    pdf_bytes = doc.tobytes()
+    doc.close()
+
+    result = ThumbnailService.render_pdf_thumbnail(pdf_bytes)
+    assert result is not None
+    assert result[:4] == b"\x89PNG"
+
+
+@pytest.mark.asyncio
+async def test_render_pdf_thumbnail_returns_none_for_invalid_input():
+    """ThumbnailService.render_pdf_thumbnail returns None for non-PDF input."""
+    from app.services.thumbnail_service import ThumbnailService
+
+    result = ThumbnailService.render_pdf_thumbnail(b"not a pdf")
+    assert result is None
+
+
+# -- Scanner skips _thumbnails/ prefix --
+
+
+@pytest.mark.asyncio
+async def test_scanner_skips_thumbnails_prefix(session):
+    """scan_and_index must skip blobs under the _thumbnails/ prefix."""
+    from app.services.plot_archive_service import PlotArchiveService
+
+    mock_creds = MagicMock()
+    mock_get_creds = AsyncMock(return_value=mock_creds)
+    mock_client_cls = MagicMock()
+    mock_bucket = mock_client_cls.return_value.bucket.return_value
+
+    # Create two blobs: one real plot, one thumbnail
+    mock_real_blob = MagicMock()
+    mock_real_blob.name = "experiments/1/plots/heatmap.png"
+    mock_real_blob.updated = None
+    mock_real_blob.size = 5000
+
+    mock_thumb_blob = MagicMock()
+    mock_thumb_blob.name = "_thumbnails/plot_1.png"
+    mock_thumb_blob.updated = None
+    mock_thumb_blob.size = 2000
+
+    mock_bucket.list_blobs.return_value = [mock_real_blob, mock_thumb_blob]
+
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value) "
+            "VALUES ('results_bucket_name', 'test-results-bucket') "
+            "ON CONFLICT (key) DO UPDATE SET value = 'test-results-bucket'"
+        )
+    )
+    await session.commit()
+
+    with (
+        patch("google.cloud.storage.Client", mock_client_cls),
+        patch(
+            "app.services.gcs_storage.GcsStorageService.get_credentials",
+            mock_get_creds,
+        ),
+    ):
+        indexed = await PlotArchiveService.scan_and_index(session)
+
+    # Only the real plot should be indexed, not the thumbnail
+    assert indexed <= 1  # May be 0 if already indexed
+
+
+# -- Thumbnail content endpoint --
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_content_endpoint_returns_png(client, admin_token, session, admin_user, experiment_for_plots):
+    """GET /api/plots/{id}/thumbnail/content returns PNG bytes when thumbnail exists."""
+    from app.models.file import File
+    from app.models.plot_archive_entry import PlotArchiveEntry
+    from datetime import datetime, timezone
+
+    f = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri="gs://test-bucket/plots/stats.pdf",
+        filename="stats.pdf",
+        size_bytes=20000,
+        file_type="pdf",
+        uploader_user_id=admin_user.id,
+    )
+    session.add(f)
+    await session.flush()
+
+    plot = PlotArchiveEntry(
+        organization_id=admin_user.organization_id,
+        file_id=f.id,
+        title="stats.pdf",
+        experiment_id=experiment_for_plots.id,
+        thumbnail_gcs_uri="gs://test-bucket/_thumbnails/plot_99.png",
+        indexed_at=datetime.now(timezone.utc),
+    )
+    session.add(plot)
+    await session.flush()
+    await session.commit()
+
+    mock_client_cls = MagicMock()
+    mock_blob = mock_client_cls.return_value.bucket.return_value.blob.return_value
+    mock_blob.download_as_bytes.return_value = b"\x89PNG fake thumbnail"
+
+    with (
+        patch("google.cloud.storage.Client", mock_client_cls),
+        patch(
+            "app.services.gcs_storage.GcsStorageService.get_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        resp = await client.get(
+            f"/api/plots/{plot.id}/thumbnail/content",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    assert resp.content == b"\x89PNG fake thumbnail"
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_content_endpoint_404_when_no_thumbnail(client, admin_token, sample_plot):
+    """GET /api/plots/{id}/thumbnail/content returns 404 when no thumbnail exists."""
+    resp = await client.get(
+        f"/api/plots/{sample_plot.id}/thumbnail/content",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+# -- Backfill endpoint returns thumbnail count --
+
+
+@pytest.mark.asyncio
+async def test_backfill_endpoint_returns_thumbnail_count(client, admin_token):
+    """POST /api/plots/backfill returns both metadata_updated and thumbnails_generated."""
+    mock_client_cls = MagicMock()
+
+    with (
+        patch("google.cloud.storage.Client", mock_client_cls),
+        patch(
+            "app.services.gcs_storage.GcsStorageService.get_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        resp = await client.post(
+            "/api/plots/backfill",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "metadata_updated" in data
+    assert "thumbnails_generated" in data
+
+
+# -- Delete cleanup --
+
+
+@pytest.mark.asyncio
+async def test_file_delete_cleans_up_thumbnails(client, admin_token, session, admin_user, experiment_for_plots):
+    """Deleting a file with an associated plot thumbnail must delete the
+    thumbnail blob from GCS."""
+    from app.models.file import File
+    from app.models.plot_archive_entry import PlotArchiveEntry
+    from datetime import datetime, timezone
+
+    f = File(
+        organization_id=admin_user.organization_id,
+        gcs_uri="gs://test-bucket/plots/cleanup-test.pdf",
+        filename="cleanup-test.pdf",
+        size_bytes=10000,
+        file_type="pdf",
+        uploader_user_id=admin_user.id,
+    )
+    session.add(f)
+    await session.flush()
+
+    plot = PlotArchiveEntry(
+        organization_id=admin_user.organization_id,
+        file_id=f.id,
+        title="cleanup-test.pdf",
+        experiment_id=experiment_for_plots.id,
+        thumbnail_gcs_uri="gs://test-bucket/_thumbnails/plot_cleanup.png",
+        indexed_at=datetime.now(timezone.utc),
+    )
+    session.add(plot)
+    await session.flush()
+    await session.commit()
+
+    mock_delete_thumb = AsyncMock(return_value=True)
+
+    with patch(
+        "app.services.thumbnail_service.ThumbnailService.delete_thumbnail",
+        mock_delete_thumb,
+    ):
+        resp = await client.delete(
+            f"/api/files/{f.id}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert resp.status_code == 200
+    mock_delete_thumb.assert_called_once()
+    call_args = mock_delete_thumb.call_args
+    assert call_args[0][1] == "gs://test-bucket/_thumbnails/plot_cleanup.png"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/results/plot-archive/page.tsx
+++ b/frontend/src/app/results/plot-archive/page.tsx
@@ -26,7 +26,15 @@ function PlotThumbnail({
   const url = fileContentUrl(fileId);
 
   if (error) {
-    return <span className="text-gray-400 text-xs">Failed to load</span>;
+    return (
+      <button
+        type="button"
+        className="text-gray-400 text-xs cursor-pointer hover:text-gray-600"
+        onClick={() => onClick(url)}
+      >
+        Failed to load
+      </button>
+    );
   }
   return (
     <img

--- a/frontend/src/app/results/plot-archive/page.tsx
+++ b/frontend/src/app/results/plot-archive/page.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { PlotModal } from "@/components/shared/PlotModal";
 import { ContentLoading } from "@/components/shared/ContentLoading";
-import { api, fileContentUrl } from "@/lib/api";
+import { api, fileContentUrl, plotThumbnailContentUrl } from "@/lib/api";
 import type {
   PlotArchiveResponse,
   PlotArchiveListResponse,
@@ -14,34 +14,62 @@ import type {
 } from "@/lib/types";
 
 function PlotThumbnail({
-  fileId,
-  title,
+  plot,
   onClick,
 }: {
-  fileId: number;
-  title: string;
-  onClick: (url: string) => void;
+  plot: PlotArchiveResponse;
+  onClick: () => void;
 }) {
   const [error, setError] = useState(false);
-  const url = fileContentUrl(fileId);
+  const fileType = plot.file?.file_type?.toLowerCase() ?? "";
+  const isPdf = fileType === "pdf";
+  const hasThumbnail = !!plot.thumbnail_url;
+
+  // For PDFs without a generated thumbnail, show file-type icon
+  if (isPdf && !hasThumbnail) {
+    return (
+      <button
+        type="button"
+        className="flex flex-col items-center gap-2 py-6 cursor-pointer hover:opacity-80"
+        onClick={onClick}
+      >
+        <div className="w-16 h-16 bg-gray-200 rounded-lg flex items-center justify-center text-gray-500 text-xs font-bold uppercase">
+          PDF
+        </div>
+        <span className="text-xs text-gray-400">No preview available</span>
+      </button>
+    );
+  }
+
+  // Determine the image source: thumbnail for PDFs, content for images
+  const imgUrl = isPdf && hasThumbnail
+    ? plotThumbnailContentUrl(plot.id)
+    : plot.file
+      ? fileContentUrl(plot.file.id)
+      : "";
 
   if (error) {
     return (
       <button
         type="button"
-        className="text-gray-400 text-xs cursor-pointer hover:text-gray-600"
-        onClick={() => onClick(url)}
+        className="flex flex-col items-center gap-2 py-6 cursor-pointer hover:opacity-80"
+        onClick={onClick}
       >
-        Failed to load
+        <div className="w-16 h-16 bg-gray-200 rounded-lg flex items-center justify-center text-gray-500 text-xs font-bold uppercase">
+          {fileType || "?"}
+        </div>
+        <span className="text-xs text-gray-400">No preview available</span>
       </button>
     );
   }
+
   return (
+    // eslint-disable-next-line @next/next/no-img-element
     <img
-      src={url}
-      alt={title}
+      src={imgUrl}
+      alt={plot.title ?? "Plot"}
       className="w-full h-full object-cover cursor-pointer"
-      onClick={() => onClick(url)}
+      onClick={onClick}
       onError={() => setError(true)}
     />
   );
@@ -145,8 +173,14 @@ export default function PlotArchivePage() {
 
   const resetPage = () => setPage(1);
 
-  const handleExpand = (plot: PlotArchiveResponse, signedUrl: string) => {
-    setExpandedUrl(signedUrl);
+  const handleExpand = (plot: PlotArchiveResponse) => {
+    const isPdf = plot.file?.file_type?.toLowerCase() === "pdf";
+    const url = isPdf && plot.thumbnail_url
+      ? plotThumbnailContentUrl(plot.id)
+      : plot.file
+        ? fileContentUrl(plot.file.id)
+        : "";
+    setExpandedUrl(url);
     setExpandedTitle(plot.title ?? "Plot");
     setExpandedPlot(plot);
   };
@@ -266,9 +300,8 @@ export default function PlotArchivePage() {
                             <StorageDeletedPlaceholder />
                           ) : plot.file ? (
                             <PlotThumbnail
-                              fileId={plot.file.id}
-                              title={plot.title ?? "Plot"}
-                              onClick={(url) => handleExpand(plot, url)}
+                              plot={plot}
+                              onClick={() => handleExpand(plot)}
                             />
                           ) : (
                             <span className="text-gray-400 text-xs">
@@ -322,25 +355,22 @@ export default function PlotArchivePage() {
               </>
             )}
 
-            {expandedUrl && (
+            {expandedUrl && expandedPlot && (
               <PlotModal
                 url={expandedUrl}
                 title={expandedTitle}
-                metadata={
-                  expandedPlot
-                    ? {
-                        experimentName: expandedPlot.experiment_name,
-                        projectName: expandedPlot.project_name,
-                        pipelineRunId: expandedPlot.pipeline_run_id,
-                        pipelineRunName: expandedPlot.pipeline_run_name,
-                        notebookSessionId: expandedPlot.notebook_session_id,
-                        notebookSessionType: expandedPlot.notebook_session_type,
-                        sourceType: expandedPlot.source_type,
-                        tags: expandedPlot.tags,
-                        indexedAt: expandedPlot.indexed_at,
-                      }
-                    : undefined
-                }
+                metadata={{
+                  experimentName: expandedPlot.experiment_name,
+                  projectName: expandedPlot.project_name,
+                  pipelineRunId: expandedPlot.pipeline_run_id,
+                  pipelineRunName: expandedPlot.pipeline_run_name,
+                  notebookSessionId: expandedPlot.notebook_session_id,
+                  notebookSessionType: expandedPlot.notebook_session_type,
+                  sourceType: expandedPlot.source_type,
+                  tags: expandedPlot.tags,
+                  indexedAt: expandedPlot.indexed_at,
+                  file: expandedPlot.file,
+                }}
                 onClose={() => {
                   setExpandedUrl(null);
                   setExpandedPlot(null);

--- a/frontend/src/app/results/plot-archive/page.tsx
+++ b/frontend/src/app/results/plot-archive/page.tsx
@@ -295,7 +295,7 @@ export default function PlotArchivePage() {
                         key={plot.id}
                         className={`bg-white rounded-lg shadow overflow-hidden transition-shadow ${deleted ? "opacity-60" : "hover:shadow-md"}`}
                       >
-                        <div className="aspect-square bg-gray-100 flex items-center justify-center">
+                        <div className="aspect-square bg-gray-100 flex items-center justify-center relative">
                           {deleted ? (
                             <StorageDeletedPlaceholder />
                           ) : plot.file ? (
@@ -308,9 +308,14 @@ export default function PlotArchivePage() {
                               No preview
                             </span>
                           )}
+                          {plot.file && (
+                            <span className="absolute top-1.5 right-1.5 px-1.5 py-0.5 bg-black/50 text-white text-[10px] font-semibold uppercase rounded">
+                              {plot.file.file_type}
+                            </span>
+                          )}
                         </div>
                         <div className="p-2">
-                          <p className={`text-xs font-medium truncate ${deleted ? "text-gray-400" : ""}`}>
+                          <p className={`text-[11px] leading-tight font-medium line-clamp-2 ${deleted ? "text-gray-400" : ""}`} title={plot.title ?? undefined}>
                             {plot.title}
                           </p>
                           {plot.tags.length > 0 && (

--- a/frontend/src/app/results/plot-archive/page.tsx
+++ b/frontend/src/app/results/plot-archive/page.tsx
@@ -72,6 +72,7 @@ export default function PlotArchivePage() {
   const [loading, setLoading] = useState(true);
   const [expandedUrl, setExpandedUrl] = useState<string | null>(null);
   const [expandedTitle, setExpandedTitle] = useState("");
+  const [expandedPlot, setExpandedPlot] = useState<PlotArchiveResponse | null>(null);
   const pageSize = 24;
 
   const [experiments, setExperiments] = useState<
@@ -147,6 +148,7 @@ export default function PlotArchivePage() {
   const handleExpand = (plot: PlotArchiveResponse, signedUrl: string) => {
     setExpandedUrl(signedUrl);
     setExpandedTitle(plot.title ?? "Plot");
+    setExpandedPlot(plot);
   };
 
   return (
@@ -324,7 +326,25 @@ export default function PlotArchivePage() {
               <PlotModal
                 url={expandedUrl}
                 title={expandedTitle}
-                onClose={() => setExpandedUrl(null)}
+                metadata={
+                  expandedPlot
+                    ? {
+                        experimentName: expandedPlot.experiment_name,
+                        projectName: expandedPlot.project_name,
+                        pipelineRunId: expandedPlot.pipeline_run_id,
+                        pipelineRunName: expandedPlot.pipeline_run_name,
+                        notebookSessionId: expandedPlot.notebook_session_id,
+                        notebookSessionType: expandedPlot.notebook_session_type,
+                        sourceType: expandedPlot.source_type,
+                        tags: expandedPlot.tags,
+                        indexedAt: expandedPlot.indexed_at,
+                      }
+                    : undefined
+                }
+                onClose={() => {
+                  setExpandedUrl(null);
+                  setExpandedPlot(null);
+                }}
               />
             )}
           </div>

--- a/frontend/src/components/shared/PlotModal.tsx
+++ b/frontend/src/components/shared/PlotModal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect } from "react";
+import { api } from "@/lib/api";
+import type { FileResponse } from "@/lib/types";
 
 interface PlotMetadata {
   experimentName?: string | null;
@@ -12,6 +14,7 @@ interface PlotMetadata {
   sourceType?: string | null;
   tags?: string[];
   indexedAt?: string | null;
+  file?: FileResponse | null;
 }
 
 interface PlotModalProps {
@@ -19,6 +22,14 @@ interface PlotModalProps {
   title: string;
   metadata?: PlotMetadata;
   onClose: () => void;
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null) return "-";
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 }
 
 function sourceLabel(sourceType: string): string {
@@ -39,20 +50,14 @@ function sourceLabel(sourceType: string): string {
   }
 }
 
-function MetadataRow({
-  label,
-  value,
-}: {
-  label: string;
-  value: string | null | undefined;
-}) {
-  if (!value) return null;
-  return (
-    <div className="flex gap-2">
-      <span className="text-gray-400 text-xs w-24 shrink-0">{label}</span>
-      <span className="text-gray-700 text-xs">{value}</span>
-    </div>
-  );
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 export function PlotModal({ url, title, metadata, onClose }: PlotModalProps) {
@@ -64,27 +69,74 @@ export function PlotModal({ url, title, metadata, onClose }: PlotModalProps) {
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
-  const hasMetadata =
-    metadata &&
-    (metadata.experimentName ||
-      metadata.projectName ||
-      metadata.pipelineRunName ||
-      metadata.notebookSessionType ||
-      metadata.sourceType ||
-      metadata.indexedAt ||
-      (metadata.tags && metadata.tags.length > 0));
+  const file = metadata?.file;
+  const hasDetail = !!metadata;
+
+  const triggerDownload = async (fileId: number) => {
+    try {
+      const { download_url } = await api.get<{ download_url: string }>(
+        `/api/files/${fileId}/download`
+      );
+      const a = document.createElement("a");
+      a.href = download_url;
+      a.download = "";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } catch {
+      // ignore
+    }
+  };
+
+  // Simple mode for non-archive consumers (experiments, QC dashboards, results)
+  if (!hasDetail) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+        onClick={onClose}
+      >
+        <div
+          className="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[80vh] overflow-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="sticky top-0 flex items-center justify-between p-4 border-b bg-white rounded-t-lg">
+            <h3 className="text-lg font-semibold truncate pr-4">{title}</h3>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 text-xl leading-none px-2"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="p-4 flex justify-center bg-gray-50">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={url}
+              alt={title}
+              className="max-h-64 object-contain rounded"
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Detail mode for plot archive -- matches Files page modal
+  const isImage = file
+    ? ["png", "jpg", "jpeg", "svg"].includes(file.file_type.toLowerCase())
+    : true;
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
       onClick={onClose}
     >
       <div
-        className="relative bg-white rounded-lg shadow-xl max-w-[90vw] max-h-[90vh] overflow-auto mx-4"
+        className="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[80vh] overflow-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="sticky top-0 flex items-center justify-between p-4 border-b bg-white rounded-t-lg">
-          <h3 className="font-medium text-sm">{title}</h3>
+          <h3 className="text-lg font-semibold truncate pr-4">{title}</h3>
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-gray-600 text-xl leading-none px-2"
@@ -92,71 +144,149 @@ export function PlotModal({ url, title, metadata, onClose }: PlotModalProps) {
             &times;
           </button>
         </div>
-        <div className="p-4">
-          <img src={url} alt={title} className="max-w-full" />
-        </div>
-        {hasMetadata && (
-          <div className="px-4 pb-4 pt-2 border-t space-y-1.5">
-            <MetadataRow label="Project" value={metadata.projectName} />
-            <MetadataRow
-              label="Experiment"
-              value={metadata.experimentName}
+
+        {isImage ? (
+          <div className="p-4 flex justify-center bg-gray-50">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={url}
+              alt={title}
+              className="max-h-64 object-contain rounded"
             />
-            <MetadataRow
-              label="Pipeline"
-              value={
-                metadata.pipelineRunName
-                  ? `${metadata.pipelineRunName} (#${metadata.pipelineRunId})`
-                  : undefined
-              }
+          </div>
+        ) : (
+          <div className="p-4 flex justify-center bg-gray-50">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={url}
+              alt={title}
+              className="max-h-64 object-contain rounded"
             />
-            <MetadataRow
-              label="Session"
-              value={
-                metadata.notebookSessionType
-                  ? `${metadata.notebookSessionType} (#${metadata.notebookSessionId})`
-                  : undefined
-              }
-            />
-            <MetadataRow
-              label="Source"
-              value={
-                metadata.sourceType
-                  ? sourceLabel(metadata.sourceType)
-                  : undefined
-              }
-            />
-            <MetadataRow
-              label="Indexed"
-              value={
-                metadata.indexedAt
-                  ? new Date(metadata.indexedAt).toLocaleDateString("en-US", {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })
-                  : undefined
-              }
-            />
-            {metadata.tags && metadata.tags.length > 0 && (
-              <div className="flex gap-2 items-start">
-                <span className="text-gray-400 text-xs w-24 shrink-0">
-                  Tags
-                </span>
-                <div className="flex flex-wrap gap-1">
-                  {metadata.tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded text-[10px]"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
+          </div>
+        )}
+
+        <dl className="p-4 grid grid-cols-2 gap-x-4 gap-y-3">
+          {file && (
+            <>
+              <div>
+                <dt className="text-xs font-medium text-gray-500 uppercase">
+                  File Type
+                </dt>
+                <dd className="mt-0.5 text-sm text-gray-900">
+                  {file.file_type}
+                </dd>
               </div>
-            )}
+              <div>
+                <dt className="text-xs font-medium text-gray-500 uppercase">
+                  Size
+                </dt>
+                <dd className="mt-0.5 text-sm text-gray-900">
+                  {formatBytes(file.size_bytes)}
+                </dd>
+              </div>
+            </>
+          )}
+          {metadata.projectName && (
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase">
+                Project
+              </dt>
+              <dd className="mt-0.5 text-sm text-gray-900">
+                {metadata.projectName}
+              </dd>
+            </div>
+          )}
+          {metadata.experimentName && (
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase">
+                Experiment
+              </dt>
+              <dd className="mt-0.5 text-sm text-gray-900">
+                {metadata.experimentName}
+              </dd>
+            </div>
+          )}
+          {metadata.pipelineRunName && (
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase">
+                Pipeline
+              </dt>
+              <dd className="mt-0.5 text-sm text-gray-900">
+                {metadata.pipelineRunName} (#{metadata.pipelineRunId})
+              </dd>
+            </div>
+          )}
+          {metadata.notebookSessionType && (
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase">
+                Session
+              </dt>
+              <dd className="mt-0.5 text-sm text-gray-900">
+                {metadata.notebookSessionType} (#{metadata.notebookSessionId})
+              </dd>
+            </div>
+          )}
+          {metadata.sourceType && (
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase">
+                Source
+              </dt>
+              <dd className="mt-0.5 text-sm text-gray-900">
+                {sourceLabel(metadata.sourceType)}
+              </dd>
+            </div>
+          )}
+          {metadata.indexedAt && (
+            <div>
+              <dt className="text-xs font-medium text-gray-500 uppercase">
+                Indexed
+              </dt>
+              <dd className="mt-0.5 text-sm text-gray-900">
+                {formatDate(metadata.indexedAt)}
+              </dd>
+            </div>
+          )}
+          {metadata.tags && metadata.tags.length > 0 && (
+            <div className="col-span-2">
+              <dt className="text-xs font-medium text-gray-500 uppercase">
+                Tags
+              </dt>
+              <dd className="mt-0.5 flex flex-wrap gap-1">
+                {metadata.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-2 py-0.5 bg-gray-100 text-gray-700 text-xs rounded"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </dd>
+            </div>
+          )}
+        </dl>
+
+        {file && !file.storage_deleted && (
+          <div className="px-4 pb-4">
+            <button
+              onClick={() => triggerDownload(file.id)}
+              className="w-full px-4 py-2 bg-green-600 text-white rounded-md text-sm font-medium hover:bg-green-700 flex items-center justify-center gap-2"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V3"
+                />
+              </svg>
+              Download
+            </button>
           </div>
         )}
       </div>

--- a/frontend/src/components/shared/PlotModal.tsx
+++ b/frontend/src/components/shared/PlotModal.tsx
@@ -2,13 +2,60 @@
 
 import { useEffect } from "react";
 
+interface PlotMetadata {
+  experimentName?: string | null;
+  projectName?: string | null;
+  pipelineRunId?: number | null;
+  pipelineRunName?: string | null;
+  notebookSessionId?: number | null;
+  notebookSessionType?: string | null;
+  sourceType?: string | null;
+  tags?: string[];
+  indexedAt?: string | null;
+}
+
 interface PlotModalProps {
   url: string;
   title: string;
+  metadata?: PlotMetadata;
   onClose: () => void;
 }
 
-export function PlotModal({ url, title, onClose }: PlotModalProps) {
+function sourceLabel(sourceType: string): string {
+  switch (sourceType) {
+    case "pipeline":
+    case "plot_archive":
+      return "Pipeline";
+    case "notebook":
+      return "Notebook";
+    case "cellxgene":
+      return "CellXGene";
+    case "qc_dashboard":
+      return "QC Dashboard";
+    case "upload":
+      return "Upload";
+    default:
+      return sourceType;
+  }
+}
+
+function MetadataRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  if (!value) return null;
+  return (
+    <div className="flex gap-2">
+      <span className="text-gray-400 text-xs w-24 shrink-0">{label}</span>
+      <span className="text-gray-700 text-xs">{value}</span>
+    </div>
+  );
+}
+
+export function PlotModal({ url, title, metadata, onClose }: PlotModalProps) {
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -16,6 +63,16 @@ export function PlotModal({ url, title, onClose }: PlotModalProps) {
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
+
+  const hasMetadata =
+    metadata &&
+    (metadata.experimentName ||
+      metadata.projectName ||
+      metadata.pipelineRunName ||
+      metadata.notebookSessionType ||
+      metadata.sourceType ||
+      metadata.indexedAt ||
+      (metadata.tags && metadata.tags.length > 0));
 
   return (
     <div
@@ -38,6 +95,70 @@ export function PlotModal({ url, title, onClose }: PlotModalProps) {
         <div className="p-4">
           <img src={url} alt={title} className="max-w-full" />
         </div>
+        {hasMetadata && (
+          <div className="px-4 pb-4 pt-2 border-t space-y-1.5">
+            <MetadataRow label="Project" value={metadata.projectName} />
+            <MetadataRow
+              label="Experiment"
+              value={metadata.experimentName}
+            />
+            <MetadataRow
+              label="Pipeline"
+              value={
+                metadata.pipelineRunName
+                  ? `${metadata.pipelineRunName} (#${metadata.pipelineRunId})`
+                  : undefined
+              }
+            />
+            <MetadataRow
+              label="Session"
+              value={
+                metadata.notebookSessionType
+                  ? `${metadata.notebookSessionType} (#${metadata.notebookSessionId})`
+                  : undefined
+              }
+            />
+            <MetadataRow
+              label="Source"
+              value={
+                metadata.sourceType
+                  ? sourceLabel(metadata.sourceType)
+                  : undefined
+              }
+            />
+            <MetadataRow
+              label="Indexed"
+              value={
+                metadata.indexedAt
+                  ? new Date(metadata.indexedAt).toLocaleDateString("en-US", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })
+                  : undefined
+              }
+            />
+            {metadata.tags && metadata.tags.length > 0 && (
+              <div className="flex gap-2 items-start">
+                <span className="text-gray-400 text-xs w-24 shrink-0">
+                  Tags
+                </span>
+                <div className="flex flex-wrap gap-1">
+                  {metadata.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded text-[10px]"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -277,4 +277,10 @@ export function fileContentUrl(fileId: number): string {
   return token ? `${base}?token=${encodeURIComponent(token)}` : base;
 }
 
+export function plotThumbnailContentUrl(plotId: number): string {
+  const token = getToken();
+  const base = `${API_URL}/api/plots/${plotId}/thumbnail/content`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}
+
 export { ApiError };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1014,8 +1014,13 @@ export interface PlotArchiveResponse {
   title: string | null;
   file: FileResponse | null;
   experiment_id: number | null;
+  experiment_name: string | null;
+  project_name: string | null;
   pipeline_run_id: number | null;
+  pipeline_run_name: string | null;
   notebook_session_id: number | null;
+  notebook_session_type: string | null;
+  source_type: string | null;
   tags: string[];
   thumbnail_url: string | null;
   indexed_at: string;

--- a/frontend/tests/pages/plot-archive.test.tsx
+++ b/frontend/tests/pages/plot-archive.test.tsx
@@ -14,6 +14,7 @@ jest.mock("@/lib/api", () => ({
     get: (...args: unknown[]) => mockApiGet(...args),
   },
   fileContentUrl: (fileId: number) => `http://localhost:8000/api/files/${fileId}/content?token=fake`,
+  plotThumbnailContentUrl: (plotId: number) => `http://localhost:8000/api/plots/${plotId}/thumbnail/content?token=fake`,
 }));
 
 jest.mock("@/components/layout/Sidebar", () => ({
@@ -275,12 +276,11 @@ test("opens plot modal when failed-to-load thumbnail is clicked", async () => {
   const images = screen.getAllByRole("img");
   fireEvent.error(images[0]);
 
-  // The "Failed to load" text should appear and be clickable
-  await waitFor(() => {
-    expect(screen.getByText("Failed to load")).toBeInTheDocument();
-  });
+  // The fallback should appear and be clickable
+  const fallbacks = screen.getAllByText("No preview available");
+  expect(fallbacks.length).toBeGreaterThan(0);
 
-  fireEvent.click(screen.getByText("Failed to load"));
+  fireEvent.click(fallbacks[0]);
 
   await waitFor(() => {
     expect(screen.getByTestId("plot-modal")).toBeInTheDocument();

--- a/frontend/tests/pages/plot-archive.test.tsx
+++ b/frontend/tests/pages/plot-archive.test.tsx
@@ -223,3 +223,31 @@ test("opens plot modal when thumbnail is clicked", async () => {
     expect(screen.getByTestId("plot-modal")).toBeInTheDocument();
   });
 });
+
+test("opens plot modal when failed-to-load thumbnail is clicked", async () => {
+  render(<PlotArchivePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText("fastqc_heatmap.png")).toBeInTheDocument();
+  });
+
+  await waitFor(() => {
+    const images = screen.getAllByRole("img");
+    expect(images.length).toBeGreaterThan(0);
+  });
+
+  // Simulate image load failure on the first thumbnail
+  const images = screen.getAllByRole("img");
+  fireEvent.error(images[0]);
+
+  // The "Failed to load" text should appear and be clickable
+  await waitFor(() => {
+    expect(screen.getByText("Failed to load")).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByText("Failed to load"));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("plot-modal")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/pages/plot-archive.test.tsx
+++ b/frontend/tests/pages/plot-archive.test.tsx
@@ -23,9 +23,13 @@ jest.mock("@/components/layout/Header", () => ({
   Header: () => <div data-testid="header">Header</div>,
 }));
 jest.mock("@/components/shared/PlotModal", () => ({
-  PlotModal: ({ title, onClose }: { title: string; onClose: () => void }) => (
+  PlotModal: ({ title, metadata, onClose }: { title: string; metadata?: { experimentName?: string | null; projectName?: string | null; pipelineRunName?: string | null; sourceType?: string | null }; onClose: () => void }) => (
     <div data-testid="plot-modal">
       <span>{title}</span>
+      {metadata?.experimentName && <span data-testid="modal-experiment">{metadata.experimentName}</span>}
+      {metadata?.projectName && <span data-testid="modal-project">{metadata.projectName}</span>}
+      {metadata?.pipelineRunName && <span data-testid="modal-pipeline">{metadata.pipelineRunName}</span>}
+      {metadata?.sourceType && <span data-testid="modal-source">{metadata.sourceType}</span>}
       <button onClick={onClose}>Close</button>
     </div>
   ),
@@ -40,8 +44,13 @@ const mockPlots = {
       title: "fastqc_heatmap.png",
       file: { id: 10, filename: "fastqc_heatmap.png", gcs_uri: "gs://bucket/heatmap.png", size_bytes: 1024, md5_checksum: null, file_type: "png", tags: [], uploader: null, upload_timestamp: "2026-03-19T00:00:00Z", created_at: "2026-03-19T00:00:00Z" },
       experiment_id: 1,
+      experiment_name: "RNA-seq Batch 1",
+      project_name: "Cancer Genomics",
       pipeline_run_id: 5,
+      pipeline_run_name: "nf-core/rnaseq",
       notebook_session_id: null,
+      notebook_session_type: null,
+      source_type: "pipeline",
       tags: ["fastqc", "qc"],
       thumbnail_url: null,
       indexed_at: "2026-03-19T00:00:00Z",
@@ -51,8 +60,13 @@ const mockPlots = {
       title: "adapter_content.png",
       file: { id: 11, filename: "adapter_content.png", gcs_uri: "gs://bucket/adapter.png", size_bytes: 2048, md5_checksum: null, file_type: "png", tags: [], uploader: null, upload_timestamp: "2026-03-19T00:00:00Z", created_at: "2026-03-19T00:00:00Z" },
       experiment_id: 2,
+      experiment_name: "ATAC-seq Run",
+      project_name: null,
       pipeline_run_id: null,
+      pipeline_run_name: null,
       notebook_session_id: null,
+      notebook_session_type: null,
+      source_type: null,
       tags: [],
       thumbnail_url: null,
       indexed_at: "2026-03-18T00:00:00Z",
@@ -222,6 +236,27 @@ test("opens plot modal when thumbnail is clicked", async () => {
   await waitFor(() => {
     expect(screen.getByTestId("plot-modal")).toBeInTheDocument();
   });
+});
+
+test("plot modal receives metadata when thumbnail is clicked", async () => {
+  render(<PlotArchivePage />);
+
+  await waitFor(() => {
+    const images = screen.getAllByRole("img");
+    expect(images.length).toBeGreaterThan(0);
+  });
+
+  const images = screen.getAllByRole("img");
+  fireEvent.click(images[0]);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("plot-modal")).toBeInTheDocument();
+  });
+
+  expect(screen.getByTestId("modal-experiment")).toHaveTextContent("RNA-seq Batch 1");
+  expect(screen.getByTestId("modal-project")).toHaveTextContent("Cancer Genomics");
+  expect(screen.getByTestId("modal-pipeline")).toHaveTextContent("nf-core/rnaseq");
+  expect(screen.getByTestId("modal-source")).toHaveTextContent("pipeline");
 });
 
 test("opens plot modal when failed-to-load thumbnail is clicked", async () => {


### PR DESCRIPTION
## Summary

- Fix plot archive scanner failing with "Multiple rows were found" by adding unique constraint on `platform_config.key` (fixes #151)
- Fix scanner using bare ADC instead of app service account credentials
- Add SVG and PDF content-type mappings so browsers render them correctly
- Generate PDF page-1 thumbnails using PyMuPDF, stored under `_thumbnails/` in results bucket
- Rework plot detail modal to match Data & Files page layout with metadata grid and download button
- Add file format badges (PNG, SVG, PDF) to thumbnail cards

## Test plan

- [x] Backend: 1752 tests pass (including 11 new plot archive tests)
- [x] Frontend: 409 tests pass (including new metadata and thumbnail tests)
- [x] ruff format, ruff check, mypy, tsc, markdownlint all pass
- [ ] Verify PDF thumbnails generate via `POST /api/plots/backfill`
- [ ] Verify plot detail modal shows metadata and download button
- [ ] Verify file format badges display on thumbnail cards
- [ ] Verify thumbnail cleanup when files are deleted

Closes #151