### PR TITLE
v0.7.0: Security hardening, deployment reliability fixes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## v0.7.0
+
+Security hardening and deployment reliability improvements from external pentest findings.
+
+### Security
+
+- Reject known-insecure JWT secret keys at startup (prevents running with default/public secrets)
+- Disable OpenAPI docs and Swagger UI in production (404 instead of serving 376-endpoint schema)
+- Remove smtp_configured from unauthenticated bootstrap status response
+- Require authentication for /api/health/services and /api/health/status endpoints
+- Replace full session JWTs in file/plot content URLs with short-lived, resource-scoped tokens (60s TTL)
+- New POST /api/content-tokens endpoint for issuing scoped content access tokens
+
+### Deployment Fixes
+
+- Fix GCP zone fallback for regions without a "-a" zone (us-east1, europe-west1)
+- Add backend region-to-zone mapping with correct zones for all 17 supported regions
+- Setup wizard now blocks on GCP validation failure and displays missing permissions inline
+- Fix zone fallback in frontend settings and setup wizard
+
 ## v0.6.6
 
 Automated backup scheduling and timezone fixes across the platform.

--- a/backend/app/gcp_zones.py
+++ b/backend/app/gcp_zones.py
@@ -1,0 +1,38 @@
+"""GCP region-to-zone mapping.
+
+Not every GCP region has a "-a" zone (e.g. us-east1 only has b, c, d).
+Use these helpers instead of appending "-a" blindly.
+"""
+
+GCP_ZONES: dict[str, list[str]] = {
+    "us-central1": ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"],
+    "us-east1": ["us-east1-b", "us-east1-c", "us-east1-d"],
+    "us-east4": ["us-east4-a", "us-east4-b", "us-east4-c"],
+    "us-west1": ["us-west1-a", "us-west1-b", "us-west1-c"],
+    "us-west2": ["us-west2-a", "us-west2-b", "us-west2-c"],
+    "us-west3": ["us-west3-a", "us-west3-b", "us-west3-c"],
+    "us-west4": ["us-west4-a", "us-west4-b", "us-west4-c"],
+    "europe-west1": ["europe-west1-b", "europe-west1-c", "europe-west1-d"],
+    "europe-west2": ["europe-west2-a", "europe-west2-b", "europe-west2-c"],
+    "europe-west3": ["europe-west3-a", "europe-west3-b", "europe-west3-c"],
+    "europe-west4": ["europe-west4-a", "europe-west4-b", "europe-west4-c"],
+    "europe-west6": ["europe-west6-a", "europe-west6-b", "europe-west6-c"],
+    "asia-east1": ["asia-east1-a", "asia-east1-b", "asia-east1-c"],
+    "asia-east2": ["asia-east2-a", "asia-east2-b", "asia-east2-c"],
+    "asia-northeast1": ["asia-northeast1-a", "asia-northeast1-b", "asia-northeast1-c"],
+    "asia-south1": ["asia-south1-a", "asia-south1-b", "asia-south1-c"],
+    "asia-southeast1": ["asia-southeast1-a", "asia-southeast1-b", "asia-southeast1-c"],
+}
+
+
+def default_zone(region: str) -> str:
+    """Return the first available zone for a region."""
+    zones = GCP_ZONES.get(region)
+    if zones:
+        return zones[0]
+    return f"{region}-b"
+
+
+def zones_for_region(region: str) -> list[str]:
+    """Return all known zones for a region."""
+    return GCP_ZONES.get(region, [f"{region}-b", f"{region}-c", f"{region}-d"])

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -418,7 +418,9 @@ async def deploy_stack(
         original_region = await _read_config(session, "gcp_region")
         await _set_config(session, "gcp_region", compute_region)
         if not compute_zone:
-            compute_zone = f"{compute_region}-a"
+            from app.gcp_zones import default_zone
+
+            compute_zone = default_zone(compute_region)
     if compute_zone:
         original_zone = await _read_config(session, "gcp_zone")
         await _set_config(session, "gcp_zone", compute_zone)

--- a/backend/app/services/terraform_executor.py
+++ b/backend/app/services/terraform_executor.py
@@ -851,7 +851,9 @@ class TerraformExecutor:
         """
         project_id = config.get("gcp_project_id") or ""
         region = config.get("gcp_region") or "us-central1"
-        zone = config.get("gcp_zone") or f"{region}-a"
+        from app.gcp_zones import default_zone
+
+        zone = config.get("gcp_zone") or default_zone(region)
         org_slug = config.get("org_slug") or "bioaf"
         # The deploy suffix is stored in platform_config for the
         # duration of a deployment. On destroy, the variable is omitted
@@ -883,7 +885,9 @@ class TerraformExecutor:
             # Multi-zone node placement: derive all zones in the region so
             # the autoscaler can fall back when a machine type is unavailable
             # in the primary zone (e.g. GCE capacity exhaustion).
-            tfvars["k8s_node_zones"] = [f"{region}-a", f"{region}-b", f"{region}-c"]
+            from app.gcp_zones import zones_for_region
+
+            tfvars["k8s_node_zones"] = zones_for_region(region)
             # Cluster configuration from platform_config
             if config.get("k8s_pipeline_machine_type"):
                 tfvars["k8s_pipeline_machine_type"] = config["k8s_pipeline_machine_type"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.6.6"
+version = "0.7.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,4 @@ Welcome to the bioAF documentation. bioAF is a turnkey computational biology pla
 
 ## API Reference
 
-The FastAPI backend auto-generates an OpenAPI specification at `/docs` when running. Access it at `http://localhost:8000/docs` during development.
+The FastAPI backend auto-generates an OpenAPI specification at `/docs` in development mode (`BIOAF_ENVIRONMENT=development`). Access it at `http://localhost:8000/docs` during local development. The docs endpoint is disabled in production.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/components/auth/SetupWizard.tsx
+++ b/frontend/src/components/auth/SetupWizard.tsx
@@ -32,7 +32,7 @@ const GCP_ZONES: Record<string, string[]> = {
 };
 
 function zonesForRegion(region: string): string[] {
-  return GCP_ZONES[region] ?? [`${region}-a`, `${region}-b`, `${region}-c`];
+  return GCP_ZONES[region] ?? [`${region}-b`, `${region}-c`, `${region}-d`];
 }
 
 const SETUP_RECOMMENDED_ROLES = [
@@ -97,6 +97,11 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const [gcpServiceAccountEmail, setGcpServiceAccountEmail] = useState("");
   const [gcpSaving, setGcpSaving] = useState(false);
   const [gcpConfigured, setGcpConfigured] = useState(false);
+  const [gcpValidation, setGcpValidation] = useState<{
+    passed: boolean;
+    checks: { name: string; passed: boolean; message: string }[];
+    permission_details: { permission: string; granted: boolean; recommended_role: string }[];
+  } | null>(null);
 
   // Step 4: SMTP
   const [smtpHost, setSmtpHost] = useState("");
@@ -174,6 +179,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 
   const handleSaveGcp = async () => {
     setError("");
+    setGcpValidation(null);
     setGcpSaving(true);
     try {
       await api.put("/api/v1/settings/gcp", {
@@ -188,9 +194,14 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
             : undefined,
         gcp_service_account_email: gcpServiceAccountEmail || undefined,
       });
-      await api.post("/api/v1/settings/gcp/validate");
-      setGcpConfigured(true);
-      setStep(4);
+      const result = await api.post<typeof gcpValidation>("/api/v1/settings/gcp/validate");
+      setGcpValidation(result);
+      if (result?.passed) {
+        setGcpConfigured(true);
+        setStep(4);
+      } else {
+        setError("Validation failed. Fix the issues below and try again.");
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to save GCP configuration");
     } finally {
@@ -470,8 +481,45 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 
           <button onClick={handleSaveGcp} disabled={gcpSaving}
             className="w-full bg-bioaf-600 text-white py-2 rounded hover:bg-bioaf-700 disabled:opacity-50">
-            {gcpSaving ? "Saving..." : "Save & Validate"}
+            {gcpSaving ? "Validating..." : "Save & Validate"}
           </button>
+
+          {gcpValidation && !gcpValidation.passed && (
+            <div className="border rounded divide-y text-sm">
+              <div className="p-3 bg-red-50">
+                <h4 className="font-semibold text-red-800">Validation Failed</h4>
+              </div>
+              <div className="p-3 space-y-1.5">
+                <p className="text-xs font-medium text-gray-600">System Checks</p>
+                {gcpValidation.checks.map((c) => (
+                  <div key={c.name} className="flex items-start gap-2 text-xs">
+                    <span className={c.passed ? "text-green-600" : "text-red-600"}>
+                      {c.passed ? "\u2713" : "\u2717"}
+                    </span>
+                    <span>
+                      <span className="font-medium">{c.name}</span>{" "}
+                      <span className="text-gray-500">{c.message}</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+              {gcpValidation.permission_details.some((p) => !p.granted) && (
+                <div className="p-3 space-y-1.5">
+                  <p className="text-xs font-medium text-gray-600">Missing Permissions</p>
+                  {gcpValidation.permission_details
+                    .filter((p) => !p.granted)
+                    .map((p) => (
+                      <div key={p.permission} className="flex items-center gap-2 text-xs">
+                        <span className="text-red-600">{"\u2717"}</span>
+                        <code className="bg-red-50 px-1 rounded">{p.permission}</code>
+                        <span className="text-gray-400">(needs {p.recommended_role})</span>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </div>
+          )}
+
           <button onClick={() => setStep(4)} className="w-full text-gray-500 text-sm hover:text-gray-700">
             Do this later
           </button>

--- a/frontend/src/components/settings/GcpSettingsContent.tsx
+++ b/frontend/src/components/settings/GcpSettingsContent.tsx
@@ -60,7 +60,7 @@ const GCP_ZONES: Record<string, string[]> = {
 };
 
 function zonesForRegion(region: string): string[] {
-  return GCP_ZONES[region] ?? [`${region}-a`, `${region}-b`, `${region}-c`];
+  return GCP_ZONES[region] ?? [`${region}-b`, `${region}-c`, `${region}-d`];
 }
 
 const RECOMMENDED_ROLES = [

--- a/frontend/src/lib/gcp-regions.ts
+++ b/frontend/src/lib/gcp-regions.ts
@@ -14,5 +14,5 @@ export const GCP_ZONES: Record<string, string[]> = {
 };
 
 export function zonesForRegion(region: string): string[] {
-  return GCP_ZONES[region] ?? [`${region}-a`, `${region}-b`, `${region}-c`];
+  return GCP_ZONES[region] ?? [`${region}-b`, `${region}-c`, `${region}-d`];
 }

--- a/frontend/tests/components/auth/SetupWizard.test.tsx
+++ b/frontend/tests/components/auth/SetupWizard.test.tsx
@@ -171,7 +171,7 @@ describe("SetupWizard", () => {
     await advanceToGcpStep(user);
 
     mockApiPut.mockResolvedValueOnce({});
-    mockApiPost.mockResolvedValueOnce({});
+    mockApiPost.mockResolvedValueOnce({ passed: true, checks: [], permission_details: [] });
     await user.type(screen.getByLabelText("GCP Project ID"), "proj");
     await user.click(screen.getByRole("button", { name: "Save & Validate" }));
     await screen.findByRole("heading", { name: "SMTP Settings" });


### PR DESCRIPTION
## Summary

- Fix GCP zone fallback that broke deployments to us-east1 and europe-west1 (no "-a" zone)
- Setup wizard now blocks on GCP validation failure and shows missing IAM permissions inline
- Add backend region-to-zone mapping for all 17 supported regions
- Fix zone fallback in frontend settings and setup wizard
- Update docs README to note /docs is dev-only

## Test plan

- [ ] Deploy to us-east1 region and confirm zone resolves to us-east1-b (not us-east1-a)
- [ ] Run setup wizard with a service account missing roles and confirm validation results display
- [ ] Confirm setup wizard blocks advancement until validation passes
- [ ] Verify "Do this later" still works to skip GCP step
- [ ] Run full backend test suite
- [ ] Run full frontend test suite (409 tests)
- [ ] Verify tsc, ruff, mypy, markdownlint all pass