### PR TITLE
v0.7.3: OOM detection, preemption classification, cluster config UX

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
 # Release Notes
 
+## v0.7.3
+
+OOM detection, preemption classification, and cluster configuration UX improvements.
+
+### Pipeline monitoring
+
+- Detect OOM-killed pipelines from K8s container termination reasons and set failure_reason to "oom" with actionable guidance
+- Detect Spot preemption exhaustion from failed process exit codes (143/137/247) and set failure_reason to "preemption_exhausted"
+- Emit PIPELINE_OOM event (critical severity) for notification routing
+- Store exit_code on PipelineProcess records from adapter progress data
+
+### Infrastructure UI
+
+- Reorganize cluster config panel into "Pipeline Nodes" and "Interactive Nodes" columns
+- Add Spot instance info tooltip explaining cost savings and auto-retry behavior
+- Remove pt-5 alignment hack on the Spot toggle
+
+### Pipeline run UI
+
+- Show amber OOM banner with "Update node size" link on run detail page
+- Show blue preemption banner with "Re-run" and "Disable Spot" actions on run detail page
+- Add orange "OOM" and blue "Preempted" badges on the pipeline runs table
+
+### Database
+
+- Add nullable failure_reason column to pipeline_runs (migration 066)
+
 ## v0.7.2
 
 Security hardening from external pentest, deployment and setup reliability fixes.

