### PR TITLE
v0.8.0: Library and BarcodeMap backend groundwork (#233)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,24 @@
 # Release Notes
 
+## v0.8.0
+
+Library and BarcodeMap data model groundwork. No user-visible changes in this release.
+
+This is a backend-only update that lays the foundation for a near-future release adding Library and Barcode support and mapping to the UI. Current installs will see no new screens, menus, or workflows.
+
+### Backend
+
+- New `Library` entity sitting between Sample and File, capturing prep metadata, indexing fields (i5 / i7, index type, orientation convention), QC snapshot at prep time, and lifecycle status
+- New `BarcodeMap` table covering both library-level sample indices and intra-library variant barcodes (cell barcodes, UMIs, sgRNAs, hashtags, lineage barcodes), with optional `whitelist_reference` for rule-based mappings against external reference sets
+- New nullable `files.library_id` foreign key so files can be attributed to a specific library. Existing sample-to-file links remain valid; library links are additive
+- New `libraries` resource in the permission model with `view` / `create` / `edit` / `delete` actions, wired into the built-in admin, comp_bio, bench, and viewer roles
+- New API surface: `POST/GET/PATCH /api/libraries`, `GET /api/samples/{id}/libraries`, `GET /api/experiments/{id}/libraries`, `POST /api/libraries/{id}/files/{file_id}`, `POST/GET /api/libraries/{id}/barcodes` (single and bulk), `GET /api/barcodes/lookup`, `GET /api/sequencing-batches/{id}/barcode-collisions`
+- Sequence canonicalisation (uppercase + ACGTN validation) applied at the service layer. Library index fields automatically materialise as `library_index` BarcodeMap rows for unified reverse lookup. Collision detection flags library pairs that share an (i5, i7) within the same sequencing batch
+
+### Database
+
+- Additive Alembic migration `067` adds the `libraries` and `barcode_maps` tables plus the nullable `files.library_id` column. No existing data is modified or backfilled
+
 ## v0.7.5
 
 Plot Archive thumbnail bug fix.

--- a/backend/alembic/versions/067_add_library_and_barcode_map.py
+++ b/backend/alembic/versions/067_add_library_and_barcode_map.py
@@ -88,12 +88,8 @@ def upgrade() -> None:
         ),
     )
     op.create_index("idx_libraries_sample_id", "libraries", ["sample_id"])
