### PR TITLE
v0.7.1: Fix validation error display

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.7.1
+
+Fix validation error display in setup wizard and all API error surfaces.
+
+### Fixes
+
+- Pydantic 422 validation errors (e.g. invalid org slug) now display the actual error message instead of "[object Object]"
+- Applies to all API calls: fetchApi, uploadFile, and downloadFile
+
 ## v0.7.0
 
 Security hardening and deployment reliability improvements from external pentest findings.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.7.0"
+version = "0.7.1"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,16 @@ class ApiError extends Error {
   }
 }
 
+function extractErrorMessage(body: { detail?: unknown }): string {
+  if (typeof body.detail === "string") return body.detail;
+  if (Array.isArray(body.detail)) {
+    return body.detail
+      .map((e: { msg?: string }) => e.msg ?? "Validation error")
+      .join("; ");
+  }
+  return "Request failed";
+}
+
 async function fetchApi<T>(
   path: string,
   options: RequestInit = {},
@@ -47,7 +57,7 @@ async function fetchApi<T>(
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ detail: "Unknown error" }));
-    throw new ApiError(response.status, error.detail || "Request failed");
+    throw new ApiError(response.status, extractErrorMessage(error));
   }
 
   if (response.status === 204) {
@@ -89,7 +99,7 @@ async function uploadFile<T>(path: string, file: File, extraFields?: Record<stri
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ detail: "Unknown error" }));
-    throw new ApiError(response.status, error.detail || "Request failed");
+    throw new ApiError(response.status, extractErrorMessage(error));
   }
 
   return response.json();
@@ -215,7 +225,7 @@ async function downloadFile(
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ detail: "Download failed" }));
-    throw new ApiError(response.status, error.detail || "Download failed");
+    throw new ApiError(response.status, extractErrorMessage(error));
   }
 
   const blob = await response.blob();


### PR DESCRIPTION
## Summary

- Pydantic 422 validation errors (e.g. invalid org slug with spaces) displayed as `[object Object]` instead of the actual error message
- New `extractErrorMessage` helper extracts `.msg` strings from Pydantic's validation error array
- Applied to all three API call surfaces: `fetchApi`, `uploadFile`, `downloadFile`

## Test plan

- [ ] Enter an invalid org slug (e.g. "bioaf test" with a space) in the setup wizard and confirm the actual validation message displays
- [ ] Verify all 409 frontend tests pass
- [ ] Verify tsc passes with zero errors