--- a/backend/alembic/versions/066_add_failure_reason_to_pipeline_runs.py
+++ b/backend/alembic/versions/066_add_failure_reason_to_pipeline_runs.py
@@ -1,0 +1,24 @@
+"""Add failure_reason to pipeline_runs.
+
+Revision ID: 066
+Revises: 065
+Create Date: 2026-04-14
+
+Adds a nullable failure_reason column so the UI can render specific
+treatments for OOM, preemption exhaustion, and generic task errors
+without parsing error message text.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "066"
+down_revision = "065"
+
+
+def upgrade() -> None:
+    op.add_column("pipeline_runs", sa.Column("failure_reason", sa.String(50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("pipeline_runs", "failure_reason")

--- a/backend/app/adapters/compute/kubernetes.py
+++ b/backend/app/adapters/compute/kubernetes.py
@@ -913,12 +913,30 @@ class KubernetesComputeProvider(ComputeProvider):
         elif job.status.active and job.status.active > 0:
             status = "running"
 
-        return {
+        result = {
             "job_id": job_id,
             "status": status,
             "pod_name": pod_name,
             "node_name": node_name,
         }
+
+        # Include container termination details when job has failed
+        if status == "failed" and pod_list.items:
+            termination_reasons = []
+            pod = pod_list.items[0]
+            for cs in pod.status.container_statuses or []:
+                terminated = getattr(cs.state, "terminated", None)
+                if terminated:
+                    termination_reasons.append(
+                        {
+                            "container": cs.name,
+                            "exit_code": terminated.exit_code,
+                            "reason": terminated.reason or "",
+                        }
+                    )
+            result["termination_reasons"] = termination_reasons
+
+        return result
 
     async def _k8s_list_jobs(self, filters: dict | None = None) -> list[dict]:
         """List K8s Jobs in the pipeline namespace."""

--- a/backend/app/models/pipeline_run.py
+++ b/backend/app/models/pipeline_run.py
@@ -26,6 +26,7 @@ class PipelineRun(Base):
     status: Mapped[str] = mapped_column(String(50), nullable=False, default="pending")
     cost_estimate: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(String(50), nullable=True)
     work_dir: Mapped[str | None] = mapped_column(String(500), nullable=True)
     slurm_job_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
     k8s_job_name: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/app/schemas/pipeline_run.py
+++ b/backend/app/schemas/pipeline_run.py
@@ -70,6 +70,7 @@ class PipelineRunResponse(BaseModel):
     progress: PipelineProgress | None = None
     cost_estimate: float | None = None
     error_message: str | None = None
+    failure_reason: str | None = None
     work_dir: str | None = None
     slurm_job_id: str | None = None
     k8s_job_name: str | None = None

--- a/backend/app/services/event_types.py
+++ b/backend/app/services/event_types.py
@@ -5,6 +5,7 @@ PIPELINE_STARTED = "pipeline.started"
 PIPELINE_COMPLETED = "pipeline.completed"
 PIPELINE_FAILED = "pipeline.failed"
 PIPELINE_STAGE_ERROR = "pipeline.stage_error"
+PIPELINE_OOM = "pipeline.oom"
 PIPELINE_RUN_REVIEWED = "pipeline_run.reviewed"
 PIPELINE_RUN_REVIEW_REMINDER = "pipeline_run.review_reminder"
 
@@ -93,6 +94,7 @@ ALL_EVENT_TYPES = [
     PIPELINE_COMPLETED,
     PIPELINE_FAILED,
     PIPELINE_STAGE_ERROR,
+    PIPELINE_OOM,
     QC_RESULTS_READY,
     EXPERIMENT_STATUS_CHANGED,
     BUDGET_THRESHOLD_50,
@@ -143,6 +145,7 @@ EVENT_SEVERITY = {
     PIPELINE_COMPLETED: "info",
     PIPELINE_FAILED: "critical",
     PIPELINE_STAGE_ERROR: "warning",
+    PIPELINE_OOM: "critical",
     QC_RESULTS_READY: "info",
     EXPERIMENT_STATUS_CHANGED: "info",
     BUDGET_THRESHOLD_50: "info",

--- a/backend/app/services/pipeline_monitor_service.py
+++ b/backend/app/services/pipeline_monitor_service.py
@@ -14,7 +14,7 @@ from app.models.pipeline_process import PipelineProcess
 from app.models.pipeline_run import PipelineRun
 from app.services.audit_service import log_action
 from app.services.event_bus import event_bus
-from app.services.event_types import PIPELINE_COMPLETED, PIPELINE_FAILED
+from app.services.event_types import PIPELINE_COMPLETED, PIPELINE_FAILED, PIPELINE_OOM
 from app.adapters.registry import get_compute_adapter, get_storage_adapter
 
 if TYPE_CHECKING:
@@ -180,7 +180,104 @@ class PipelineMonitorService:
             except Exception:
                 run.error_message = "Job failed (could not retrieve logs)"
 
+            # Classify failure reason from K8s termination info and trace data
+            await PipelineMonitorService._classify_failure(session, run, status_result)
+
             await PipelineMonitorService._handle_completion(session, run)
+
+    @staticmethod
+    async def _classify_failure(session: AsyncSession, run: PipelineRun, status_result: dict) -> None:
+        """Set failure_reason based on K8s termination info and trace data.
+
+        Priority:
+        1. OOMKilled in container termination reasons -> 'oom'
+        2. Preemption exit codes (143/137/247) in failed processes -> 'preemption_exhausted'
+        3. Otherwise -> 'task_error'
+        """
+        PREEMPTION_EXIT_CODES = {143, 137, 247}
+
+        termination_reasons = status_result.get("termination_reasons", [])
+        oom_detected = any(r.get("reason") == "OOMKilled" for r in termination_reasons)
+
+        if oom_detected:
+            machine_type = await PipelineMonitorService._get_pipeline_machine_type(session)
+            run.failure_reason = "oom"
+            run.error_message = (
+                f"Pipeline failed: out of memory. The pipeline's memory requirements "
+                f"exceeded the capacity of the current node size ({machine_type}). "
+                f"Go to Infrastructure > Components and select a larger pipeline machine size, "
+                f"then re-run the pipeline."
+            )
+
+            # Emit OOM event for notifications
+            import asyncio
+
+            experiment_name = ""
+            if run.experiment_id:
+                from app.models.experiment import Experiment
+
+                exp_result = await session.execute(select(Experiment.name).where(Experiment.id == run.experiment_id))
+                experiment_name = exp_result.scalar_one_or_none() or ""
+
+            asyncio.create_task(
+                event_bus.emit(
+                    PIPELINE_OOM,
+                    {
+                        "event_type": PIPELINE_OOM,
+                        "org_id": run.organization_id,
+                        "user_id": run.submitted_by_user_id,
+                        "target_user_id": run.submitted_by_user_id,
+                        "entity_type": "pipeline_run",
+                        "entity_id": run.id,
+                        "run_id": run.id,
+                        "pipeline_name": run.pipeline_name,
+                        "experiment_name": experiment_name,
+                        "machine_type": machine_type,
+                        "title": "Pipeline failed: out of memory",
+                        "message": (
+                            f"{run.pipeline_name} on experiment {experiment_name} failed because "
+                            f"a process exceeded the memory capacity of the current node size "
+                            f"({machine_type})."
+                        ),
+                        "severity": "critical",
+                        "summary": (f"Pipeline '{run.pipeline_name}' run {run.id} failed: out of memory"),
+                    },
+                )
+            )
+            return
+
+        # Check process records for preemption exit codes.
+        # Query the session directly since _populate_progress may have added
+        # new PipelineProcess records that aren't in the relationship yet.
+        proc_result = await session.execute(
+            select(PipelineProcess).where(
+                PipelineProcess.pipeline_run_id == run.id,
+                PipelineProcess.status == "failed",
+            )
+        )
+        failed_processes = list(proc_result.scalars().all())
+        preemption_detected = any(p.exit_code in PREEMPTION_EXIT_CODES for p in failed_processes)
+
+        if preemption_detected:
+            run.failure_reason = "preemption_exhausted"
+            run.error_message = (
+                "Pipeline failed after repeated interruptions from Spot instance "
+                "reclamation. This can happen during periods of high cloud demand. "
+                "Re-run the pipeline to try again, or disable Spot instances in "
+                "Infrastructure > Components for guaranteed availability."
+            )
+            return
+
+        run.failure_reason = "task_error"
+
+    @staticmethod
+    async def _get_pipeline_machine_type(session: AsyncSession) -> str:
+        """Read the pipeline machine type from platform_config."""
+        result = await session.execute(
+            text("SELECT value FROM platform_config WHERE key = 'k8s_pipeline_machine_type'")
+        )
+        row = result.first()
+        return row[0] if row else "unknown"
 
     @staticmethod
     async def _populate_progress(
@@ -229,6 +326,9 @@ class PipelineMonitorService:
                 session.add(proc)
 
             proc.status = status
+            exit_val = proc_data.get("exit_code")
+            if exit_val is not None:
+                proc.exit_code = exit_val
             cpu_val = proc_data.get("cpu")
             if cpu_val is not None:
                 proc.cpu_usage = cpu_val

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.7.2"
+version = "0.7.3"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_pipeline_monitor_oom.py
+++ b/backend/tests/test_pipeline_monitor_oom.py
@@ -1,0 +1,168 @@
+"""Tests for OOM detection in the pipeline monitor.
+
+When a K8s job fails and a container's terminated reason is OOMKilled,
+the monitor should set failure_reason='oom', write a specific error
+message, and emit a PIPELINE_OOM event.
+"""
+
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from app.models.pipeline_run import PipelineRun
+from app.services.pipeline_monitor_service import PipelineMonitorService
+
+
+@pytest_asyncio.fixture
+async def k8s_failed_oom_run(session, admin_user):
+    """Pipeline run whose K8s job will report OOMKilled termination."""
+    from app.models.experiment import Experiment
+
+    exp = Experiment(
+        organization_id=admin_user.organization_id,
+        name="OOM Test Experiment",
+        owner_user_id=admin_user.id,
+        status="processing",
+    )
+    session.add(exp)
+    await session.flush()
+
+    run = PipelineRun(
+        organization_id=admin_user.organization_id,
+        experiment_id=exp.id,
+        submitted_by_user_id=admin_user.id,
+        pipeline_name="nf-core/scrnaseq",
+        pipeline_version="2.7.1",
+        status="running",
+        k8s_job_name="bioaf-pipeline-oom-1",
+        k8s_namespace="bioaf-pipelines",
+        started_at=datetime.now(timezone.utc),
+    )
+    session.add(run)
+    await session.flush()
+    await session.commit()
+    return run
+
+
+@pytest.mark.asyncio
+async def test_oom_detection_sets_failure_reason(session, k8s_failed_oom_run):
+    """When K8s reports OOMKilled, failure_reason should be 'oom'."""
+    mock_compute = AsyncMock()
+    mock_compute.get_job_status.return_value = {
+        "status": "failed",
+        "pod_name": "bioaf-pipeline-oom-1-abc",
+        "node_name": "gke-node-1",
+        "termination_reasons": [
+            {
+                "container": "pipeline",
+                "exit_code": 137,
+                "reason": "OOMKilled",
+            }
+        ],
+    }
+    mock_compute.get_job_progress.return_value = {"percent_complete": 0.0, "processes": []}
+    mock_compute.get_job_logs.return_value = "STAR genome generate failed"
+
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = []
+
+    with (
+        patch("app.services.pipeline_monitor_service.get_compute_adapter", return_value=mock_compute),
+        patch("app.services.pipeline_monitor_service.get_storage_adapter", return_value=mock_storage),
+        patch("app.services.experiment_service.ExperimentService.update_status", new_callable=AsyncMock),
+    ):
+        await PipelineMonitorService.sync_run_statuses(session)
+
+    from sqlalchemy import select
+
+    result = await session.execute(select(PipelineRun).where(PipelineRun.id == k8s_failed_oom_run.id))
+    run = result.scalar_one()
+
+    assert run.status == "failed"
+    assert run.failure_reason == "oom"
+    assert "out of memory" in run.error_message.lower()
+    assert "Infrastructure" in run.error_message
+
+
+@pytest.mark.asyncio
+async def test_oom_detection_emits_pipeline_oom_event(session, k8s_failed_oom_run):
+    """OOM failure should emit a PIPELINE_OOM event through the event bus."""
+    mock_compute = AsyncMock()
+    mock_compute.get_job_status.return_value = {
+        "status": "failed",
+        "pod_name": "bioaf-pipeline-oom-1-abc",
+        "node_name": "gke-node-1",
+        "termination_reasons": [
+            {
+                "container": "pipeline",
+                "exit_code": 137,
+                "reason": "OOMKilled",
+            }
+        ],
+    }
+    mock_compute.get_job_progress.return_value = {"percent_complete": 0.0, "processes": []}
+    mock_compute.get_job_logs.return_value = "OOM killed"
+
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = []
+
+    emitted_events = []
+
+    async def capture_emit(event_type, payload):
+        emitted_events.append((event_type, payload))
+
+    with (
+        patch("app.services.pipeline_monitor_service.get_compute_adapter", return_value=mock_compute),
+        patch("app.services.pipeline_monitor_service.get_storage_adapter", return_value=mock_storage),
+        patch("app.services.experiment_service.ExperimentService.update_status", new_callable=AsyncMock),
+        patch("app.services.pipeline_monitor_service.event_bus.emit", side_effect=capture_emit),
+    ):
+        await PipelineMonitorService.sync_run_statuses(session)
+
+    from app.services.event_types import PIPELINE_OOM
+
+    oom_events = [(t, p) for t, p in emitted_events if t == PIPELINE_OOM]
+    assert len(oom_events) == 1
+    payload = oom_events[0][1]
+    assert payload["run_id"] == k8s_failed_oom_run.id
+    assert payload["pipeline_name"] == "nf-core/scrnaseq"
+    assert "severity" in payload
+
+
+@pytest.mark.asyncio
+async def test_non_oom_failure_does_not_set_oom_reason(session, k8s_failed_oom_run):
+    """A regular task failure (no OOMKilled) should not set failure_reason='oom'."""
+    mock_compute = AsyncMock()
+    mock_compute.get_job_status.return_value = {
+        "status": "failed",
+        "pod_name": "bioaf-pipeline-oom-1-abc",
+        "node_name": "gke-node-1",
+        "termination_reasons": [
+            {
+                "container": "pipeline",
+                "exit_code": 1,
+                "reason": "Error",
+            }
+        ],
+    }
+    mock_compute.get_job_progress.return_value = {"percent_complete": 0.0, "processes": []}
+    mock_compute.get_job_logs.return_value = "Process exited with error"
+
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = []
+
+    with (
+        patch("app.services.pipeline_monitor_service.get_compute_adapter", return_value=mock_compute),
+        patch("app.services.pipeline_monitor_service.get_storage_adapter", return_value=mock_storage),
+        patch("app.services.experiment_service.ExperimentService.update_status", new_callable=AsyncMock),
+    ):
+        await PipelineMonitorService.sync_run_statuses(session)
+
+    from sqlalchemy import select
+
+    result = await session.execute(select(PipelineRun).where(PipelineRun.id == k8s_failed_oom_run.id))
+    run = result.scalar_one()
+
+    assert run.status == "failed"
+    assert run.failure_reason == "task_error"

--- a/backend/tests/test_pipeline_monitor_preemption.py
+++ b/backend/tests/test_pipeline_monitor_preemption.py
@@ -1,0 +1,183 @@
+"""Tests for preemption exhaustion detection in the pipeline monitor.
+
+When a pipeline fails and the Nextflow trace shows processes with exit
+codes 143/137/247 that have FAILED status, the monitor should set
+failure_reason='preemption_exhausted' with a specific error message.
+"""
+
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from app.models.pipeline_run import PipelineRun
+from app.services.pipeline_monitor_service import PipelineMonitorService
+
+
+TRACE_WITH_PREEMPTION = (
+    "task_id\thash\tnative_id\tprocess\ttag\tname\tstatus\texit\t"
+    "submit\tstart\tcomplete\tduration\trealtime\t%cpu\tpeak_rss\tpeak_vmem\trchar\twchar\n"
+    "1\tab/123456\t100\tSTAR_GENOMEGENERATE\t-\tSTAR_GENOMEGENERATE (GRCh38)\tFAILED\t143\t"
+    "2026-01-01 00:00\t2026-01-01 00:01\t2026-01-01 00:15\t15m\t14m\t85.2\t4.5 GB\t8.1 GB\t100\t200\n"
+    "2\tcd/789012\t101\tFASTQC\t-\tFASTQC (SAMPLE_1)\tCOMPLETED\t0\t"
+    "2026-01-01 00:00\t2026-01-01 00:01\t2026-01-01 00:05\t5m\t4m\t20.5\t500 MB\t1.2 GB\t50\t10\n"
+)
+
+TRACE_WITH_OOM_EXIT = (
+    "task_id\thash\tnative_id\tprocess\ttag\tname\tstatus\texit\t"
+    "submit\tstart\tcomplete\tduration\trealtime\t%cpu\tpeak_rss\tpeak_vmem\trchar\twchar\n"
+    "1\tab/123456\t100\tSTAR_GENOMEGENERATE\t-\tSTAR_GENOMEGENERATE (GRCh38)\tFAILED\t137\t"
+    "2026-01-01 00:00\t2026-01-01 00:01\t2026-01-01 00:15\t15m\t14m\t85.2\t4.5 GB\t8.1 GB\t100\t200\n"
+)
+
+TRACE_WITH_NORMAL_FAILURE = (
+    "task_id\thash\tnative_id\tprocess\ttag\tname\tstatus\texit\t"
+    "submit\tstart\tcomplete\tduration\trealtime\t%cpu\tpeak_rss\tpeak_vmem\trchar\twchar\n"
+    "1\tab/123456\t100\tSTAR_GENOMEGENERATE\t-\tSTAR_GENOMEGENERATE (GRCh38)\tFAILED\t1\t"
+    "2026-01-01 00:00\t2026-01-01 00:01\t2026-01-01 00:15\t15m\t14m\t85.2\t4.5 GB\t8.1 GB\t100\t200\n"
+)
+
+
+@pytest_asyncio.fixture
+async def k8s_failed_preemption_run(session, admin_user):
+    """Pipeline run that failed after Spot preemption exhausted retries."""
+    from app.models.experiment import Experiment
+
+    exp = Experiment(
+        organization_id=admin_user.organization_id,
+        name="Preemption Test Experiment",
+        owner_user_id=admin_user.id,
+        status="processing",
+    )
+    session.add(exp)
+    await session.flush()
+
+    run = PipelineRun(
+        organization_id=admin_user.organization_id,
+        experiment_id=exp.id,
+        submitted_by_user_id=admin_user.id,
+        pipeline_name="nf-core/scrnaseq",
+        pipeline_version="2.7.1",
+        status="running",
+        k8s_job_name="bioaf-pipeline-preempt-1",
+        k8s_namespace="bioaf-pipelines",
+        started_at=datetime.now(timezone.utc),
+    )
+    session.add(run)
+    await session.flush()
+    await session.commit()
+    return run
+
+
+def _make_mock_compute(termination_reasons=None, trace_content=""):
+    """Build a mock compute adapter returning the given K8s status and trace."""
+    mock = AsyncMock()
+    status = {
+        "status": "failed",
+        "pod_name": "bioaf-pipeline-preempt-1-xyz",
+        "node_name": "gke-node-1",
+        "termination_reasons": termination_reasons or [],
+    }
+    mock.get_job_status.return_value = status
+    mock.get_job_progress.return_value = {"percent_complete": 0.0, "processes": []}
+    mock.get_job_logs.return_value = trace_content or "Pipeline failed"
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_preemption_exhaustion_detected_from_trace(session, k8s_failed_preemption_run):
+    """Exit 143 with FAILED status in trace -> failure_reason='preemption_exhausted'."""
+    mock_compute = _make_mock_compute(
+        termination_reasons=[{"container": "pipeline", "exit_code": 143, "reason": "Error"}],
+    )
+    # The monitor reads the trace from get_job_progress processes or parses trace.tsv.
+    # For the preemption path, OOM is checked first (no OOMKilled), then trace is checked.
+    # We simulate the trace being available via the progress adapter.
+    mock_compute.get_job_progress.return_value = {
+        "percent_complete": 0.0,
+        "processes": [
+            {"name": "STAR_GENOMEGENERATE", "status": "failed", "exit_code": 143},
+            {"name": "FASTQC", "status": "completed"},
+        ],
+    }
+
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = []
+
+    with (
+        patch("app.services.pipeline_monitor_service.get_compute_adapter", return_value=mock_compute),
+        patch("app.services.pipeline_monitor_service.get_storage_adapter", return_value=mock_storage),
+        patch("app.services.experiment_service.ExperimentService.update_status", new_callable=AsyncMock),
+    ):
+        await PipelineMonitorService.sync_run_statuses(session)
+
+    from sqlalchemy import select
+
+    result = await session.execute(select(PipelineRun).where(PipelineRun.id == k8s_failed_preemption_run.id))
+    run = result.scalar_one()
+
+    assert run.status == "failed"
+    assert run.failure_reason == "preemption_exhausted"
+    assert "Spot" in run.error_message or "interruption" in run.error_message.lower()
+
+
+@pytest.mark.asyncio
+async def test_preemption_exit_137_detected(session, k8s_failed_preemption_run):
+    """Exit 137 with FAILED status (non-OOMKilled K8s reason) -> preemption_exhausted."""
+    mock_compute = _make_mock_compute(
+        termination_reasons=[{"container": "pipeline", "exit_code": 137, "reason": "Error"}],
+    )
+    mock_compute.get_job_progress.return_value = {
+        "percent_complete": 0.0,
+        "processes": [
+            {"name": "STAR_GENOMEGENERATE", "status": "failed", "exit_code": 137},
+        ],
+    }
+
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = []
+
+    with (
+        patch("app.services.pipeline_monitor_service.get_compute_adapter", return_value=mock_compute),
+        patch("app.services.pipeline_monitor_service.get_storage_adapter", return_value=mock_storage),
+        patch("app.services.experiment_service.ExperimentService.update_status", new_callable=AsyncMock),
+    ):
+        await PipelineMonitorService.sync_run_statuses(session)
+
+    from sqlalchemy import select
+
+    result = await session.execute(select(PipelineRun).where(PipelineRun.id == k8s_failed_preemption_run.id))
+    run = result.scalar_one()
+
+    assert run.failure_reason == "preemption_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_normal_failure_sets_task_error(session, k8s_failed_preemption_run):
+    """A failure with exit code 1 (not preemption) -> failure_reason='task_error'."""
+    mock_compute = _make_mock_compute(
+        termination_reasons=[{"container": "pipeline", "exit_code": 1, "reason": "Error"}],
+    )
+    mock_compute.get_job_progress.return_value = {
+        "percent_complete": 0.0,
+        "processes": [
+            {"name": "STAR_GENOMEGENERATE", "status": "failed", "exit_code": 1},
+        ],
+    }
+
+    mock_storage = AsyncMock()
+    mock_storage.collect_outputs.return_value = []
+
+    with (
+        patch("app.services.pipeline_monitor_service.get_compute_adapter", return_value=mock_compute),
+        patch("app.services.pipeline_monitor_service.get_storage_adapter", return_value=mock_storage),
+        patch("app.services.experiment_service.ExperimentService.update_status", new_callable=AsyncMock),
+    ):
+        await PipelineMonitorService.sync_run_statuses(session)
+
+    from sqlalchemy import select
+
+    result = await session.execute(select(PipelineRun).where(PipelineRun.id == k8s_failed_preemption_run.id))
+    run = result.scalar_one()
+
+    assert run.failure_reason == "task_error"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/infrastructure/components/page.tsx
+++ b/frontend/src/app/infrastructure/components/page.tsx
@@ -142,6 +142,7 @@ export default function InfraComponentsPage() {
   const [destroyStorageChecked, setDestroyStorageChecked] = useState(false);
   const [destroyStoragePhrase, setDestroyStoragePhrase] = useState("");
   const [showConfigPanel, setShowConfigPanel] = useState(false);
+  const [showSpotTooltip, setShowSpotTooltip] = useState(false);
   const [configEdits, setConfigEdits] = useState<Partial<ClusterConfig>>({});
   const [configSaving, setConfigSaving] = useState(false);
   const [configError, setConfigError] = useState("");
@@ -735,83 +736,113 @@ export default function InfraComponentsPage() {
                         </div>
                       )}
 
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <label className="text-xs text-gray-500">Pipeline Machine Size</label>
-                          <select
-                            value={configEdits.k8s_pipeline_machine_type ?? clusterConfig.k8s_pipeline_machine_type}
-                            onChange={(e) => setConfigEdits({ ...configEdits, k8s_pipeline_machine_type: e.target.value })}
-                            className="w-full border rounded px-2 py-1 text-sm mt-1 bg-white"
-                            disabled={configSaving}
-                          >
-                            {PIPELINE_MACHINE_OPTIONS.map((opt) => (
-                              <option key={opt.value} value={opt.value}>
-                                {opt.label} - {opt.description}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div>
-                          <label className="text-xs text-gray-500">Pipeline Max Nodes</label>
-                          <input
-                            type="number"
-                            value={configEdits.k8s_pipeline_max_nodes ?? clusterConfig.k8s_pipeline_max_nodes}
-                            onChange={(e) => setConfigEdits({ ...configEdits, k8s_pipeline_max_nodes: Number(e.target.value) })}
-                            className="w-full border rounded px-2 py-1 text-sm mt-1"
-                            disabled={configSaving}
-                          />
-                        </div>
-                        <div className="flex items-center gap-2 pt-5">
-                          <label className="text-xs text-gray-500">Pipeline Spot Instances</label>
-                          <button
-                            type="button"
-                            disabled={configSaving}
-                            onClick={() => {
-                              const current = configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot;
-                              setConfigEdits({ ...configEdits, k8s_pipeline_use_spot: !current });
-                            }}
-                            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-                              (configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot)
-                                ? "bg-blue-600"
-                                : "bg-gray-300"
-                            }`}
-                          >
-                            <span
-                              className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
-                                (configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot)
-                                  ? "translate-x-4.5"
-                                  : "translate-x-0.5"
-                              }`}
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        {/* Pipeline Nodes column */}
+                        <div className="space-y-3">
+                          <h5 className="text-sm font-medium text-gray-700">Pipeline Nodes</h5>
+                          <div>
+                            <label className="text-xs text-gray-500">Machine Size</label>
+                            <select
+                              value={configEdits.k8s_pipeline_machine_type ?? clusterConfig.k8s_pipeline_machine_type}
+                              onChange={(e) => setConfigEdits({ ...configEdits, k8s_pipeline_machine_type: e.target.value })}
+                              className="w-full border rounded px-2 py-1 text-sm mt-1 bg-white"
+                              disabled={configSaving}
+                            >
+                              {PIPELINE_MACHINE_OPTIONS.map((opt) => (
+                                <option key={opt.value} value={opt.value}>
+                                  {opt.label} - {opt.description}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div>
+                            <label className="text-xs text-gray-500">Max Nodes</label>
+                            <input
+                              type="number"
+                              value={configEdits.k8s_pipeline_max_nodes ?? clusterConfig.k8s_pipeline_max_nodes}
+                              onChange={(e) => setConfigEdits({ ...configEdits, k8s_pipeline_max_nodes: Number(e.target.value) })}
+                              className="w-full border rounded px-2 py-1 text-sm mt-1"
+                              disabled={configSaving}
                             />
-                          </button>
-                          <span className="text-xs text-gray-600">
-                            {(configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot) ? "On" : "Off"}
-                          </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <label className="text-xs text-gray-500">Spot Instances</label>
+                            <div className="relative">
+                              <button
+                                type="button"
+                                onClick={() => setShowSpotTooltip(!showSpotTooltip)}
+                                className="inline-flex items-center justify-center w-4 h-4 rounded-full border border-gray-400 text-gray-400 text-[10px] leading-none hover:border-gray-600 hover:text-gray-600"
+                              >
+                                i
+                              </button>
+                              {showSpotTooltip && (
+                                <div className="absolute left-6 top-1/2 -translate-y-1/2 z-10 w-72 p-3 bg-gray-800 text-white text-xs rounded-lg shadow-lg">
+                                  Spot instances cost 60-70% less than standard VMs but can be reclaimed by Google Cloud with 30 seconds notice. bioAF automatically retries interrupted pipeline tasks without re-requesting additional resources. Recommended for most workloads. Disable only if your pipelines cannot tolerate any interruption.
+                                  <button
+                                    type="button"
+                                    onClick={(e) => { e.stopPropagation(); setShowSpotTooltip(false); }}
+                                    className="absolute top-1 right-2 text-gray-400 hover:text-white"
+                                  >
+                                    x
+                                  </button>
+                                </div>
+                              )}
+                            </div>
+                            <button
+                              type="button"
+                              disabled={configSaving}
+                              onClick={() => {
+                                const current = configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot;
+                                setConfigEdits({ ...configEdits, k8s_pipeline_use_spot: !current });
+                              }}
+                              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                                (configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot)
+                                  ? "bg-blue-600"
+                                  : "bg-gray-300"
+                              }`}
+                            >
+                              <span
+                                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                                  (configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot)
+                                    ? "translate-x-4.5"
+                                    : "translate-x-0.5"
+                                }`}
+                              />
+                            </button>
+                            <span className="text-xs text-gray-600">
+                              {(configEdits.k8s_pipeline_use_spot ?? clusterConfig.k8s_pipeline_use_spot) ? "On" : "Off"}
+                            </span>
+                          </div>
                         </div>
-                        <div>
-                          <label className="text-xs text-gray-500">Interactive Machine Size</label>
-                          <select
-                            value={configEdits.k8s_interactive_machine_type ?? clusterConfig.k8s_interactive_machine_type}
-                            onChange={(e) => setConfigEdits({ ...configEdits, k8s_interactive_machine_type: e.target.value })}
-                            className="w-full border rounded px-2 py-1 text-sm mt-1 bg-white"
-                            disabled={configSaving}
-                          >
-                            {INTERACTIVE_MACHINE_OPTIONS.map((opt) => (
-                              <option key={opt.value} value={opt.value}>
-                                {opt.label} - {opt.description}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div>
-                          <label className="text-xs text-gray-500">Interactive Max Nodes</label>
-                          <input
-                            type="number"
-                            value={configEdits.k8s_interactive_max_nodes ?? clusterConfig.k8s_interactive_max_nodes}
-                            onChange={(e) => setConfigEdits({ ...configEdits, k8s_interactive_max_nodes: Number(e.target.value) })}
-                            className="w-full border rounded px-2 py-1 text-sm mt-1"
-                            disabled={configSaving}
-                          />
+
+                        {/* Interactive Nodes column */}
+                        <div className="space-y-3">
+                          <h5 className="text-sm font-medium text-gray-700">Interactive Nodes</h5>
+                          <div>
+                            <label className="text-xs text-gray-500">Machine Size</label>
+                            <select
+                              value={configEdits.k8s_interactive_machine_type ?? clusterConfig.k8s_interactive_machine_type}
+                              onChange={(e) => setConfigEdits({ ...configEdits, k8s_interactive_machine_type: e.target.value })}
+                              className="w-full border rounded px-2 py-1 text-sm mt-1 bg-white"
+                              disabled={configSaving}
+                            >
+                              {INTERACTIVE_MACHINE_OPTIONS.map((opt) => (
+                                <option key={opt.value} value={opt.value}>
+                                  {opt.label} - {opt.description}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div>
+                            <label className="text-xs text-gray-500">Max Nodes</label>
+                            <input
+                              type="number"
+                              value={configEdits.k8s_interactive_max_nodes ?? clusterConfig.k8s_interactive_max_nodes}
+                              onChange={(e) => setConfigEdits({ ...configEdits, k8s_interactive_max_nodes: Number(e.target.value) })}
+                              className="w-full border rounded px-2 py-1 text-sm mt-1"
+                              disabled={configSaving}
+                            />
+                          </div>
                         </div>
                       </div>
                       <div className="flex gap-2 mt-4">

--- a/frontend/src/app/pipelines/runs/[id]/page.tsx
+++ b/frontend/src/app/pipelines/runs/[id]/page.tsx
@@ -227,7 +227,44 @@ export default function PipelineRunDetailPage() {
                   {run.progress.completed + run.progress.cached}/{run.progress.total_processes} processes
                 </span>
               </div>
-              {run.error_message && <p className="text-sm text-red-600 mt-2">{run.error_message}</p>}
+              {run.failure_reason === "oom" && (
+                <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-3">
+                  <span className="text-amber-600 text-lg" title="Memory">&#x1F4BE;</span>
+                  <div className="flex-1">
+                    <p className="text-sm text-amber-800 font-medium">This pipeline ran out of memory.</p>
+                    <p className="text-sm text-amber-700 mt-1">The current pipeline node size does not have enough RAM for this workload.</p>
+                    <button
+                      onClick={() => router.push("/infrastructure/components")}
+                      className="mt-2 px-3 py-1 text-sm bg-amber-600 text-white rounded hover:bg-amber-700"
+                    >
+                      Update node size
+                    </button>
+                  </div>
+                </div>
+              )}
+              {run.failure_reason === "preemption_exhausted" && (
+                <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                  <p className="text-sm text-blue-800 font-medium">This pipeline was interrupted multiple times by Spot instance reclamation.</p>
+                  <p className="text-sm text-blue-700 mt-1">This is unusual and typically resolves on its own.</p>
+                  <div className="flex gap-2 mt-2">
+                    <button
+                      onClick={handleReproduce}
+                      className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+                    >
+                      Re-run pipeline
+                    </button>
+                    <button
+                      onClick={() => router.push("/infrastructure/components")}
+                      className="px-3 py-1 text-sm border border-blue-300 text-blue-700 rounded hover:bg-blue-50"
+                    >
+                      Disable Spot instances
+                    </button>
+                  </div>
+                </div>
+              )}
+              {run.error_message && run.failure_reason !== "oom" && run.failure_reason !== "preemption_exhausted" && (
+                <p className="text-sm text-red-600 mt-2">{run.error_message}</p>
+              )}
             </div>
           )}
 

--- a/frontend/src/app/pipelines/runs/page.tsx
+++ b/frontend/src/app/pipelines/runs/page.tsx
@@ -127,6 +127,12 @@ export default function PipelineRunsPage() {
                     <td className="px-4 py-3 text-sm">{r.experiment?.name || "—"}</td>
                     <td className="px-4 py-3">
                       <span className={`px-2 py-0.5 text-xs rounded-full ${STATUS_COLORS[r.status]}`}>{r.status}</span>
+                      {r.status === "failed" && r.failure_reason === "oom" && (
+                        <span className="ml-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-orange-100 text-orange-700">OOM</span>
+                      )}
+                      {r.status === "failed" && r.failure_reason === "preemption_exhausted" && (
+                        <span className="ml-1 px-1.5 py-0.5 text-[10px] font-medium rounded bg-blue-100 text-blue-700">Preempted</span>
+                      )}
                     </td>
                     <td className="px-4 py-3">
                       {r.review_verdict ? <ReviewBadge verdict={r.review_verdict} /> : <span className="text-xs text-gray-400">—</span>}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -752,6 +752,7 @@ export interface PipelineRun {
   progress: PipelineProgress | null;
   cost_estimate: number | null;
   error_message: string | null;
+  failure_reason: "oom" | "preemption_exhausted" | "task_error" | null;
   work_dir: string | null;
   slurm_job_id: string | null;
   k8s_job_name: string | null;


### PR DESCRIPTION
## Summary

- Detect OOM-killed pipelines from K8s container termination reasons, classify as `failure_reason = "oom"` with actionable error message and PIPELINE_OOM event emission
- Detect Spot preemption exhaustion from failed process exit codes (143/137/247), classify as `failure_reason = "preemption_exhausted"`
- Reorganize cluster config panel into Pipeline Nodes / Interactive Nodes columns with Spot instance info tooltip
- Add failure reason banners (amber OOM, blue preemption) on pipeline run detail and badges on runs table
- Add nullable `failure_reason` column to `pipeline_runs` (migration 066)

Complements ADR-042 (Spot preemption-aware retry strategy) with UI and monitoring improvements.

## Test plan

- [x] Backend: 1796 passed (including 6 new OOM/preemption tests)
- [x] Frontend: 409 passed
- [x] TypeScript: 0 errors
- [x] Ruff format/check: clean
- [x] Mypy: clean
- [x] Verified on VM with live pipeline data -- migration 066 applies cleanly, existing runs display correctly