### PR TITLE
v0.7.5: Fix Plot Archive thumbnails after content-token rework

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v0.7.5
+
+Plot Archive thumbnail bug fix.
+
+### Bug fixes
+
+- Restore Plot Archive previews that broke after the content-token JWT rework. Thumbnails rendered an empty `<img src="">` while the content token was still being fetched, which fired `onError` and latched the card into the "No preview available" fallback. The grid now shows a skeleton until the short-lived content URL is ready.
+
 ## v0.7.4
 
 In-app update UX improvements.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.7.4"
+version = "0.7.5"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/results/plot-archive/page.tsx
+++ b/frontend/src/app/results/plot-archive/page.tsx
@@ -62,6 +62,12 @@ function PlotThumbnail({
     );
   }
 
+  // Content-token fetch is still in flight. Don't render <img src=""> because
+  // that fires onError immediately and leaves us stuck in the error state.
+  if (!imgUrl) {
+    return <div className="w-full h-full bg-gray-100 animate-pulse" />;
+  }
+
   return (
     // eslint-disable-next-line @next/next/no-img-element
     <img


### PR DESCRIPTION
## Summary

- Plot Archive thumbnails broke after the v0.7.0 JWT/content-token rework. Each card rendered `<img src=\"\">` on first paint while the `/api/content-tokens` fetch was still in flight, which fired `onError` and latched the tile into the "No preview available" fallback permanently.
- Gate the `<img>` on a non-empty src and show a pulse skeleton until the short-lived content URL resolves. The expand modal was unaffected (it awaits the URL before mounting) and is untouched.
- Bump to v0.7.5.

## Test plan

- [ ] Open Results > Plot Archive; confirm thumbnails render for PNG and SVG plots instead of the "No preview available" placeholder
- [ ] Confirm clicking a tile still opens the full preview modal with metadata
- [ ] Confirm PDFs without generated thumbnails still show the "PDF / No preview available" tile (unchanged path)
- [ ] Confirm storage-deleted plots still show the red storage-deleted placeholder