-    op.create_index(
-        "idx_libraries_sequencing_batch_id", "libraries", ["sequencing_batch_id"]
-    )
-    op.create_index(
-        "idx_libraries_i7_i5", "libraries", ["i7_sequence", "i5_sequence"]
-    )
+    op.create_index("idx_libraries_sequencing_batch_id", "libraries", ["sequencing_batch_id"])
+    op.create_index("idx_libraries_i7_i5", "libraries", ["i7_sequence", "i5_sequence"])
 
     op.create_table(
         "barcode_maps",
@@ -116,9 +112,7 @@ def upgrade() -> None:
         sa.Column("read_position", sa.String(length=8), nullable=True),
         sa.Column("offset_in_read", sa.Integer(), nullable=True),
         sa.Column("length", sa.Integer(), nullable=True),
-        sa.Column(
-            "allowed_mismatches", sa.Integer(), nullable=True, server_default="1"
-        ),
+        sa.Column("allowed_mismatches", sa.Integer(), nullable=True, server_default="1"),
         sa.Column("whitelist_reference", sa.String(length=255), nullable=True),
         sa.Column("attributes_json", postgresql.JSONB(), nullable=True),
         sa.Column(

--- a/backend/alembic/versions/067_add_library_and_barcode_map.py
+++ b/backend/alembic/versions/067_add_library_and_barcode_map.py
@@ -1,0 +1,170 @@
+"""Add Library and BarcodeMap tables plus File.library_id.
+
+Revision ID: 067
+Revises: 066
+Create Date: 2026-04-15
+
+Introduces the Library entity between Sample and File, the BarcodeMap
+table for library indices and intra-library barcodes, and a nullable
+File.library_id FK. All additive; no backfill.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "067"
+down_revision = "066"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "libraries",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column(
+            "organization_id",
+            sa.Integer(),
+            sa.ForeignKey("organizations.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "sample_id",
+            sa.Integer(),
+            sa.ForeignKey("samples.id"),
+            nullable=False,
+        ),
+        sa.Column("library_id_external", sa.String(length=255), nullable=True),
+        sa.Column("prep_kit", sa.String(length=200), nullable=True),
+        sa.Column("prep_protocol_version", sa.String(length=50), nullable=True),
+        sa.Column("prep_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("assay_type", sa.String(length=100), nullable=True),
+        sa.Column("molecule_type", sa.String(length=100), nullable=True),
+        sa.Column("strandedness", sa.String(length=50), nullable=True),
+        sa.Column("read_layout", sa.String(length=50), nullable=True),
+        sa.Column("target_read_length", sa.Integer(), nullable=True),
+        sa.Column(
+            "index_type",
+            sa.String(length=20),
+            nullable=False,
+            server_default="none",
+        ),
+        sa.Column("i5_sequence", sa.String(length=32), nullable=True),
+        sa.Column("i7_sequence", sa.String(length=32), nullable=True),
+        sa.Column("i5_orientation_convention", sa.String(length=50), nullable=True),
+        sa.Column("insert_size_mean", sa.Integer(), nullable=True),
+        sa.Column("molarity_nm", sa.Numeric(10, 3), nullable=True),
+        sa.Column("concentration_ng_ul", sa.Numeric(10, 3), nullable=True),
+        sa.Column("qc_status", sa.String(length=20), nullable=True),
+        sa.Column("qc_notes", sa.Text(), nullable=True),
+        sa.Column(
+            "sequencing_batch_id",
+            sa.Integer(),
+            sa.ForeignKey("sequencing_batches.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=50),
+            nullable=False,
+            server_default="planned",
+        ),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "organization_id",
+            "library_id_external",
+            name="uq_libraries_org_external_id",
+        ),
+    )
+    op.create_index("idx_libraries_sample_id", "libraries", ["sample_id"])
+    op.create_index(
+        "idx_libraries_sequencing_batch_id", "libraries", ["sequencing_batch_id"]
+    )
+    op.create_index(
+        "idx_libraries_i7_i5", "libraries", ["i7_sequence", "i5_sequence"]
+    )
+
+    op.create_table(
+        "barcode_maps",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column(
+            "organization_id",
+            sa.Integer(),
+            sa.ForeignKey("organizations.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_id",
+            sa.Integer(),
+            sa.ForeignKey("libraries.id"),
+            nullable=False,
+        ),
+        sa.Column("barcode_type", sa.String(length=30), nullable=False),
+        sa.Column("sequence", sa.String(length=64), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("read_position", sa.String(length=8), nullable=True),
+        sa.Column("offset_in_read", sa.Integer(), nullable=True),
+        sa.Column("length", sa.Integer(), nullable=True),
+        sa.Column(
+            "allowed_mismatches", sa.Integer(), nullable=True, server_default="1"
+        ),
+        sa.Column("whitelist_reference", sa.String(length=255), nullable=True),
+        sa.Column("attributes_json", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "library_id",
+            "barcode_type",
+            "sequence",
+            "read_position",
+            name="uq_barcode_maps_library_type_seq_pos",
+        ),
+    )
+    op.create_index("idx_barcode_maps_library_id", "barcode_maps", ["library_id"])
+    op.create_index("idx_barcode_maps_sequence", "barcode_maps", ["sequence"])
+    op.create_index(
+        "idx_barcode_maps_type_sequence",
+        "barcode_maps",
+        ["barcode_type", "sequence"],
+    )
+
+    op.add_column(
+        "files",
+        sa.Column(
+            "library_id",
+            sa.Integer(),
+            sa.ForeignKey("libraries.id"),
+            nullable=True,
+        ),
+    )
+    op.create_index("idx_files_library_id", "files", ["library_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_files_library_id", table_name="files")
+    op.drop_column("files", "library_id")
+
+    op.drop_index("idx_barcode_maps_type_sequence", table_name="barcode_maps")
+    op.drop_index("idx_barcode_maps_sequence", table_name="barcode_maps")
+    op.drop_index("idx_barcode_maps_library_id", table_name="barcode_maps")
+    op.drop_table("barcode_maps")
+
+    op.drop_index("idx_libraries_i7_i5", table_name="libraries")
+    op.drop_index("idx_libraries_sequencing_batch_id", table_name="libraries")
+    op.drop_index("idx_libraries_sample_id", table_name="libraries")
+    op.drop_table("libraries")

--- a/backend/app/api/barcode_maps.py
+++ b/backend/app/api/barcode_maps.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_permission
@@ -14,9 +14,7 @@ from app.services.barcode_service import BarcodeService
 router = APIRouter(tags=["barcode_maps"])
 
 
-@router.post(
-    "/api/libraries/{library_id}/barcodes", response_model=BarcodeMapResponse
-)
+@router.post("/api/libraries/{library_id}/barcodes", response_model=BarcodeMapResponse)
 async def create_barcode(
     library_id: int,
     body: BarcodeMapCreate,
@@ -40,16 +38,12 @@ async def bulk_create_barcodes(
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
-    rows = await BarcodeService.bulk_create_barcode_maps(
-        session, org_id, library_id, body
-    )
+    rows = await BarcodeService.bulk_create_barcode_maps(session, org_id, library_id, body)
     await session.commit()
     return [BarcodeMapResponse.model_validate(r) for r in rows]
 
 
-@router.get(
-    "/api/libraries/{library_id}/barcodes", response_model=list[BarcodeMapResponse]
-)
+@router.get("/api/libraries/{library_id}/barcodes", response_model=list[BarcodeMapResponse])
 async def list_barcodes(
     library_id: int,
     barcode_type: str | None = Query(default=None),
@@ -57,9 +51,7 @@ async def list_barcodes(
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
-    rows = await BarcodeService.list_barcode_maps_for_library(
-        session, org_id, library_id, barcode_type
-    )
+    rows = await BarcodeService.list_barcode_maps_for_library(session, org_id, library_id, barcode_type)
     return [BarcodeMapResponse.model_validate(r) for r in rows]
 
 

--- a/backend/app/api/barcode_maps.py
+++ b/backend/app/api/barcode_maps.py
@@ -1,0 +1,88 @@
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import require_permission
+from app.database import get_session
+from app.schemas.barcode_map import (
+    BarcodeCollisionEntry,
+    BarcodeMapBulkCreate,
+    BarcodeMapCreate,
+    BarcodeMapResponse,
+)
+from app.services.barcode_service import BarcodeService
+
+router = APIRouter(tags=["barcode_maps"])
+
+
+@router.post(
+    "/api/libraries/{library_id}/barcodes", response_model=BarcodeMapResponse
+)
+async def create_barcode(
+    library_id: int,
+    body: BarcodeMapCreate,
+    current_user: dict = require_permission("libraries", "edit"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    row = await BarcodeService.create_barcode_map(session, org_id, library_id, body)
+    await session.commit()
+    return BarcodeMapResponse.model_validate(row)
+
+
+@router.post(
+    "/api/libraries/{library_id}/barcodes/bulk",
+    response_model=list[BarcodeMapResponse],
+)
+async def bulk_create_barcodes(
+    library_id: int,
+    body: BarcodeMapBulkCreate,
+    current_user: dict = require_permission("libraries", "edit"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    rows = await BarcodeService.bulk_create_barcode_maps(
+        session, org_id, library_id, body
+    )
+    await session.commit()
+    return [BarcodeMapResponse.model_validate(r) for r in rows]
+
+
+@router.get(
+    "/api/libraries/{library_id}/barcodes", response_model=list[BarcodeMapResponse]
+)
+async def list_barcodes(
+    library_id: int,
+    barcode_type: str | None = Query(default=None),
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    rows = await BarcodeService.list_barcode_maps_for_library(
+        session, org_id, library_id, barcode_type
+    )
+    return [BarcodeMapResponse.model_validate(r) for r in rows]
+
+
+@router.get("/api/barcodes/lookup", response_model=list[BarcodeMapResponse])
+async def lookup_barcode(
+    sequence: str = Query(...),
+    barcode_type: str | None = Query(default=None),
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    rows = await BarcodeService.lookup_by_sequence(session, org_id, sequence, barcode_type)
+    return [BarcodeMapResponse.model_validate(r) for r in rows]
+
+
+@router.get(
+    "/api/sequencing-batches/{batch_id}/barcode-collisions",
+    response_model=list[BarcodeCollisionEntry],
+)
+async def list_batch_collisions(
+    batch_id: int,
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    return await BarcodeService.detect_collisions_in_batch(session, org_id, batch_id)

--- a/backend/app/api/libraries.py
+++ b/backend/app/api/libraries.py
@@ -1,0 +1,111 @@
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import require_permission
+from app.database import get_session
+from app.models.library import Library
+from app.schemas.library import LibraryCreate, LibraryResponse, LibraryUpdate
+from app.services.library_service import LibraryService
+
+router = APIRouter(tags=["libraries"])
+
+
+def _response(lib: Library) -> LibraryResponse:
+    return LibraryResponse.model_validate(lib)
+
+
+@router.post("/api/libraries", response_model=LibraryResponse)
+async def create_library(
+    body: LibraryCreate,
+    current_user: dict = require_permission("libraries", "create"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    lib = await LibraryService.create_library(session, org_id, body, user_id=user_id)
+    await session.commit()
+    return _response(lib)
+
+
+@router.get("/api/libraries/{library_id}", response_model=LibraryResponse)
+async def get_library(
+    library_id: int,
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    lib = await LibraryService.get_library(session, org_id, library_id)
+    return _response(lib)
+
+
+@router.patch("/api/libraries/{library_id}", response_model=LibraryResponse)
+async def update_library(
+    library_id: int,
+    body: LibraryUpdate,
+    current_user: dict = require_permission("libraries", "edit"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    lib = await LibraryService.update_library(
+        session, org_id, library_id, body, user_id=user_id
+    )
+    await session.commit()
+    return _response(lib)
+
+
+@router.get(
+    "/api/samples/{sample_id}/libraries", response_model=list[LibraryResponse]
+)
+async def list_libraries_for_sample(
+    sample_id: int,
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    libs = await LibraryService.list_libraries_for_sample(session, org_id, sample_id)
+    return [_response(lib) for lib in libs]
+
+
+@router.get(
+    "/api/experiments/{experiment_id}/libraries",
+    response_model=list[LibraryResponse],
+)
+async def list_libraries_for_experiment(
+    experiment_id: int,
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    libs = await LibraryService.list_libraries_for_experiment(
+        session, org_id, experiment_id
+    )
+    return [_response(lib) for lib in libs]
+
+
+@router.post("/api/libraries/{library_id}/files/{file_id}", response_model=LibraryResponse)
+async def attach_file(
+    library_id: int,
+    file_id: int,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    _: dict = require_permission("libraries", "edit"),
+):
+    current_user = request.state.current_user
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    # Files permission is additionally enforced so users without file edit can't mutate file rows.
+    from app.services import role_service
+
+    if not await role_service.has_permission(
+        session, int(current_user["role_id"]), "files", "edit"
+    ):
+        from fastapi import HTTPException
+
+        raise HTTPException(403, "Insufficient permissions")
+
+    lib = await LibraryService.attach_file(
+        session, org_id, library_id, file_id, user_id=user_id
+    )
+    await session.commit()
+    return _response(lib)

--- a/backend/app/api/libraries.py
+++ b/backend/app/api/libraries.py
@@ -47,16 +47,12 @@ async def update_library(
 ):
     org_id = int(current_user["org_id"])
     user_id = int(current_user["sub"])
-    lib = await LibraryService.update_library(
-        session, org_id, library_id, body, user_id=user_id
-    )
+    lib = await LibraryService.update_library(session, org_id, library_id, body, user_id=user_id)
     await session.commit()
     return _response(lib)
 
 
-@router.get(
-    "/api/samples/{sample_id}/libraries", response_model=list[LibraryResponse]
-)
+@router.get("/api/samples/{sample_id}/libraries", response_model=list[LibraryResponse])
 async def list_libraries_for_sample(
     sample_id: int,
     current_user: dict = require_permission("libraries", "view"),
@@ -77,9 +73,7 @@ async def list_libraries_for_experiment(
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
-    libs = await LibraryService.list_libraries_for_experiment(
-        session, org_id, experiment_id
-    )
+    libs = await LibraryService.list_libraries_for_experiment(session, org_id, experiment_id)
     return [_response(lib) for lib in libs]
 
 
@@ -97,15 +91,11 @@ async def attach_file(
     # Files permission is additionally enforced so users without file edit can't mutate file rows.
     from app.services import role_service
 
-    if not await role_service.has_permission(
-        session, int(current_user["role_id"]), "files", "edit"
-    ):
+    if not await role_service.has_permission(session, int(current_user["role_id"]), "files", "edit"):
         from fastapi import HTTPException
 
         raise HTTPException(403, "Insufficient permissions")
 
-    lib = await LibraryService.attach_file(
-        session, org_id, library_id, file_id, user_id=user_id
-    )
+    lib = await LibraryService.attach_file(session, org_id, library_id, file_id, user_id=user_id)
     await session.commit()
     return _response(lib)

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -63,6 +63,8 @@ from app.api.sequencing_batches import router as sequencing_batches_router
 from app.api.slack_oauth import router as slack_oauth_router
 from app.api.experiment_auto_runs import router as experiment_auto_runs_router
 from app.api.content_tokens import router as content_tokens_router
+from app.api.libraries import router as libraries_router
+from app.api.barcode_maps import router as barcode_maps_router
 
 api_router = APIRouter()
 
@@ -129,3 +131,5 @@ api_router.include_router(sequencing_batches_router)
 api_router.include_router(slack_oauth_router)
 api_router.include_router(experiment_auto_runs_router)
 api_router.include_router(content_tokens_router)
+api_router.include_router(libraries_router)
+api_router.include_router(barcode_maps_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -61,6 +61,8 @@ from app.models.role import Role, RolePermission
 from app.models.sample_custom_field import SampleCustomField
 from app.models.experiment_auto_run import ExperimentAutoRun
 from app.models.pending_auto_run import PendingAutoRun
+from app.models.library import Library
+from app.models.barcode_map import BarcodeMap
 
 __all__ = [
     "User",
@@ -132,4 +134,6 @@ __all__ = [
     "SampleCustomField",
     "ExperimentAutoRun",
     "PendingAutoRun",
+    "Library",
+    "BarcodeMap",
 ]

--- a/backend/app/models/barcode_map.py
+++ b/backend/app/models/barcode_map.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+BARCODE_TYPES = [
+    "library_index",
+    "cell_barcode",
+    "umi",
+    "sgrna",
+    "hashtag",
+    "lineage",
+    "other",
+]
+
+READ_POSITIONS = ["R1", "R2", "I1", "I2"]
+
+
+class BarcodeMap(Base):
+    __tablename__ = "barcode_maps"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
+    library_id: Mapped[int] = mapped_column(Integer, ForeignKey("libraries.id"), nullable=False, index=True)
+
+    barcode_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    sequence: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    read_position: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    offset_in_read: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    length: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    allowed_mismatches: Mapped[int | None] = mapped_column(Integer, nullable=True, server_default="1")
+
+    whitelist_reference: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    attributes_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        Index("idx_barcode_maps_library_id", "library_id"),
+        Index("idx_barcode_maps_sequence", "sequence"),
+        Index("idx_barcode_maps_type_sequence", "barcode_type", "sequence"),
+        UniqueConstraint(
+            "library_id",
+            "barcode_type",
+            "sequence",
+            "read_position",
+            name="uq_barcode_maps_library_type_seq_pos",
+        ),
+    )
+
+    library = relationship("Library", back_populates="barcode_maps")
+    organization = relationship("Organization")

--- a/backend/app/models/file.py
+++ b/backend/app/models/file.py
@@ -34,10 +34,16 @@ class File(Base):
     sha256_checksum: Mapped[str | None] = mapped_column(String(64), nullable=True)
     artifact_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     sequencing_batch_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("sequencing_batches.id"), nullable=True)
+    library_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("libraries.id"), nullable=True, index=True
+    )
     storage_deleted: Mapped[bool] = mapped_column(Boolean, server_default="false", nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    __table_args__ = (Index("idx_files_experiment_id", "experiment_id"),)
+    __table_args__ = (
+        Index("idx_files_experiment_id", "experiment_id"),
+        Index("idx_files_library_id", "library_id"),
+    )
 
     organization = relationship("Organization")
     uploader = relationship("User")
@@ -46,5 +52,6 @@ class File(Base):
     source_pipeline_run = relationship("PipelineRun", foreign_keys=[source_pipeline_run_id])
     source_notebook_session = relationship("ComputeSession", foreign_keys=[source_notebook_session_id])
     sequencing_batch = relationship("SequencingBatch", back_populates="files")
+    library = relationship("Library", back_populates="files")
     consumed_by_runs = relationship("PipelineRunInputFile", cascade="all, delete-orphan", passive_deletes=True)
     notebook_sessions = relationship("NotebookSessionFile", foreign_keys="NotebookSessionFile.file_id")

--- a/backend/app/models/file.py
+++ b/backend/app/models/file.py
@@ -34,9 +34,7 @@ class File(Base):
     sha256_checksum: Mapped[str | None] = mapped_column(String(64), nullable=True)
     artifact_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     sequencing_batch_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("sequencing_batches.id"), nullable=True)
-    library_id: Mapped[int | None] = mapped_column(
-        Integer, ForeignKey("libraries.id"), nullable=True, index=True
-    )
+    library_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("libraries.id"), nullable=True, index=True)
     storage_deleted: Mapped[bool] = mapped_column(Boolean, server_default="false", nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/models/library.py
+++ b/backend/app/models/library.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+LIBRARY_STATUSES = [
+    "planned",
+    "prepped",
+    "qc_pass",
+    "qc_fail",
+    "sequenced",
+    "retired",
+]
+
+INDEX_TYPES = ["none", "single", "dual", "udi"]
+
+
+class Library(Base):
+    __tablename__ = "libraries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
+    sample_id: Mapped[int] = mapped_column(Integer, ForeignKey("samples.id"), nullable=False, index=True)
+
+    library_id_external: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    prep_kit: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    prep_protocol_version: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    prep_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    assay_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    molecule_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    strandedness: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    read_layout: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    target_read_length: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    index_type: Mapped[str] = mapped_column(String(20), nullable=False, server_default="none")
+    i5_sequence: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    i7_sequence: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    i5_orientation_convention: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    insert_size_mean: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    molarity_nm: Mapped[Decimal | None] = mapped_column(Numeric(10, 3), nullable=True)
+    concentration_ng_ul: Mapped[Decimal | None] = mapped_column(Numeric(10, 3), nullable=True)
+    qc_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    qc_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    sequencing_batch_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("sequencing_batches.id"), nullable=True
+    )
+
+    status: Mapped[str] = mapped_column(String(50), nullable=False, server_default="planned")
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("organization_id", "library_id_external", name="uq_libraries_org_external_id"),
+        Index("idx_libraries_sample_id", "sample_id"),
+        Index("idx_libraries_sequencing_batch_id", "sequencing_batch_id"),
+        Index("idx_libraries_i7_i5", "i7_sequence", "i5_sequence"),
+    )
+
+    sample = relationship("Sample", back_populates="libraries")
+    organization = relationship("Organization")
+    sequencing_batch = relationship("SequencingBatch")
+    files = relationship("File", back_populates="library")
+    barcode_maps = relationship("BarcodeMap", back_populates="library", cascade="all, delete-orphan")

--- a/backend/app/models/library.py
+++ b/backend/app/models/library.py
@@ -57,9 +57,7 @@ class Library(Base):
     qc_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
     qc_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    sequencing_batch_id: Mapped[int | None] = mapped_column(
-        Integer, ForeignKey("sequencing_batches.id"), nullable=True
-    )
+    sequencing_batch_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("sequencing_batches.id"), nullable=True)
 
     status: Mapped[str] = mapped_column(String(50), nullable=False, server_default="planned")
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/sample.py
+++ b/backend/app/models/sample.py
@@ -80,3 +80,4 @@ class Sample(Base):
     parent_sample = relationship("Sample", remote_side="Sample.id", foreign_keys=[parent_sample_id])
     derived_samples = relationship("Sample", foreign_keys=[parent_sample_id], overlaps="parent_sample")
     custom_fields = relationship("SampleCustomField", back_populates="sample", cascade="all, delete-orphan")
+    libraries = relationship("Library", back_populates="sample", cascade="all, delete-orphan")

--- a/backend/app/schemas/barcode_map.py
+++ b/backend/app/schemas/barcode_map.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+BarcodeType = Literal[
+    "library_index",
+    "cell_barcode",
+    "umi",
+    "sgrna",
+    "hashtag",
+    "lineage",
+    "other",
+]
+
+ReadPosition = Literal["R1", "R2", "I1", "I2"]
+
+
+class BarcodeMapCreate(BaseModel):
+    barcode_type: BarcodeType
+    sequence: str | None = None
+    name: str | None = None
+    read_position: ReadPosition | None = None
+    offset_in_read: int | None = None
+    length: int | None = None
+    allowed_mismatches: int | None = 1
+    whitelist_reference: str | None = None
+    attributes_json: dict | None = None
+
+
+class BarcodeMapBulkCreate(BaseModel):
+    entries: list[BarcodeMapCreate]
+
+
+class BarcodeMapResponse(BaseModel):
+    id: int
+    organization_id: int
+    library_id: int
+    barcode_type: str
+    sequence: str | None = None
+    name: str | None = None
+    read_position: str | None = None
+    offset_in_read: int | None = None
+    length: int | None = None
+    allowed_mismatches: int | None = None
+    whitelist_reference: str | None = None
+    attributes_json: dict | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BarcodeCollisionEntry(BaseModel):
+    """One pair of libraries in the same batch sharing an (i5, i7)."""
+
+    library_a_id: int
+    library_b_id: int
+    i5_sequence: str | None
+    i7_sequence: str | None

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class LibraryCreate(BaseModel):
+    sample_id: int
+    library_id_external: str | None = None
+    prep_kit: str | None = None
+    prep_protocol_version: str | None = None
+    prep_date: datetime | None = None
+    assay_type: str | None = None
+    molecule_type: str | None = None
+    strandedness: str | None = None
+    read_layout: str | None = None
+    target_read_length: int | None = None
+    index_type: Literal["none", "single", "dual", "udi"] = "none"
+    i5_sequence: str | None = None
+    i7_sequence: str | None = None
+    i5_orientation_convention: str | None = None
+    insert_size_mean: int | None = None
+    molarity_nm: Decimal | None = None
+    concentration_ng_ul: Decimal | None = None
+    qc_status: Literal["pass", "warning", "fail"] | None = None
+    qc_notes: str | None = None
+    sequencing_batch_id: int | None = None
+    notes: str | None = None
+
+
+class LibraryUpdate(BaseModel):
+    library_id_external: str | None = None
+    prep_kit: str | None = None
+    prep_protocol_version: str | None = None
+    prep_date: datetime | None = None
+    assay_type: str | None = None
+    molecule_type: str | None = None
+    strandedness: str | None = None
+    read_layout: str | None = None
+    target_read_length: int | None = None
+    index_type: Literal["none", "single", "dual", "udi"] | None = None
+    i5_sequence: str | None = None
+    i7_sequence: str | None = None
+    i5_orientation_convention: str | None = None
+    insert_size_mean: int | None = None
+    molarity_nm: Decimal | None = None
+    concentration_ng_ul: Decimal | None = None
+    qc_status: Literal["pass", "warning", "fail"] | None = None
+    qc_notes: str | None = None
+    sequencing_batch_id: int | None = None
+    status: str | None = None
+    notes: str | None = None
+
+
+class LibraryResponse(BaseModel):
+    id: int
+    organization_id: int
+    sample_id: int
+    library_id_external: str | None = None
+    prep_kit: str | None = None
+    prep_protocol_version: str | None = None
+    prep_date: datetime | None = None
+    assay_type: str | None = None
+    molecule_type: str | None = None
+    strandedness: str | None = None
+    read_layout: str | None = None
+    target_read_length: int | None = None
+    index_type: str
+    i5_sequence: str | None = None
+    i7_sequence: str | None = None
+    i5_orientation_convention: str | None = None
+    insert_size_mean: int | None = None
+    molarity_nm: Decimal | None = None
+    concentration_ng_ul: Decimal | None = None
+    qc_status: str | None = None
+    qc_notes: str | None = None
+    sequencing_batch_id: int | None = None
+    status: str
+    notes: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/barcode_service.py
+++ b/backend/app/services/barcode_service.py
@@ -24,9 +24,7 @@ MAX_BARCODES_PER_LIBRARY = 10_000
 
 class BarcodeService:
     @staticmethod
-    def _build_row(
-        org_id: int, library_id: int, payload: BarcodeMapCreate
-    ) -> BarcodeMap:
+    def _build_row(org_id: int, library_id: int, payload: BarcodeMapCreate) -> BarcodeMap:
         seq = _canonicalize(payload.sequence)
         if payload.barcode_type == "library_index" and seq is None:
             raise HTTPException(
@@ -41,11 +39,7 @@ class BarcodeService:
                 status_code=422,
                 detail="library_index rows require read_position in {I1, I2}",
             )
-        if (
-            seq is not None
-            and payload.length is not None
-            and len(seq) != payload.length
-        ):
+        if seq is not None and payload.length is not None and len(seq) != payload.length:
             raise HTTPException(
                 status_code=422,
                 detail="sequence length does not match declared length",
@@ -87,10 +81,8 @@ class BarcodeService:
         await LibraryService._get_library_in_org(session, org_id, library_id)
 
         existing_count = (
-            await session.execute(
-                select(BarcodeMap).where(BarcodeMap.library_id == library_id)
-            )
-        ).scalars().all()
+            (await session.execute(select(BarcodeMap).where(BarcodeMap.library_id == library_id))).scalars().all()
+        )
         if len(existing_count) + len(payload.entries) > MAX_BARCODES_PER_LIBRARY:
             raise HTTPException(
                 status_code=422,
@@ -100,10 +92,7 @@ class BarcodeService:
                 ),
             )
 
-        rows = [
-            BarcodeService._build_row(org_id, library_id, entry)
-            for entry in payload.entries
-        ]
+        rows = [BarcodeService._build_row(org_id, library_id, entry) for entry in payload.entries]
         session.add_all(rows)
         await session.flush()
         return rows
@@ -146,19 +135,16 @@ class BarcodeService:
         """Return pairs of libraries in the batch sharing an (i5, i7)."""
         a = aliased(Library)
         b = aliased(Library)
-        stmt = (
-            select(a, b)
-            .where(
-                a.organization_id == org_id,
-                b.organization_id == org_id,
-                a.sequencing_batch_id == sequencing_batch_id,
-                b.sequencing_batch_id == sequencing_batch_id,
-                a.id < b.id,
-                a.i5_sequence.isnot(None),
-                a.i7_sequence.isnot(None),
-                a.i5_sequence == b.i5_sequence,
-                a.i7_sequence == b.i7_sequence,
-            )
+        stmt = select(a, b).where(
+            a.organization_id == org_id,
+            b.organization_id == org_id,
+            a.sequencing_batch_id == sequencing_batch_id,
+            b.sequencing_batch_id == sequencing_batch_id,
+            a.id < b.id,
+            a.i5_sequence.isnot(None),
+            a.i7_sequence.isnot(None),
+            a.i5_sequence == b.i5_sequence,
+            a.i7_sequence == b.i7_sequence,
         )
         results = (await session.execute(stmt)).all()
         out = [

--- a/backend/app/services/barcode_service.py
+++ b/backend/app/services/barcode_service.py
@@ -1,0 +1,186 @@
+"""BarcodeService: per-library barcode map CRUD, reverse lookup, collision detection."""
+
+import asyncio
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.models.barcode_map import BarcodeMap
+from app.models.library import Library
+from app.schemas.barcode_map import (
+    BarcodeCollisionEntry,
+    BarcodeMapBulkCreate,
+    BarcodeMapCreate,
+)
+from app.services import event_types
+from app.services.event_bus import event_bus
+from app.services.library_service import LibraryService, _canonicalize
+
+
+MAX_BARCODES_PER_LIBRARY = 10_000
+
+
+class BarcodeService:
+    @staticmethod
+    def _build_row(
+        org_id: int, library_id: int, payload: BarcodeMapCreate
+    ) -> BarcodeMap:
+        seq = _canonicalize(payload.sequence)
+        if payload.barcode_type == "library_index" and seq is None:
+            raise HTTPException(
+                status_code=422,
+                detail="library_index rows require a sequence",
+            )
+        if payload.barcode_type == "library_index" and payload.read_position not in (
+            "I1",
+            "I2",
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail="library_index rows require read_position in {I1, I2}",
+            )
+        if (
+            seq is not None
+            and payload.length is not None
+            and len(seq) != payload.length
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail="sequence length does not match declared length",
+            )
+        return BarcodeMap(
+            organization_id=org_id,
+            library_id=library_id,
+            barcode_type=payload.barcode_type,
+            sequence=seq,
+            name=payload.name,
+            read_position=payload.read_position,
+            offset_in_read=payload.offset_in_read,
+            length=payload.length,
+            allowed_mismatches=payload.allowed_mismatches,
+            whitelist_reference=payload.whitelist_reference,
+            attributes_json=payload.attributes_json,
+        )
+
+    @staticmethod
+    async def create_barcode_map(
+        session: AsyncSession,
+        org_id: int,
+        library_id: int,
+        payload: BarcodeMapCreate,
+    ) -> BarcodeMap:
+        await LibraryService._get_library_in_org(session, org_id, library_id)
+        row = BarcodeService._build_row(org_id, library_id, payload)
+        session.add(row)
+        await session.flush()
+        return row
+
+    @staticmethod
+    async def bulk_create_barcode_maps(
+        session: AsyncSession,
+        org_id: int,
+        library_id: int,
+        payload: BarcodeMapBulkCreate,
+    ) -> list[BarcodeMap]:
+        await LibraryService._get_library_in_org(session, org_id, library_id)
+
+        existing_count = (
+            await session.execute(
+                select(BarcodeMap).where(BarcodeMap.library_id == library_id)
+            )
+        ).scalars().all()
+        if len(existing_count) + len(payload.entries) > MAX_BARCODES_PER_LIBRARY:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Library {library_id} would exceed {MAX_BARCODES_PER_LIBRARY} "
+                    "barcode rows. Use whitelist_reference for large sets."
+                ),
+            )
+
+        rows = [
+            BarcodeService._build_row(org_id, library_id, entry)
+            for entry in payload.entries
+        ]
+        session.add_all(rows)
+        await session.flush()
+        return rows
+
+    @staticmethod
+    async def list_barcode_maps_for_library(
+        session: AsyncSession,
+        org_id: int,
+        library_id: int,
+        barcode_type: str | None = None,
+    ) -> list[BarcodeMap]:
+        await LibraryService._get_library_in_org(session, org_id, library_id)
+        stmt = select(BarcodeMap).where(BarcodeMap.library_id == library_id)
+        if barcode_type is not None:
+            stmt = stmt.where(BarcodeMap.barcode_type == barcode_type)
+        return list((await session.execute(stmt)).scalars().all())
+
+    @staticmethod
+    async def lookup_by_sequence(
+        session: AsyncSession,
+        org_id: int,
+        sequence: str,
+        barcode_type: str | None = None,
+    ) -> list[BarcodeMap]:
+        canon = _canonicalize(sequence)
+        stmt = select(BarcodeMap).where(
+            BarcodeMap.organization_id == org_id,
+            BarcodeMap.sequence == canon,
+        )
+        if barcode_type is not None:
+            stmt = stmt.where(BarcodeMap.barcode_type == barcode_type)
+        return list((await session.execute(stmt)).scalars().all())
+
+    @staticmethod
+    async def detect_collisions_in_batch(
+        session: AsyncSession,
+        org_id: int,
+        sequencing_batch_id: int,
+    ) -> list[BarcodeCollisionEntry]:
+        """Return pairs of libraries in the batch sharing an (i5, i7)."""
+        a = aliased(Library)
+        b = aliased(Library)
+        stmt = (
+            select(a, b)
+            .where(
+                a.organization_id == org_id,
+                b.organization_id == org_id,
+                a.sequencing_batch_id == sequencing_batch_id,
+                b.sequencing_batch_id == sequencing_batch_id,
+                a.id < b.id,
+                a.i5_sequence.isnot(None),
+                a.i7_sequence.isnot(None),
+                a.i5_sequence == b.i5_sequence,
+                a.i7_sequence == b.i7_sequence,
+            )
+        )
+        results = (await session.execute(stmt)).all()
+        out = [
+            BarcodeCollisionEntry(
+                library_a_id=row[0].id,
+                library_b_id=row[1].id,
+                i5_sequence=row[0].i5_sequence,
+                i7_sequence=row[0].i7_sequence,
+            )
+            for row in results
+        ]
+        if out:
+            asyncio.create_task(
+                event_bus.emit(
+                    event_types.BARCODE_COLLISION_DETECTED,
+                    {
+                        "event_type": event_types.BARCODE_COLLISION_DETECTED,
+                        "org_id": org_id,
+                        "entity_type": "sequencing_batch",
+                        "entity_id": sequencing_batch_id,
+                        "collision_count": len(out),
+                    },
+                )
+            )
+        return out

--- a/backend/app/services/bootstrap_roles.py
+++ b/backend/app/services/bootstrap_roles.py
@@ -20,6 +20,7 @@ ALL_RESOURCES_ACTIONS: dict[str, list[str]] = {
     "roles": ["view", "create", "edit", "delete"],
     "quotas": ["view", "configure"],
     "settings": ["view", "configure"],
+    "libraries": ["view", "create", "edit", "delete"],
 }
 
 BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
@@ -42,6 +43,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "infrastructure": ["view"],
             "audit_log": ["view"],
             "cost_center": ["view"],
+            "libraries": ["view", "create", "edit"],
         },
     ),
     "bench": (
@@ -54,6 +56,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "environments": ["view"],
             "files": ["view", "upload"],
             "projects": ["view"],
+            "libraries": ["view", "create", "edit"],
         },
     ),
     "viewer": (
@@ -64,6 +67,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "environments": ["view"],
             "files": ["view"],
             "projects": ["view"],
+            "libraries": ["view"],
         },
     ),
 }

--- a/backend/app/services/event_types.py
+++ b/backend/app/services/event_types.py
@@ -89,6 +89,12 @@ AUTO_RUN_CANCELLED = "auto_run.cancelled"
 # Terraform events
 TERRAFORM_APPLY_FAILURE = "terraform.apply_failure"
 
+# Library / barcode events
+LIBRARY_CREATED = "library.created"
+LIBRARY_UPDATED = "library.updated"
+LIBRARY_FILE_ATTACHED = "library.file_attached"
+BARCODE_COLLISION_DETECTED = "barcode.collision_detected"
+
 ALL_EVENT_TYPES = [
     PIPELINE_STARTED,
     PIPELINE_COMPLETED,
@@ -137,6 +143,10 @@ ALL_EVENT_TYPES = [
     AUTO_RUN_BUDGET_DISABLED,
     AUTO_RUN_LAUNCHED,
     AUTO_RUN_CANCELLED,
+    LIBRARY_CREATED,
+    LIBRARY_UPDATED,
+    LIBRARY_FILE_ATTACHED,
+    BARCODE_COLLISION_DETECTED,
 ]
 
 # Severity mapping for event types
@@ -188,4 +198,8 @@ EVENT_SEVERITY = {
     AUTO_RUN_BUDGET_DISABLED: "critical",
     AUTO_RUN_LAUNCHED: "info",
     AUTO_RUN_CANCELLED: "warning",
+    LIBRARY_CREATED: "info",
+    LIBRARY_UPDATED: "info",
+    LIBRARY_FILE_ATTACHED: "info",
+    BARCODE_COLLISION_DETECTED: "warning",
 }

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -1,0 +1,302 @@
+"""Library service: create/update libraries and maintain derived library_index barcodes.
+
+Canonicalisation rule (§6): all index sequences are uppercased and validated
+against ``[ACGTN]`` before persistence. Invalid input raises 422.
+"""
+
+import asyncio
+import re
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.barcode_map import BarcodeMap
+from app.models.file import File
+from app.models.library import Library
+from app.models.sample import Sample, sample_files
+from app.schemas.library import LibraryCreate, LibraryUpdate
+from app.services import event_types
+from app.services.audit_service import log_action
+from app.services.event_bus import event_bus
+
+
+_SEQ_RE = re.compile(r"^[ACGTN]+$")
+
+
+def _canonicalize(seq: str | None) -> str | None:
+    if seq is None:
+        return None
+    cleaned = seq.strip().upper()
+    if cleaned == "":
+        return None
+    if not _SEQ_RE.match(cleaned):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid barcode sequence: '{seq}'. Must match [ACGTN]+.",
+        )
+    return cleaned
+
+
+class LibraryService:
+    @staticmethod
+    async def _assert_sample_in_org(
+        session: AsyncSession, org_id: int, sample_id: int
+    ) -> Sample:
+        """Verify sample belongs to an experiment in the caller's organization."""
+        from app.models.experiment import Experiment
+
+        row = (
+            await session.execute(
+                select(Sample, Experiment.organization_id)
+                .join(Experiment, Sample.experiment_id == Experiment.id)
+                .where(Sample.id == sample_id)
+            )
+        ).first()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Sample not found")
+        sample, sample_org_id = row
+        if sample_org_id != org_id:
+            raise HTTPException(status_code=403, detail="Sample belongs to another organization")
+        return sample
+
+    @staticmethod
+    async def _get_library_in_org(
+        session: AsyncSession, org_id: int, library_id: int
+    ) -> Library:
+        lib = await session.get(Library, library_id)
+        if lib is None or lib.organization_id != org_id:
+            raise HTTPException(status_code=404, detail="Library not found")
+        return lib
+
+    @staticmethod
+    async def rebuild_library_index_barcodes(
+        session: AsyncSession, library: Library
+    ) -> None:
+        """Delete and regenerate library_index BarcodeMap rows from the library's index fields."""
+        existing = (
+            await session.execute(
+                select(BarcodeMap).where(
+                    BarcodeMap.library_id == library.id,
+                    BarcodeMap.barcode_type == "library_index",
+                )
+            )
+        ).scalars().all()
+        for row in existing:
+            await session.delete(row)
+        await session.flush()
+
+        # Mapping: i7 -> I1, i5 -> I2 (standard Illumina convention).
+        if library.i7_sequence:
+            session.add(
+                BarcodeMap(
+                    organization_id=library.organization_id,
+                    library_id=library.id,
+                    barcode_type="library_index",
+                    sequence=library.i7_sequence,
+                    read_position="I1",
+                    length=len(library.i7_sequence),
+                )
+            )
+        if library.i5_sequence:
+            session.add(
+                BarcodeMap(
+                    organization_id=library.organization_id,
+                    library_id=library.id,
+                    barcode_type="library_index",
+                    sequence=library.i5_sequence,
+                    read_position="I2",
+                    length=len(library.i5_sequence),
+                )
+            )
+        await session.flush()
+
+    @staticmethod
+    async def create_library(
+        session: AsyncSession,
+        org_id: int,
+        payload: LibraryCreate,
+        user_id: int | None = None,
+    ) -> Library:
+        await LibraryService._assert_sample_in_org(session, org_id, payload.sample_id)
+
+        i5 = _canonicalize(payload.i5_sequence)
+        i7 = _canonicalize(payload.i7_sequence)
+
+        lib = Library(
+            organization_id=org_id,
+            sample_id=payload.sample_id,
+            library_id_external=payload.library_id_external,
+            prep_kit=payload.prep_kit,
+            prep_protocol_version=payload.prep_protocol_version,
+            prep_date=payload.prep_date,
+            assay_type=payload.assay_type,
+            molecule_type=payload.molecule_type,
+            strandedness=payload.strandedness,
+            read_layout=payload.read_layout,
+            target_read_length=payload.target_read_length,
+            index_type=payload.index_type,
+            i5_sequence=i5,
+            i7_sequence=i7,
+            i5_orientation_convention=payload.i5_orientation_convention,
+            insert_size_mean=payload.insert_size_mean,
+            molarity_nm=payload.molarity_nm,
+            concentration_ng_ul=payload.concentration_ng_ul,
+            qc_status=payload.qc_status,
+            qc_notes=payload.qc_notes,
+            sequencing_batch_id=payload.sequencing_batch_id,
+            notes=payload.notes,
+        )
+        session.add(lib)
+        await session.flush()
+
+        await LibraryService.rebuild_library_index_barcodes(session, lib)
+
+        await log_action(
+            session, user_id, "library", lib.id, "created",
+            details={"sample_id": lib.sample_id, "index_type": lib.index_type},
+        )
+        asyncio.create_task(
+            event_bus.emit(
+                event_types.LIBRARY_CREATED,
+                {
+                    "event_type": event_types.LIBRARY_CREATED,
+                    "org_id": org_id,
+                    "entity_type": "library",
+                    "entity_id": lib.id,
+                },
+            )
+        )
+        return lib
+
+    @staticmethod
+    async def update_library(
+        session: AsyncSession,
+        org_id: int,
+        library_id: int,
+        payload: LibraryUpdate,
+        user_id: int | None = None,
+    ) -> Library:
+        lib = await LibraryService._get_library_in_org(session, org_id, library_id)
+
+        data = payload.model_dump(exclude_unset=True)
+        index_changed = False
+        for key, value in data.items():
+            if key in ("i5_sequence", "i7_sequence"):
+                value = _canonicalize(value)
+                if getattr(lib, key) != value:
+                    index_changed = True
+            if key == "index_type" and getattr(lib, key) != value:
+                index_changed = True
+            setattr(lib, key, value)
+        await session.flush()
+
+        if index_changed:
+            await LibraryService.rebuild_library_index_barcodes(session, lib)
+
+        await log_action(
+            session, user_id, "library", lib.id, "updated",
+            details={k: v for k, v in data.items()},
+        )
+        asyncio.create_task(
+            event_bus.emit(
+                event_types.LIBRARY_UPDATED,
+                {
+                    "event_type": event_types.LIBRARY_UPDATED,
+                    "org_id": org_id,
+                    "entity_type": "library",
+                    "entity_id": lib.id,
+                },
+            )
+        )
+        return lib
+
+    @staticmethod
+    async def get_library(
+        session: AsyncSession, org_id: int, library_id: int
+    ) -> Library:
+        return await LibraryService._get_library_in_org(session, org_id, library_id)
+
+    @staticmethod
+    async def list_libraries_for_sample(
+        session: AsyncSession, org_id: int, sample_id: int
+    ) -> list[Library]:
+        await LibraryService._assert_sample_in_org(session, org_id, sample_id)
+        rows = (
+            await session.execute(
+                select(Library).where(
+                    Library.organization_id == org_id,
+                    Library.sample_id == sample_id,
+                )
+            )
+        ).scalars().all()
+        return list(rows)
+
+    @staticmethod
+    async def list_libraries_for_experiment(
+        session: AsyncSession, org_id: int, experiment_id: int
+    ) -> list[Library]:
+        from app.models.experiment import Experiment
+
+        exp = await session.get(Experiment, experiment_id)
+        if exp is None or exp.organization_id != org_id:
+            raise HTTPException(status_code=404, detail="Experiment not found")
+        rows = (
+            await session.execute(
+                select(Library)
+                .join(Sample, Library.sample_id == Sample.id)
+                .where(
+                    Library.organization_id == org_id,
+                    Sample.experiment_id == experiment_id,
+                )
+            )
+        ).scalars().all()
+        return list(rows)
+
+    @staticmethod
+    async def attach_file(
+        session: AsyncSession,
+        org_id: int,
+        library_id: int,
+        file_id: int,
+        user_id: int | None = None,
+    ) -> Library:
+        lib = await LibraryService._get_library_in_org(session, org_id, library_id)
+        f = await session.get(File, file_id)
+        if f is None or f.organization_id != org_id:
+            raise HTTPException(status_code=404, detail="File not found")
+
+        f.library_id = lib.id
+
+        existing = (
+            await session.execute(
+                select(sample_files).where(
+                    sample_files.c.file_id == f.id,
+                    sample_files.c.sample_id == lib.sample_id,
+                )
+            )
+        ).first()
+        if existing is None:
+            await session.execute(
+                sample_files.insert().values(sample_id=lib.sample_id, file_id=f.id)
+            )
+
+        await session.flush()
+
+        await log_action(
+            session, user_id, "library", lib.id, "file_attached",
+            details={"file_id": f.id, "sample_id": lib.sample_id},
+        )
+        asyncio.create_task(
+            event_bus.emit(
+                event_types.LIBRARY_FILE_ATTACHED,
+                {
+                    "event_type": event_types.LIBRARY_FILE_ATTACHED,
+                    "org_id": org_id,
+                    "entity_type": "library",
+                    "entity_id": lib.id,
+                    "file_id": f.id,
+                },
+            )
+        )
+        return lib

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -40,9 +40,7 @@ def _canonicalize(seq: str | None) -> str | None:
 
 class LibraryService:
     @staticmethod
-    async def _assert_sample_in_org(
-        session: AsyncSession, org_id: int, sample_id: int
-    ) -> Sample:
+    async def _assert_sample_in_org(session: AsyncSession, org_id: int, sample_id: int) -> Sample:
         """Verify sample belongs to an experiment in the caller's organization."""
         from app.models.experiment import Experiment
 
@@ -61,27 +59,27 @@ class LibraryService:
         return sample
 
     @staticmethod
-    async def _get_library_in_org(
-        session: AsyncSession, org_id: int, library_id: int
-    ) -> Library:
+    async def _get_library_in_org(session: AsyncSession, org_id: int, library_id: int) -> Library:
         lib = await session.get(Library, library_id)
         if lib is None or lib.organization_id != org_id:
             raise HTTPException(status_code=404, detail="Library not found")
         return lib
 
     @staticmethod
-    async def rebuild_library_index_barcodes(
-        session: AsyncSession, library: Library
-    ) -> None:
+    async def rebuild_library_index_barcodes(session: AsyncSession, library: Library) -> None:
         """Delete and regenerate library_index BarcodeMap rows from the library's index fields."""
         existing = (
-            await session.execute(
-                select(BarcodeMap).where(
-                    BarcodeMap.library_id == library.id,
-                    BarcodeMap.barcode_type == "library_index",
+            (
+                await session.execute(
+                    select(BarcodeMap).where(
+                        BarcodeMap.library_id == library.id,
+                        BarcodeMap.barcode_type == "library_index",
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for row in existing:
             await session.delete(row)
         await session.flush()
@@ -153,7 +151,11 @@ class LibraryService:
         await LibraryService.rebuild_library_index_barcodes(session, lib)
 
         await log_action(
-            session, user_id, "library", lib.id, "created",
+            session,
+            user_id,
+            "library",
+            lib.id,
+            "created",
             details={"sample_id": lib.sample_id, "index_type": lib.index_type},
         )
         asyncio.create_task(
@@ -195,7 +197,11 @@ class LibraryService:
             await LibraryService.rebuild_library_index_barcodes(session, lib)
 
         await log_action(
-            session, user_id, "library", lib.id, "updated",
+            session,
+            user_id,
+            "library",
+            lib.id,
+            "updated",
             details={k: v for k, v in data.items()},
         )
         asyncio.create_task(
@@ -212,45 +218,47 @@ class LibraryService:
         return lib
 
     @staticmethod
-    async def get_library(
-        session: AsyncSession, org_id: int, library_id: int
-    ) -> Library:
+    async def get_library(session: AsyncSession, org_id: int, library_id: int) -> Library:
         return await LibraryService._get_library_in_org(session, org_id, library_id)
 
     @staticmethod
-    async def list_libraries_for_sample(
-        session: AsyncSession, org_id: int, sample_id: int
-    ) -> list[Library]:
+    async def list_libraries_for_sample(session: AsyncSession, org_id: int, sample_id: int) -> list[Library]:
         await LibraryService._assert_sample_in_org(session, org_id, sample_id)
         rows = (
-            await session.execute(
-                select(Library).where(
-                    Library.organization_id == org_id,
-                    Library.sample_id == sample_id,
+            (
+                await session.execute(
+                    select(Library).where(
+                        Library.organization_id == org_id,
+                        Library.sample_id == sample_id,
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         return list(rows)
 
     @staticmethod
-    async def list_libraries_for_experiment(
-        session: AsyncSession, org_id: int, experiment_id: int
-    ) -> list[Library]:
+    async def list_libraries_for_experiment(session: AsyncSession, org_id: int, experiment_id: int) -> list[Library]:
         from app.models.experiment import Experiment
 
         exp = await session.get(Experiment, experiment_id)
         if exp is None or exp.organization_id != org_id:
             raise HTTPException(status_code=404, detail="Experiment not found")
         rows = (
-            await session.execute(
-                select(Library)
-                .join(Sample, Library.sample_id == Sample.id)
-                .where(
-                    Library.organization_id == org_id,
-                    Sample.experiment_id == experiment_id,
+            (
+                await session.execute(
+                    select(Library)
+                    .join(Sample, Library.sample_id == Sample.id)
+                    .where(
+                        Library.organization_id == org_id,
+                        Sample.experiment_id == experiment_id,
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         return list(rows)
 
     @staticmethod
@@ -277,14 +285,16 @@ class LibraryService:
             )
         ).first()
         if existing is None:
-            await session.execute(
-                sample_files.insert().values(sample_id=lib.sample_id, file_id=f.id)
-            )
+            await session.execute(sample_files.insert().values(sample_id=lib.sample_id, file_id=f.id))
 
         await session.flush()
 
         await log_action(
-            session, user_id, "library", lib.id, "file_attached",
+            session,
+            user_id,
+            "library",
+            lib.id,
+            "file_attached",
             details={"file_id": f.id, "sample_id": lib.sample_id},
         )
         asyncio.create_task(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.7.5"
+version = "0.8.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_barcode_map_model.py
+++ b/backend/tests/test_barcode_map_model.py
@@ -120,7 +120,5 @@ async def test_library_cascades_to_barcode_maps(session):
     await session.delete(await session.get(Library, lib.id))
     await session.flush()
 
-    remaining = (
-        await session.execute(select(BarcodeMap).where(BarcodeMap.library_id == lib.id))
-    ).scalars().all()
+    remaining = (await session.execute(select(BarcodeMap).where(BarcodeMap.library_id == lib.id))).scalars().all()
     assert remaining == []

--- a/backend/tests/test_barcode_map_model.py
+++ b/backend/tests/test_barcode_map_model.py
@@ -1,0 +1,126 @@
+"""Tests for the BarcodeMap model (issue #233)."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_library(session):
+    from app.models.experiment import Experiment
+    from app.models.library import Library
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+
+    org = Organization(name="BC Test Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="BC Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    lib = Library(organization_id=org.id, sample_id=sample.id)
+    session.add(lib)
+    await session.flush()
+    return org, lib
+
+
+async def test_barcode_map_model_is_registered():
+    from app.models import BarcodeMap
+
+    assert BarcodeMap.__tablename__ == "barcode_maps"
+
+
+async def test_create_barcode_map_with_sequence(session):
+    from app.models import BarcodeMap
+
+    org, lib = await _create_library(session)
+    bm = BarcodeMap(
+        organization_id=org.id,
+        library_id=lib.id,
+        barcode_type="library_index",
+        sequence="AAGTCCGT",
+        read_position="I1",
+        length=8,
+    )
+    session.add(bm)
+    await session.flush()
+
+    assert bm.id is not None
+    assert bm.allowed_mismatches == 1  # server default per §3.2
+
+
+async def test_barcode_map_whitelist_reference_without_sequence(session):
+    """A row may omit sequence and reference an external whitelist."""
+    from app.models import BarcodeMap
+
+    org, lib = await _create_library(session)
+    bm = BarcodeMap(
+        organization_id=org.id,
+        library_id=lib.id,
+        barcode_type="cell_barcode",
+        whitelist_reference="10x:737K-august-2016",
+        read_position="R1",
+    )
+    session.add(bm)
+    await session.flush()
+
+    fetched = (await session.execute(select(BarcodeMap).where(BarcodeMap.id == bm.id))).scalar_one()
+    assert fetched.sequence is None
+    assert fetched.whitelist_reference == "10x:737K-august-2016"
+
+
+async def test_barcode_map_unique_per_library_type_seq_pos(session):
+    from app.models import BarcodeMap
+
+    org, lib = await _create_library(session)
+    session.add(
+        BarcodeMap(
+            organization_id=org.id,
+            library_id=lib.id,
+            barcode_type="library_index",
+            sequence="AAGTCCGT",
+            read_position="I1",
+        )
+    )
+    await session.flush()
+
+    session.add(
+        BarcodeMap(
+            organization_id=org.id,
+            library_id=lib.id,
+            barcode_type="library_index",
+            sequence="AAGTCCGT",
+            read_position="I1",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await session.flush()
+
+
+async def test_library_cascades_to_barcode_maps(session):
+    """Per §3.1 cascade='all, delete-orphan': deleting a Library removes its BarcodeMaps."""
+    from app.models import BarcodeMap, Library
+
+    org, lib = await _create_library(session)
+    session.add(
+        BarcodeMap(
+            organization_id=org.id,
+            library_id=lib.id,
+            barcode_type="library_index",
+            sequence="GGGG",
+            read_position="I1",
+        )
+    )
+    await session.flush()
+
+    await session.delete(await session.get(Library, lib.id))
+    await session.flush()
+
+    remaining = (
+        await session.execute(select(BarcodeMap).where(BarcodeMap.library_id == lib.id))
+    ).scalars().all()
+    assert remaining == []

--- a/backend/tests/test_barcode_service.py
+++ b/backend/tests/test_barcode_service.py
@@ -1,0 +1,219 @@
+"""Tests for BarcodeService (issue #233 §6)."""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_library(session, org=None, sample=None, **kwargs):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    if org is None:
+        org = Organization(name=kwargs.pop("org_name", "BC Svc Org"), setup_complete=True)
+        session.add(org)
+        await session.flush()
+    if sample is None:
+        exp = Experiment(name="BC Svc Exp", organization_id=org.id)
+        session.add(exp)
+        await session.flush()
+        sample = Sample(experiment_id=exp.id)
+        session.add(sample)
+        await session.flush()
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, **kwargs),
+    )
+    await session.commit()
+    return org, sample, lib
+
+
+async def test_create_barcode_map_canonicalises_sequence(session):
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, _, lib = await _make_library(session)
+    bm = await BarcodeService.create_barcode_map(
+        session,
+        org.id,
+        lib.id,
+        BarcodeMapCreate(
+            barcode_type="hashtag",
+            sequence=" acgtn ",
+            name="HT-1",
+            read_position="R2",
+            length=5,
+        ),
+    )
+    await session.commit()
+    assert bm.sequence == "ACGTN"
+
+
+async def test_create_barcode_map_rejects_invalid_chars(session):
+    from fastapi import HTTPException
+
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, _, lib = await _make_library(session)
+    with pytest.raises(HTTPException) as exc:
+        await BarcodeService.create_barcode_map(
+            session,
+            org.id,
+            lib.id,
+            BarcodeMapCreate(barcode_type="hashtag", sequence="AXCZ"),
+        )
+    assert exc.value.status_code == 422
+
+
+async def test_lookup_by_sequence_returns_matches(session):
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, _, lib = await _make_library(
+        session, index_type="dual", i5_sequence="TTTT", i7_sequence="AAAA"
+    )
+    await BarcodeService.create_barcode_map(
+        session,
+        org.id,
+        lib.id,
+        BarcodeMapCreate(barcode_type="hashtag", sequence="GGGG", name="HT-A"),
+    )
+    await session.commit()
+
+    # library_index row was auto-created with i7 = AAAA on I1
+    matches = await BarcodeService.lookup_by_sequence(session, org.id, "aaaa")
+    assert any(m.sequence == "AAAA" and m.barcode_type == "library_index" for m in matches)
+
+    filtered = await BarcodeService.lookup_by_sequence(
+        session, org.id, "GGGG", barcode_type="hashtag"
+    )
+    assert len(filtered) == 1
+    assert filtered[0].name == "HT-A"
+
+
+async def test_lookup_is_org_scoped(session):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.services.barcode_service import BarcodeService
+
+    org_a, _, lib_a = await _make_library(
+        session, index_type="single", i7_sequence="AAAA"
+    )
+    # Other org with colliding sequence.
+    org_b = Organization(name="Other BC Org", setup_complete=True)
+    session.add(org_b)
+    await session.flush()
+    exp_b = Experiment(name="E", organization_id=org_b.id)
+    session.add(exp_b)
+    await session.flush()
+    sample_b = Sample(experiment_id=exp_b.id)
+    session.add(sample_b)
+    await session.flush()
+    await _make_library(
+        session, org=org_b, sample=sample_b, index_type="single", i7_sequence="AAAA"
+    )
+
+    matches_a = await BarcodeService.lookup_by_sequence(session, org_a.id, "AAAA")
+    for m in matches_a:
+        assert m.organization_id == org_a.id
+        assert m.library_id == lib_a.id
+
+
+async def test_detect_collisions_in_batch(session):
+    """Per §8: two libraries in same batch with same (i5, i7) flagged; diff batches not."""
+    from app.models.sample import Sample
+    from app.models.sequencing_batch import SequencingBatch
+    from app.schemas.library import LibraryCreate
+    from app.services.barcode_service import BarcodeService
+    from app.services.library_service import LibraryService
+
+    org, seed_sample, _ = await _make_library(
+        session, index_type="dual", i5_sequence="TTTT", i7_sequence="AAAA"
+    )
+
+    batch = SequencingBatch(organization_id=org.id, code="BC-1", status="pending")
+    session.add(batch)
+    await session.flush()
+    batch2 = SequencingBatch(organization_id=org.id, code="BC-2", status="pending")
+    session.add(batch2)
+    await session.flush()
+
+    # Two libraries with same indices, both in batch 1 -> collision.
+    s1 = Sample(experiment_id=seed_sample.experiment_id)
+    s2 = Sample(experiment_id=seed_sample.experiment_id)
+    s3 = Sample(experiment_id=seed_sample.experiment_id)
+    session.add_all([s1, s2, s3])
+    await session.flush()
+
+    lib1 = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=s1.id,
+            index_type="dual",
+            i5_sequence="CCCC",
+            i7_sequence="GGGG",
+            sequencing_batch_id=batch.id,
+        ),
+    )
+    lib2 = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=s2.id,
+            index_type="dual",
+            i5_sequence="CCCC",
+            i7_sequence="GGGG",
+            sequencing_batch_id=batch.id,
+        ),
+    )
+    # Same indices, different batch -> no collision.
+    lib3 = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=s3.id,
+            index_type="dual",
+            i5_sequence="CCCC",
+            i7_sequence="GGGG",
+            sequencing_batch_id=batch2.id,
+        ),
+    )
+    await session.commit()
+
+    collisions = await BarcodeService.detect_collisions_in_batch(session, org.id, batch.id)
+    collided_pairs = {tuple(sorted([c.library_a_id, c.library_b_id])) for c in collisions}
+    assert (min(lib1.id, lib2.id), max(lib1.id, lib2.id)) in collided_pairs
+
+    collisions_b2 = await BarcodeService.detect_collisions_in_batch(session, org.id, batch2.id)
+    assert collisions_b2 == []
+    # And lib3 is not in batch1 collisions.
+    for c in collisions:
+        assert lib3.id not in (c.library_a_id, c.library_b_id)
+
+
+async def test_bulk_create_barcode_maps(session):
+    from app.schemas.barcode_map import BarcodeMapBulkCreate, BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, _, lib = await _make_library(session)
+    payload = BarcodeMapBulkCreate(
+        entries=[
+            BarcodeMapCreate(
+                barcode_type="sgrna", sequence="AAAAAA", name="g1", read_position="R1"
+            ),
+            BarcodeMapCreate(
+                barcode_type="sgrna", sequence="CCCCCC", name="g2", read_position="R1"
+            ),
+        ]
+    )
+    rows = await BarcodeService.bulk_create_barcode_maps(session, org.id, lib.id, payload)
+    await session.commit()
+    assert len(rows) == 2
+    assert {r.name for r in rows} == {"g1", "g2"}

--- a/backend/tests/test_barcode_service.py
+++ b/backend/tests/test_barcode_service.py
@@ -74,9 +74,7 @@ async def test_lookup_by_sequence_returns_matches(session):
     from app.schemas.barcode_map import BarcodeMapCreate
     from app.services.barcode_service import BarcodeService
 
-    org, _, lib = await _make_library(
-        session, index_type="dual", i5_sequence="TTTT", i7_sequence="AAAA"
-    )
+    org, _, lib = await _make_library(session, index_type="dual", i5_sequence="TTTT", i7_sequence="AAAA")
     await BarcodeService.create_barcode_map(
         session,
         org.id,
@@ -89,9 +87,7 @@ async def test_lookup_by_sequence_returns_matches(session):
     matches = await BarcodeService.lookup_by_sequence(session, org.id, "aaaa")
     assert any(m.sequence == "AAAA" and m.barcode_type == "library_index" for m in matches)
 
-    filtered = await BarcodeService.lookup_by_sequence(
-        session, org.id, "GGGG", barcode_type="hashtag"
-    )
+    filtered = await BarcodeService.lookup_by_sequence(session, org.id, "GGGG", barcode_type="hashtag")
     assert len(filtered) == 1
     assert filtered[0].name == "HT-A"
 
@@ -102,9 +98,7 @@ async def test_lookup_is_org_scoped(session):
     from app.models.sample import Sample
     from app.services.barcode_service import BarcodeService
 
-    org_a, _, lib_a = await _make_library(
-        session, index_type="single", i7_sequence="AAAA"
-    )
+    org_a, _, lib_a = await _make_library(session, index_type="single", i7_sequence="AAAA")
     # Other org with colliding sequence.
     org_b = Organization(name="Other BC Org", setup_complete=True)
     session.add(org_b)
@@ -115,9 +109,7 @@ async def test_lookup_is_org_scoped(session):
     sample_b = Sample(experiment_id=exp_b.id)
     session.add(sample_b)
     await session.flush()
-    await _make_library(
-        session, org=org_b, sample=sample_b, index_type="single", i7_sequence="AAAA"
-    )
+    await _make_library(session, org=org_b, sample=sample_b, index_type="single", i7_sequence="AAAA")
 
     matches_a = await BarcodeService.lookup_by_sequence(session, org_a.id, "AAAA")
     for m in matches_a:
@@ -133,9 +125,7 @@ async def test_detect_collisions_in_batch(session):
     from app.services.barcode_service import BarcodeService
     from app.services.library_service import LibraryService
 
-    org, seed_sample, _ = await _make_library(
-        session, index_type="dual", i5_sequence="TTTT", i7_sequence="AAAA"
-    )
+    org, seed_sample, _ = await _make_library(session, index_type="dual", i5_sequence="TTTT", i7_sequence="AAAA")
 
     batch = SequencingBatch(organization_id=org.id, code="BC-1", status="pending")
     session.add(batch)
@@ -205,12 +195,8 @@ async def test_bulk_create_barcode_maps(session):
     org, _, lib = await _make_library(session)
     payload = BarcodeMapBulkCreate(
         entries=[
-            BarcodeMapCreate(
-                barcode_type="sgrna", sequence="AAAAAA", name="g1", read_position="R1"
-            ),
-            BarcodeMapCreate(
-                barcode_type="sgrna", sequence="CCCCCC", name="g2", read_position="R1"
-            ),
+            BarcodeMapCreate(barcode_type="sgrna", sequence="AAAAAA", name="g1", read_position="R1"),
+            BarcodeMapCreate(barcode_type="sgrna", sequence="CCCCCC", name="g2", read_position="R1"),
         ]
     )
     rows = await BarcodeService.bulk_create_barcode_maps(session, org.id, lib.id, payload)

--- a/backend/tests/test_libraries_api.py
+++ b/backend/tests/test_libraries_api.py
@@ -37,7 +37,6 @@ async def _create_sample(client, token, experiment_id: int) -> int:
 
 
 async def test_create_library_via_api(client, admin_token, session):
-    from app.models import Library
 
     exp_id = await _create_experiment(client, admin_token)
     sample_id = await _create_sample(client, admin_token, exp_id)
@@ -70,9 +69,7 @@ async def test_create_library_via_api(client, admin_token, session):
     assert positions == {"I1": "GCATACGA", "I2": "AAGTCCGT"}
 
 
-async def test_viewer_cannot_create_library(
-    client, admin_token, viewer_token
-):
+async def test_viewer_cannot_create_library(client, admin_token, viewer_token):
     exp_id = await _create_experiment(client, admin_token)
     sample_id = await _create_sample(client, admin_token, exp_id)
     r = await client.post(
@@ -219,9 +216,7 @@ async def test_batch_collision_endpoint(client, admin_token, session):
     from app.models.user import User
 
     admin = (await session.execute(select(User).limit(1))).scalar_one()
-    batch = SequencingBatch(
-        organization_id=admin.organization_id, code="COL-1", status="pending"
-    )
+    batch = SequencingBatch(organization_id=admin.organization_id, code="COL-1", status="pending")
     session.add(batch)
     await session.flush()
     await session.commit()
@@ -258,9 +253,7 @@ async def test_batch_collision_endpoint(client, admin_token, session):
 # --- 3. Lineage traversal ---
 
 
-async def test_upstream_lineage_file_to_library_to_sample_to_experiment(
-    client, admin_token, session
-):
+async def test_upstream_lineage_file_to_library_to_sample_to_experiment(client, admin_token, session):
     from app.models import File
 
     exp_id = await _create_experiment(client, admin_token)
@@ -308,9 +301,7 @@ async def test_upstream_lineage_file_to_library_to_sample_to_experiment(
     assert exp_row.id == exp_id
 
 
-async def test_downstream_lineage_sample_to_libraries_to_files(
-    client, admin_token, session
-):
+async def test_downstream_lineage_sample_to_libraries_to_files(client, admin_token, session):
     from app.models import File
     from sqlalchemy.orm import selectinload
 
@@ -370,9 +361,7 @@ async def test_downstream_lineage_sample_to_libraries_to_files(
     from app.models.library import Library
 
     lib_row = (
-        await session.execute(
-            select(Library).options(selectinload(Library.files)).where(Library.id == lib_a["id"])
-        )
+        await session.execute(select(Library).options(selectinload(Library.files)).where(Library.id == lib_a["id"]))
     ).scalar_one()
     assert [lf.id for lf in lib_row.files] == [f.id]
 

--- a/backend/tests/test_libraries_api.py
+++ b/backend/tests/test_libraries_api.py
@@ -1,0 +1,401 @@
+"""API tests for Library and BarcodeMap endpoints (issue #233 §8).
+
+Covers the three mandatory scenarios from the issue:
+  1. Creation via API (RBAC + org scoping).
+  2. Lookup by barcode.
+  3. Lineage traversal (upstream: File -> Library -> Sample -> Experiment;
+     downstream: Sample -> Libraries -> Files).
+"""
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_experiment(client, token) -> int:
+    r = await client.post(
+        "/api/experiments",
+        json={"name": "Lib API Exp"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _create_sample(client, token, experiment_id: int) -> int:
+    r = await client.post(
+        f"/api/experiments/{experiment_id}/samples",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+# --- 1. Creation ---
+
+
+async def test_create_library_via_api(client, admin_token, session):
+    from app.models import Library
+
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+
+    r = await client.post(
+        "/api/libraries",
+        json={
+            "sample_id": sample_id,
+            "library_id_external": "LIB-API-001",
+            "index_type": "dual",
+            "i5_sequence": "aagtccgt",
+            "i7_sequence": "GCATACGA",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["library_id_external"] == "LIB-API-001"
+    assert data["i5_sequence"] == "AAGTCCGT"
+    assert data["i7_sequence"] == "GCATACGA"
+    assert data["status"] == "planned"
+
+    # library_index BarcodeMaps auto-created.
+    list_r = await client.get(
+        f"/api/libraries/{data['id']}/barcodes?barcode_type=library_index",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert list_r.status_code == 200
+    positions = {b["read_position"]: b["sequence"] for b in list_r.json()}
+    assert positions == {"I1": "GCATACGA", "I2": "AAGTCCGT"}
+
+
+async def test_viewer_cannot_create_library(
+    client, admin_token, viewer_token
+):
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+    r = await client.post(
+        "/api/libraries",
+        json={"sample_id": sample_id},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 403
+
+
+async def test_viewer_can_read_library(client, admin_token, viewer_token):
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+    create_r = await client.post(
+        "/api/libraries",
+        json={"sample_id": sample_id},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert create_r.status_code == 200
+    lib_id = create_r.json()["id"]
+
+    get_r = await client.get(
+        f"/api/libraries/{lib_id}",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert get_r.status_code == 200
+
+
+async def test_create_library_rejects_invalid_sequence(client, admin_token):
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+    r = await client.post(
+        "/api/libraries",
+        json={
+            "sample_id": sample_id,
+            "index_type": "single",
+            "i7_sequence": "BADSEQ!",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 422
+
+
+async def test_create_barcode_via_api(client, admin_token):
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+    lib = (
+        await client.post(
+            "/api/libraries",
+            json={"sample_id": sample_id},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    ).json()
+
+    r = await client.post(
+        f"/api/libraries/{lib['id']}/barcodes",
+        json={
+            "barcode_type": "sgrna",
+            "sequence": "ATCGATCG",
+            "name": "guide-1",
+            "read_position": "R1",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["sequence"] == "ATCGATCG"
+
+
+# --- 2. Lookup by barcode ---
+
+
+async def test_lookup_barcode_by_sequence(client, admin_token):
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+    lib = (
+        await client.post(
+            "/api/libraries",
+            json={
+                "sample_id": sample_id,
+                "index_type": "dual",
+                "i5_sequence": "AAAA",
+                "i7_sequence": "TTTT",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    ).json()
+
+    r = await client.get(
+        "/api/barcodes/lookup?sequence=tttt",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    matches = r.json()
+    assert any(m["library_id"] == lib["id"] and m["sequence"] == "TTTT" for m in matches)
+
+
+async def test_lookup_org_scoped(client, admin_token, session):
+    """A sequence registered in another org must not surface."""
+    from app.models import BarcodeMap
+    from app.models.experiment import Experiment
+    from app.models.library import Library
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+
+    other_org = Organization(name="Other Tenant", setup_complete=True)
+    session.add(other_org)
+    await session.flush()
+    exp = Experiment(name="other", organization_id=other_org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    lib = Library(
+        organization_id=other_org.id,
+        sample_id=sample.id,
+        i7_sequence="GGGGCCCC",
+    )
+    session.add(lib)
+    await session.flush()
+    session.add(
+        BarcodeMap(
+            organization_id=other_org.id,
+            library_id=lib.id,
+            barcode_type="library_index",
+            sequence="GGGGCCCC",
+            read_position="I1",
+        )
+    )
+    await session.commit()
+
+    r = await client.get(
+        "/api/barcodes/lookup?sequence=GGGGCCCC",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+async def test_batch_collision_endpoint(client, admin_token, session):
+    from app.models.sequencing_batch import SequencingBatch
+
+    # Seed batch within the admin's org.
+    from app.models.user import User
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+    batch = SequencingBatch(
+        organization_id=admin.organization_id, code="COL-1", status="pending"
+    )
+    session.add(batch)
+    await session.flush()
+    await session.commit()
+
+    exp_id = await _create_experiment(client, admin_token)
+    sample_a = await _create_sample(client, admin_token, exp_id)
+    sample_b = await _create_sample(client, admin_token, exp_id)
+
+    for sid in (sample_a, sample_b):
+        r = await client.post(
+            "/api/libraries",
+            json={
+                "sample_id": sid,
+                "index_type": "dual",
+                "i5_sequence": "AAAA",
+                "i7_sequence": "CCCC",
+                "sequencing_batch_id": batch.id,
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200, r.text
+
+    r = await client.get(
+        f"/api/sequencing-batches/{batch.id}/barcode-collisions",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    collisions = r.json()
+    assert len(collisions) == 1
+    assert collisions[0]["i5_sequence"] == "AAAA"
+    assert collisions[0]["i7_sequence"] == "CCCC"
+
+
+# --- 3. Lineage traversal ---
+
+
+async def test_upstream_lineage_file_to_library_to_sample_to_experiment(
+    client, admin_token, session
+):
+    from app.models import File
+
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+    lib = (
+        await client.post(
+            "/api/libraries",
+            json={"sample_id": sample_id},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    ).json()
+
+    from app.models.user import User
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+    f = File(
+        organization_id=admin.organization_id,
+        gcs_uri="gs://test/lineage.fq.gz",
+        filename="lineage.fq.gz",
+        file_type="fastq",
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+
+    attach_r = await client.post(
+        f"/api/libraries/{lib['id']}/files/{f.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert attach_r.status_code == 200
+
+    # Re-read File fresh from DB to traverse up to Experiment.
+    from app.models.experiment import Experiment
+    from app.models.library import Library
+    from app.models.sample import Sample
+
+    file_row = await session.get(File, f.id)
+    await session.refresh(file_row)
+    assert file_row.library_id == lib["id"]
+
+    lib_row = await session.get(Library, file_row.library_id)
+    sample_row = await session.get(Sample, lib_row.sample_id)
+    exp_row = await session.get(Experiment, sample_row.experiment_id)
+    assert sample_row.id == sample_id
+    assert exp_row.id == exp_id
+
+
+async def test_downstream_lineage_sample_to_libraries_to_files(
+    client, admin_token, session
+):
+    from app.models import File
+    from sqlalchemy.orm import selectinload
+
+    exp_id = await _create_experiment(client, admin_token)
+    sample_id = await _create_sample(client, admin_token, exp_id)
+
+    lib_a = (
+        await client.post(
+            "/api/libraries",
+            json={
+                "sample_id": sample_id,
+                "library_id_external": "DS-A",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    ).json()
+    lib_b = (
+        await client.post(
+            "/api/libraries",
+            json={
+                "sample_id": sample_id,
+                "library_id_external": "DS-B",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    ).json()
+
+    list_r = await client.get(
+        f"/api/samples/{sample_id}/libraries",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert list_r.status_code == 200
+    ids = {lib["id"] for lib in list_r.json()}
+    assert ids == {lib_a["id"], lib_b["id"]}
+
+    # Attach a file to lib_a.
+    from app.models.user import User
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+    f = File(
+        organization_id=admin.organization_id,
+        gcs_uri="gs://test/ds.fq.gz",
+        filename="ds.fq.gz",
+        file_type="fastq",
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+
+    attach_r = await client.post(
+        f"/api/libraries/{lib_a['id']}/files/{f.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert attach_r.status_code == 200
+
+    # Sample -> Library.files traversal.
+    from app.models.library import Library
+
+    lib_row = (
+        await session.execute(
+            select(Library).options(selectinload(Library.files)).where(Library.id == lib_a["id"])
+        )
+    ).scalar_one()
+    assert [lf.id for lf in lib_row.files] == [f.id]
+
+
+async def test_experiment_libraries_endpoint(client, admin_token):
+    exp_id = await _create_experiment(client, admin_token)
+    s1 = await _create_sample(client, admin_token, exp_id)
+    s2 = await _create_sample(client, admin_token, exp_id)
+    await client.post(
+        "/api/libraries",
+        json={"sample_id": s1, "library_id_external": "EX-A"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    await client.post(
+        "/api/libraries",
+        json={"sample_id": s2, "library_id_external": "EX-B"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    r = await client.get(
+        f"/api/experiments/{exp_id}/libraries",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    externals = sorted(lib["library_id_external"] for lib in r.json())
+    assert externals == ["EX-A", "EX-B"]

--- a/backend/tests/test_library_model.py
+++ b/backend/tests/test_library_model.py
@@ -1,0 +1,105 @@
+"""Tests for the Library model (issue #233)."""
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_org_and_experiment(session):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+
+    org = Organization(name="Lib Test Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+
+    exp = Experiment(name="Lib Test Experiment", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    return org, exp
+
+
+async def _create_sample(session, experiment_id):
+    from app.models.sample import Sample
+
+    sample = Sample(experiment_id=experiment_id)
+    session.add(sample)
+    await session.flush()
+    return sample
+
+
+async def test_library_model_is_registered():
+    """Library must be importable from app.models."""
+    from app.models import Library
+
+    assert Library.__tablename__ == "libraries"
+
+
+async def test_create_library_with_required_fields(session):
+    from app.models import Library
+
+    org, exp = await _create_org_and_experiment(session)
+    sample = await _create_sample(session, exp.id)
+
+    lib = Library(organization_id=org.id, sample_id=sample.id)
+    session.add(lib)
+    await session.flush()
+
+    assert lib.id is not None
+    # Defaults per spec §3.1
+    assert lib.status == "planned"
+    assert lib.index_type == "none"
+
+
+async def test_library_stores_prep_and_index_metadata(session):
+    from app.models import Library
+
+    org, exp = await _create_org_and_experiment(session)
+    sample = await _create_sample(session, exp.id)
+
+    lib = Library(
+        organization_id=org.id,
+        sample_id=sample.id,
+        library_id_external="LIB-001",
+        prep_kit="TruSeq RNA v2",
+        assay_type="rna-seq",
+        read_layout="paired",
+        target_read_length=150,
+        index_type="dual",
+        i5_sequence="AAGTCCGT",
+        i7_sequence="GCATACGA",
+        i5_orientation_convention="reverse_complement",
+        insert_size_mean=350,
+        molarity_nm=Decimal("4.500"),
+        qc_status="pass",
+    )
+    session.add(lib)
+    await session.flush()
+
+    fetched = (await session.execute(select(Library).where(Library.id == lib.id))).scalar_one()
+    assert fetched.library_id_external == "LIB-001"
+    assert fetched.prep_kit == "TruSeq RNA v2"
+    assert fetched.i5_sequence == "AAGTCCGT"
+    assert fetched.i7_sequence == "GCATACGA"
+    assert fetched.i5_orientation_convention == "reverse_complement"
+    assert fetched.index_type == "dual"
+
+
+async def test_library_external_id_unique_per_org(session):
+    """Per §3.1: UniqueConstraint on (organization_id, library_id_external)."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models import Library
+
+    org, exp = await _create_org_and_experiment(session)
+    sample = await _create_sample(session, exp.id)
+
+    session.add(Library(organization_id=org.id, sample_id=sample.id, library_id_external="DUP"))
+    await session.flush()
+
+    session.add(Library(organization_id=org.id, sample_id=sample.id, library_id_external="DUP"))
+    with pytest.raises(IntegrityError):
+        await session.flush()

--- a/backend/tests/test_library_relationships.py
+++ b/backend/tests/test_library_relationships.py
@@ -1,0 +1,135 @@
+"""Tests for Sample.libraries and File.library relationships (issue #233 §3.3, §3.4)."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup(session):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+
+    org = Organization(name="Rel Test Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Rel Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    return org, sample
+
+
+async def test_sample_has_libraries_relationship(session):
+    from app.models import Library, Sample
+
+    org, sample = await _setup(session)
+    session.add(Library(organization_id=org.id, sample_id=sample.id, library_id_external="A"))
+    session.add(Library(organization_id=org.id, sample_id=sample.id, library_id_external="B"))
+    await session.flush()
+
+    fetched = (
+        await session.execute(
+            select(Sample).options(selectinload(Sample.libraries)).where(Sample.id == sample.id)
+        )
+    ).scalar_one()
+    external_ids = sorted(lib.library_id_external for lib in fetched.libraries)
+    assert external_ids == ["A", "B"]
+
+
+async def test_file_library_id_nullable_and_relationship(session):
+    from app.models import File, Library
+
+    org, sample = await _setup(session)
+    lib = Library(organization_id=org.id, sample_id=sample.id, library_id_external="L1")
+    session.add(lib)
+    await session.flush()
+
+    f_linked = File(
+        organization_id=org.id,
+        gcs_uri="gs://test/a.fastq.gz",
+        filename="a.fastq.gz",
+        file_type="fastq",
+        library_id=lib.id,
+    )
+    f_unlinked = File(
+        organization_id=org.id,
+        gcs_uri="gs://test/b.fastq.gz",
+        filename="b.fastq.gz",
+        file_type="fastq",
+    )
+    session.add_all([f_linked, f_unlinked])
+    await session.flush()
+
+    fetched_linked = (
+        await session.execute(
+            select(File).options(selectinload(File.library)).where(File.id == f_linked.id)
+        )
+    ).scalar_one()
+    fetched_unlinked = (
+        await session.execute(select(File).where(File.id == f_unlinked.id))
+    ).scalar_one()
+
+    assert fetched_linked.library_id == lib.id
+    assert fetched_linked.library.id == lib.id
+    assert fetched_unlinked.library_id is None
+
+
+async def test_library_files_backref(session):
+    from app.models import File, Library
+
+    org, sample = await _setup(session)
+    lib = Library(organization_id=org.id, sample_id=sample.id, library_id_external="L2")
+    session.add(lib)
+    await session.flush()
+
+    session.add(
+        File(
+            organization_id=org.id,
+            gcs_uri="gs://test/c.fastq.gz",
+            filename="c.fastq.gz",
+            file_type="fastq",
+            library_id=lib.id,
+        )
+    )
+    await session.flush()
+
+    fetched = (
+        await session.execute(
+            select(Library).options(selectinload(Library.files)).where(Library.id == lib.id)
+        )
+    ).scalar_one()
+    assert len(fetched.files) == 1
+    assert fetched.files[0].filename == "c.fastq.gz"
+
+
+async def test_sample_deletion_cascades_to_libraries_but_not_files(session):
+    """Per §8: Sample -> Libraries cascades; Files outlive their libraries."""
+    from app.models import File, Library, Sample
+
+    org, sample = await _setup(session)
+    lib = Library(organization_id=org.id, sample_id=sample.id, library_id_external="LX")
+    session.add(lib)
+    await session.flush()
+    f = File(
+        organization_id=org.id,
+        gcs_uri="gs://test/d.fastq.gz",
+        filename="d.fastq.gz",
+        file_type="fastq",
+        library_id=lib.id,
+    )
+    session.add(f)
+    await session.flush()
+    file_id = f.id
+    lib_id = lib.id
+
+    await session.delete(await session.get(Sample, sample.id))
+    await session.flush()
+
+    assert await session.get(Library, lib_id) is None
+    surviving_file = await session.get(File, file_id)
+    assert surviving_file is not None

--- a/backend/tests/test_library_relationships.py
+++ b/backend/tests/test_library_relationships.py
@@ -33,9 +33,7 @@ async def test_sample_has_libraries_relationship(session):
     await session.flush()
 
     fetched = (
-        await session.execute(
-            select(Sample).options(selectinload(Sample.libraries)).where(Sample.id == sample.id)
-        )
+        await session.execute(select(Sample).options(selectinload(Sample.libraries)).where(Sample.id == sample.id))
     ).scalar_one()
     external_ids = sorted(lib.library_id_external for lib in fetched.libraries)
     assert external_ids == ["A", "B"]
@@ -66,13 +64,9 @@ async def test_file_library_id_nullable_and_relationship(session):
     await session.flush()
 
     fetched_linked = (
-        await session.execute(
-            select(File).options(selectinload(File.library)).where(File.id == f_linked.id)
-        )
+        await session.execute(select(File).options(selectinload(File.library)).where(File.id == f_linked.id))
     ).scalar_one()
-    fetched_unlinked = (
-        await session.execute(select(File).where(File.id == f_unlinked.id))
-    ).scalar_one()
+    fetched_unlinked = (await session.execute(select(File).where(File.id == f_unlinked.id))).scalar_one()
 
     assert fetched_linked.library_id == lib.id
     assert fetched_linked.library.id == lib.id
@@ -99,9 +93,7 @@ async def test_library_files_backref(session):
     await session.flush()
 
     fetched = (
-        await session.execute(
-            select(Library).options(selectinload(Library.files)).where(Library.id == lib.id)
-        )
+        await session.execute(select(Library).options(selectinload(Library.files)).where(Library.id == lib.id))
     ).scalar_one()
     assert len(fetched.files) == 1
     assert fetched.files[0].filename == "c.fastq.gz"

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -1,0 +1,200 @@
+"""Tests for LibraryService (issue #233 §6)."""
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup(session):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+
+    org = Organization(name="Svc Test Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Svc Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    await session.commit()
+    return org, exp, sample
+
+
+async def test_create_library_populates_library_index_barcodes(session):
+    """Per §8: dual-index library auto-creates two library_index BarcodeMap rows."""
+    from app.models import BarcodeMap
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, _, sample = await _setup(session)
+    payload = LibraryCreate(
+        sample_id=sample.id,
+        index_type="dual",
+        i5_sequence="aagtccgt",
+        i7_sequence="gcatacga",
+    )
+    lib = await LibraryService.create_library(session, org.id, payload)
+    await session.commit()
+
+    # Sequences canonicalised to uppercase.
+    assert lib.i5_sequence == "AAGTCCGT"
+    assert lib.i7_sequence == "GCATACGA"
+
+    rows = (
+        await session.execute(
+            select(BarcodeMap).where(
+                BarcodeMap.library_id == lib.id,
+                BarcodeMap.barcode_type == "library_index",
+            )
+        )
+    ).scalars().all()
+    by_position = {r.read_position: r.sequence for r in rows}
+    assert by_position == {"I1": "GCATACGA", "I2": "AAGTCCGT"}
+
+
+async def test_create_library_single_index_only_i7(session):
+    from app.models import BarcodeMap
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, _, sample = await _setup(session)
+    payload = LibraryCreate(
+        sample_id=sample.id,
+        index_type="single",
+        i7_sequence="GCATACGA",
+    )
+    lib = await LibraryService.create_library(session, org.id, payload)
+    await session.commit()
+
+    rows = (
+        await session.execute(
+            select(BarcodeMap).where(BarcodeMap.library_id == lib.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].read_position == "I1"
+    assert rows[0].sequence == "GCATACGA"
+
+
+async def test_create_library_rejects_invalid_sequence(session):
+    from fastapi import HTTPException
+
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, _, sample = await _setup(session)
+    payload = LibraryCreate(
+        sample_id=sample.id,
+        index_type="single",
+        i7_sequence="GCATxxACGA",
+    )
+    with pytest.raises(HTTPException) as exc:
+        await LibraryService.create_library(session, org.id, payload)
+    assert exc.value.status_code == 422
+
+
+async def test_update_library_rebuilds_library_index_rows(session):
+    """Per §8: updating index sequences rebuilds library_index rows idempotently."""
+    from app.models import BarcodeMap
+    from app.schemas.library import LibraryCreate, LibraryUpdate
+    from app.services.library_service import LibraryService
+
+    org, _, sample = await _setup(session)
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, index_type="single", i7_sequence="AAAA"),
+    )
+    await session.commit()
+
+    await LibraryService.update_library(
+        session,
+        org.id,
+        lib.id,
+        LibraryUpdate(index_type="dual", i5_sequence="TTTT", i7_sequence="CCCC"),
+    )
+    await session.commit()
+
+    rows = (
+        await session.execute(
+            select(BarcodeMap).where(
+                BarcodeMap.library_id == lib.id,
+                BarcodeMap.barcode_type == "library_index",
+            )
+        )
+    ).scalars().all()
+    by_position = {r.read_position: r.sequence for r in rows}
+    assert by_position == {"I1": "CCCC", "I2": "TTTT"}
+
+
+async def test_create_library_rejects_cross_org_sample(session):
+    from fastapi import HTTPException
+
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org_a, _, _ = await _setup(session)
+
+    org_b = Organization(name="Other Org", setup_complete=True)
+    session.add(org_b)
+    await session.flush()
+    exp_b = Experiment(name="Other Exp", organization_id=org_b.id)
+    session.add(exp_b)
+    await session.flush()
+    sample_b = Sample(experiment_id=exp_b.id)
+    session.add(sample_b)
+    await session.flush()
+    await session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await LibraryService.create_library(
+            session,
+            org_a.id,
+            LibraryCreate(sample_id=sample_b.id),
+        )
+    assert exc.value.status_code in (403, 404)
+
+
+async def test_attach_file_sets_library_and_sample_link(session):
+    """attach_file sets File.library_id and ensures sample_files link exists."""
+    from app.models import File
+    from app.models.sample import sample_files
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, _, sample = await _setup(session)
+    lib = await LibraryService.create_library(
+        session, org.id, LibraryCreate(sample_id=sample.id)
+    )
+    f = File(
+        organization_id=org.id,
+        gcs_uri="gs://x/a.fq.gz",
+        filename="a.fq.gz",
+        file_type="fastq",
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+
+    await LibraryService.attach_file(session, org.id, lib.id, f.id)
+    await session.commit()
+
+    updated = await session.get(File, f.id)
+    assert updated.library_id == lib.id
+
+    links = (
+        await session.execute(
+            select(sample_files).where(
+                sample_files.c.file_id == f.id,
+                sample_files.c.sample_id == sample.id,
+            )
+        )
+    ).all()
+    assert len(links) == 1

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -45,13 +45,17 @@ async def test_create_library_populates_library_index_barcodes(session):
     assert lib.i7_sequence == "GCATACGA"
 
     rows = (
-        await session.execute(
-            select(BarcodeMap).where(
-                BarcodeMap.library_id == lib.id,
-                BarcodeMap.barcode_type == "library_index",
+        (
+            await session.execute(
+                select(BarcodeMap).where(
+                    BarcodeMap.library_id == lib.id,
+                    BarcodeMap.barcode_type == "library_index",
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     by_position = {r.read_position: r.sequence for r in rows}
     assert by_position == {"I1": "GCATACGA", "I2": "AAGTCCGT"}
 
@@ -70,11 +74,7 @@ async def test_create_library_single_index_only_i7(session):
     lib = await LibraryService.create_library(session, org.id, payload)
     await session.commit()
 
-    rows = (
-        await session.execute(
-            select(BarcodeMap).where(BarcodeMap.library_id == lib.id)
-        )
-    ).scalars().all()
+    rows = (await session.execute(select(BarcodeMap).where(BarcodeMap.library_id == lib.id))).scalars().all()
     assert len(rows) == 1
     assert rows[0].read_position == "I1"
     assert rows[0].sequence == "GCATACGA"
@@ -120,13 +120,17 @@ async def test_update_library_rebuilds_library_index_rows(session):
     await session.commit()
 
     rows = (
-        await session.execute(
-            select(BarcodeMap).where(
-                BarcodeMap.library_id == lib.id,
-                BarcodeMap.barcode_type == "library_index",
+        (
+            await session.execute(
+                select(BarcodeMap).where(
+                    BarcodeMap.library_id == lib.id,
+                    BarcodeMap.barcode_type == "library_index",
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     by_position = {r.read_position: r.sequence for r in rows}
     assert by_position == {"I1": "CCCC", "I2": "TTTT"}
 
@@ -170,9 +174,7 @@ async def test_attach_file_sets_library_and_sample_link(session):
     from app.services.library_service import LibraryService
 
     org, _, sample = await _setup(session)
-    lib = await LibraryService.create_library(
-        session, org.id, LibraryCreate(sample_id=sample.id)
-    )
+    lib = await LibraryService.create_library(session, org.id, LibraryCreate(sample_id=sample.id))
     f = File(
         organization_id=org.id,
         gcs_uri="gs://x/a.fq.gz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Introduces the `Library` entity (between Sample and File) and the `BarcodeMap` table (library indices + intra-library variant barcodes), plus a nullable `files.library_id` FK. Migration is additive; no data is modified or backfilled
- Backend-only: services, Pydantic schemas, FastAPI routes, new `libraries` permission resource wired into admin / comp_bio / bench / viewer roles. Sequence canonicalisation and collision detection live in the service layer
- **No user-visible changes in this release.** This lays the foundation for a near-future release adding Library and Barcode support to the UI

Implements GitHub issue #233 per `documentation/spec-library-barcode-mapping.md`.

## Test plan

- [x] Backend tests: 1832 passed (`pytest -x -q`)
- [x] Frontend tests: 412 passed (`npm test`)
- [x] ruff format + ruff check: clean
- [x] mypy: clean across 606 files
- [x] frontend tsc: clean
- [x] markdownlint on `decisions/`, `docs/`, `docs/guides/`: clean
- [x] Migration 067 upgrade + downgrade both verified against a fresh test DB
- [ ] Manual API smoke via `/docs` if desired: create a Library, attach a File, hit `/api/barcodes/lookup`, verify `/api/sequencing-batches/{id}/barcode-collisions`