### PR TITLE
v0.7.4: Reboot countdown and re-attach during in-app update

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.7.4
+
+In-app update UX improvements.
+
+### Platform updates
+
+- Add a 60-second "restart warning" step between build and restart, giving users a visible countdown before the backend briefly goes offline during an update
+- Settings > Platform Info re-attaches to an in-progress update on page mount, so navigating away and back shows live status instead of an empty banner
+- Countdown duration is configurable via BIOAF_RESTART_WARN_SECONDS and skippable with BIOAF_SKIP_RESTART_WARN=1 for development
+
 ## v0.7.3
 
 OOM detection, preemption classification, and cluster configuration UX improvements.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.7.3"
+version = "0.7.4"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/bioaf
+++ b/bioaf
@@ -531,6 +531,17 @@ STATUSEOF
     bold "Rebuilding containers..."
     $DC_BUILD
 
+    # Warning window before restart: give the UI time to show a countdown
+    # so users know the app is about to go offline briefly. Skipped when
+    # BIOAF_SKIP_RESTART_WARN=1 (useful for tests and dev overrides).
+    local warn_seconds="${BIOAF_RESTART_WARN_SECONDS:-60}"
+    if [ "${BIOAF_SKIP_RESTART_WARN:-0}" != "1" ] && [ "$warn_seconds" -gt 0 ]; then
+        cat > "$status_dir/current.json" <<STATUSEOF
+{"status": "in_progress", "from_version": "$current_version", "to_version": "$target_version", "step": "warn", "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+STATUSEOF
+        sleep "$warn_seconds"
+    fi
+
     # Restart services
     cat > "$status_dir/current.json" <<STATUSEOF
 {"status": "in_progress", "from_version": "$current_version", "to_version": "$target_version", "step": "restart", "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/settings/info/page.tsx
+++ b/frontend/src/app/settings/info/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { usePermissions } from "@/hooks/usePermissions";
@@ -28,6 +28,7 @@ interface UpdateStatus {
   from_version?: string;
   to_version?: string;
   step?: string;
+  started_at?: string;
   error?: string;
 }
 
@@ -35,9 +36,12 @@ const STEP_LABELS: Record<string, string> = {
   backup: "Backing up database",
   checkout: "Fetching new version",
   build: "Rebuilding containers",
+  warn: "Preparing to restart",
   restart: "Restarting services",
   migrate: "Running database migrations",
 };
+
+const WARN_DURATION_SECONDS = 60;
 
 export default function SettingsInfoPage() {
   const { canAccess } = usePermissions();
@@ -47,6 +51,7 @@ export default function SettingsInfoPage() {
   const [updating, setUpdating] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [updateError, setUpdateError] = useState("");
+  const [now, setNow] = useState(() => Date.now());
   const pollRef = useRef<NodeJS.Timeout | null>(null);
 
   const canDeploy = canAccess("infrastructure", "deploy");
@@ -88,12 +93,21 @@ export default function SettingsInfoPage() {
   useEffect(() => {
     const load = async () => {
       try {
-        const [version, history] = await Promise.all([
+        const [version, history, status] = await Promise.all([
           api.get<UpdateCheck>("/api/upgrades/check"),
           api.get<{ upgrades: UpgradeHistoryItem[] }>("/api/upgrades/history"),
+          api.get<UpdateStatus>("/api/upgrades/status"),
         ]);
         setUpdateCheck(version);
         setUpgradeHistory(history.upgrades);
+
+        if (status.status === "in_progress") {
+          setUpdateStatus(status);
+          setUpdating(true);
+          if (!pollRef.current) {
+            pollRef.current = setInterval(pollUpdateStatus, 3000);
+          }
+        }
       } catch {
         // ignore
       }
@@ -105,7 +119,22 @@ export default function SettingsInfoPage() {
         clearInterval(pollRef.current);
       }
     };
-  }, []);
+  }, [pollUpdateStatus]);
+
+  // Tick once per second while showing the reboot countdown
+  useEffect(() => {
+    if (updateStatus?.step !== "warn") return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [updateStatus?.step]);
+
+  const rebootCountdown = useMemo(() => {
+    if (updateStatus?.step !== "warn" || !updateStatus.started_at) return null;
+    const started = new Date(updateStatus.started_at).getTime();
+    const elapsed = Math.floor((now - started) / 1000);
+    return Math.max(0, WARN_DURATION_SECONDS - elapsed);
+  }, [updateStatus?.step, updateStatus?.started_at, now]);
 
   const handleCheckUpdate = async () => {
     setCheckingUpdate(true);
@@ -191,7 +220,7 @@ export default function SettingsInfoPage() {
                     <div className="flex items-center gap-3 mb-2">
                       <div className="h-4 w-4 border-2 border-amber-600 border-t-transparent rounded-full animate-spin" />
                       <span className="text-sm font-medium text-amber-800">
-                        Updating to {updateCheck.latest_version}
+                        Updating to {updateStatus.to_version || updateCheck.latest_version}
                       </span>
                     </div>
                     {updateStatus.step && (
@@ -199,9 +228,15 @@ export default function SettingsInfoPage() {
                         {STEP_LABELS[updateStatus.step] || updateStatus.step}...
                       </p>
                     )}
-                    <p className="text-xs text-amber-600 ml-7 mt-1">
-                      The application will restart during this process.
-                    </p>
+                    {updateStatus.step === "warn" && rebootCountdown !== null ? (
+                      <p className="text-sm font-semibold text-amber-900 ml-7 mt-1">
+                        {`Restarting in ${rebootCountdown}s -- the application will be briefly unavailable.`}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-amber-600 ml-7 mt-1">
+                        The application will restart during this process.
+                      </p>
+                    )}
                   </div>
                 )}
 

--- a/frontend/tests/pages/settings-info.test.tsx
+++ b/frontend/tests/pages/settings-info.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, act, waitFor } from "@testing-library/react";
+import SettingsInfoPage from "@/app/settings/info/page";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/settings/info",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/hooks/usePermissions", () => ({
+  usePermissions: () => ({ canAccess: () => true }),
+}));
+
+jest.mock("@/components/layout/Sidebar", () => ({ Sidebar: () => <div /> }));
+jest.mock("@/components/layout/Header", () => ({ Header: () => <div /> }));
+
+const mockApiGet = jest.fn();
+const mockApiPost = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
+    post: (...args: unknown[]) => mockApiPost(...args),
+  },
+}));
+
+const versionCheck = {
+  current_version: "0.7.3",
+  latest_version: "0.7.4",
+  update_available: true,
+  changelog: null,
+  release_url: null,
+};
+
+const historyEmpty = { upgrades: [] };
+
+describe("Settings Info page -- update flow", () => {
+  beforeEach(() => {
+    mockApiGet.mockReset();
+    mockApiPost.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("re-attaches to an in-progress update when the page is mounted", async () => {
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === "/api/upgrades/check") return Promise.resolve(versionCheck);
+      if (url === "/api/upgrades/history") return Promise.resolve(historyEmpty);
+      if (url === "/api/upgrades/status") {
+        return Promise.resolve({
+          status: "in_progress",
+          step: "build",
+          to_version: "0.7.4",
+          started_at: new Date().toISOString(),
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    await act(async () => {
+      render(<SettingsInfoPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Updating to 0\.7\.4/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Rebuilding containers/i)).toBeInTheDocument();
+  });
+
+  it("shows a 60-second reboot countdown during the warn step", async () => {
+    jest.useFakeTimers({ doNotFake: ["nextTick"] });
+    const warnStartedAt = new Date("2026-04-15T12:00:00.000Z");
+    jest.setSystemTime(warnStartedAt);
+
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === "/api/upgrades/check") return Promise.resolve(versionCheck);
+      if (url === "/api/upgrades/history") return Promise.resolve(historyEmpty);
+      if (url === "/api/upgrades/status") {
+        return Promise.resolve({
+          status: "in_progress",
+          step: "warn",
+          to_version: "0.7.4",
+          started_at: warnStartedAt.toISOString(),
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    await act(async () => {
+      render(<SettingsInfoPage />);
+    });
+
+    // Let the initial load promises resolve
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/Restarting in 60s/)).toBeInTheDocument();
+
+    // Advance the clock by 15s; the 1s ticker should fire and update the countdown.
+    await act(async () => {
+      jest.advanceTimersByTime(15_000);
+    });
+    expect(screen.getByText(/Restarting in 45s/)).toBeInTheDocument();
+  });
+
+  it("does not attach polling when no update is in progress", async () => {
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === "/api/upgrades/check") return Promise.resolve(versionCheck);
+      if (url === "/api/upgrades/history") return Promise.resolve(historyEmpty);
+      if (url === "/api/upgrades/status") return Promise.resolve({ status: "idle" });
+      return Promise.resolve({});
+    });
+
+    await act(async () => {
+      render(<SettingsInfoPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Current Version:/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Updating to/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a 60-second warning step between `build` and `restart` in the update flow so users see a visible countdown before the backend briefly goes offline
- Re-attach to an in-progress update on Settings > Platform Info mount -- navigating away and back now shows live status instead of an empty banner
- Countdown is configurable via `BIOAF_RESTART_WARN_SECONDS` and skippable with `BIOAF_SKIP_RESTART_WARN=1` for development

Context: discovered while diagnosing that the in-app update wasn't running on `bioaf-test`. Root cause there was the `bioaf-update-agent` systemd service never being installed (install only runs during `./bioaf setup`, which predated the feature). During that investigation we also noticed two UX gaps -- the polling was tied to component lifecycle (lost on navigation away) and there was no way to know when the backend was about to restart. This PR addresses the UX gaps; the agent-install-on-update gap is a separate follow-up.

## Test plan

- [x] Unit tests added in `frontend/tests/pages/settings-info.test.tsx` (re-attach on mount, 60->45s countdown after 15s, no-op when idle)
- [x] All 1796 backend tests pass
- [x] All 412 frontend tests pass
- [x] ruff format, ruff check, mypy, tsc --noEmit, markdownlint all clean
- [ ] After merge and release: trigger an in-app update on a real host, confirm the amber banner shows step progression and a ticking "Restarting in Ns" during the new warn step
- [ ] Navigate away mid-update, return to Settings > Platform Info, confirm the banner re-appears with current step