### PR TITLE
v0.8.1: Library/Barcode operational completeness (#244)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
 # Release Notes
 
+## v0.8.1
+
+Library and BarcodeMap operational completeness. No user-visible changes in this release.
+
+Second backend-only update building on the v0.8.0 data model. Adds the services, permissions, and edge-case handling the Library / Barcode feature needs before the UI ships. Current installs will see no new screens, menus, or workflows.
+
+### Backend
+
+- **Demux reconciliation**: new `POST /api/sequencing-batches/{id}/reconcile` walks unlinked files in a batch, extracts library identifiers from filenames, and sets `File.library_id` on unambiguous matches. Handles bcl-convert / bcl2fastq defaults and exposes a configurable regex override at the `demux.filename_pattern` platform config key. Re-runs are idempotent.
+- **Library backfill wizard (backend)**: preview-then-commit backfill for legacy Sample -> File data. `POST /api/experiments/{id}/backfill-libraries/preview` shows the plan; `.../commit` applies it. One Library per sample without one, Sample prep columns carried forward, existing `sample_files` links attached. Skips samples that already have a library; re-runs are a no-op.
+- **Fuzzy barcode lookup**: new `GET /api/barcodes/fuzzy-lookup?sequence=&max_mismatches=` returns hits within Hamming distance 0, 1, or 2. Short-barcode neighbour enumeration path for sequences up to 16bp; longer sequences are supported at exact match only.
+- **Sample column deprecation path**: `SampleService.get_prep_metadata` prefers Library fields and falls back to the legacy `Sample.library_prep_method` / `Sample.library_layout` when no Library exists. Writes to the deprecated Sample columns now emit a `bioaf.sample_deprecation` warning log. No columns dropped.
+- **i5 orientation inference**: Library creation now infers `i5_orientation_convention` from the linked sequencing batch's instrument model (NovaSeq / NextSeq / iSeq / HiSeq 3000+4000 => reverse_complement; MiSeq / HiSeq 1500+2000+2500 => forward). User-supplied values always win.
+- **Index hopping tracking**: new nullable `libraries.expected_contamination_pct` column. Default inferred per sequencer model (NovaSeq 0.5%, NextSeq 2000 1.0%, MiSeq 0.05%, etc).
+- **UMI / pattern-only barcode clarity**: new `barcode_maps.is_pattern_only` boolean distinguishes positional patterns (UMIs) from explicit-sequence rows, with stricter validation on either side.
+- **Sample swap detection (data model + API)**: new `sample_swap_checks` table records per-library attribute mismatches (wrong species, wrong donor sex, etc) with resolution tracking. Endpoints at `GET/POST /api/libraries/{id}/swap-checks` and `PATCH /api/swap-checks/{id}/resolve`. Pipeline step that detects swaps is out of scope.
+- **Barcode permission split**: new `barcodes` resource (view / create / edit / delete) gates every barcode-write endpoint, so bench users can create library-index rows without being granted full `libraries:edit`.
+- **Pre-demux ingest scaffolding**: new `ingest.pre_demux_enabled` platform config key (default false). Provides the hook for future multi-library attribution; no behaviour changes in this release.
+
+### Database
+
+- Migration `068` adds `libraries.expected_contamination_pct`.
+- Migration `069` adds `barcode_maps.is_pattern_only`.
+- Migration `070` creates the `sample_swap_checks` table.
+
+All three migrations are additive and independently reversible.
+
 ## v0.8.0
 
 Library and BarcodeMap data model groundwork. No user-visible changes in this release.

--- a/backend/alembic/versions/068_add_library_expected_contamination_pct.py
+++ b/backend/alembic/versions/068_add_library_expected_contamination_pct.py
@@ -1,0 +1,27 @@
+"""Add expected_contamination_pct column to libraries.
+
+Revision ID: 068
+Revises: 067
+Create Date: 2026-04-15
+
+Records the expected index-hopping rate for a library, either inferred
+from the sequencer model at create time or set by the caller. Additive,
+nullable column.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "068"
+down_revision = "067"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "libraries",
+        sa.Column("expected_contamination_pct", sa.Numeric(5, 3), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("libraries", "expected_contamination_pct")

--- a/backend/alembic/versions/069_add_barcode_map_is_pattern_only.py
+++ b/backend/alembic/versions/069_add_barcode_map_is_pattern_only.py
@@ -1,0 +1,32 @@
+"""Add is_pattern_only column to barcode_maps.
+
+Revision ID: 069
+Revises: 068
+Create Date: 2026-04-15
+
+Distinguishes pattern-only barcode rows (UMIs and other positional
+patterns with no concrete sequence) from explicit-sequence rows. Additive,
+nullable column with default false so existing rows remain interpretable.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "069"
+down_revision = "068"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "barcode_maps",
+        sa.Column(
+            "is_pattern_only",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("barcode_maps", "is_pattern_only")

--- a/backend/alembic/versions/070_add_sample_swap_checks.py
+++ b/backend/alembic/versions/070_add_sample_swap_checks.py
@@ -67,7 +67,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "idx_sample_swap_checks_library_id", table_name="sample_swap_checks"
-    )
+    op.drop_index("idx_sample_swap_checks_library_id", table_name="sample_swap_checks")
     op.drop_table("sample_swap_checks")

--- a/backend/alembic/versions/070_add_sample_swap_checks.py
+++ b/backend/alembic/versions/070_add_sample_swap_checks.py
@@ -1,0 +1,73 @@
+"""Add sample_swap_checks table.
+
+Revision ID: 070
+Revises: 069
+Create Date: 2026-04-15
+
+Records per-library attribute mismatches surfaced by post-ingest QC
+(species-ID, XIST/Y-chromosome calls, etc). The pipeline step that
+populates these rows is tracked separately; this migration only adds
+the table and supporting index.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "070"
+down_revision = "069"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sample_swap_checks",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column(
+            "organization_id",
+            sa.Integer(),
+            sa.ForeignKey("organizations.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "library_id",
+            sa.Integer(),
+            sa.ForeignKey("libraries.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "run_id",
+            sa.Integer(),
+            sa.ForeignKey("pipeline_runs.id"),
+            nullable=True,
+        ),
+        sa.Column("expected_attribute", sa.String(length=255), nullable=False),
+        sa.Column("observed_attribute", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("evidence_json", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "resolved_by_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+        sa.Column("resolution_notes", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "idx_sample_swap_checks_library_id",
+        "sample_swap_checks",
+        ["library_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_sample_swap_checks_library_id", table_name="sample_swap_checks"
+    )
+    op.drop_table("sample_swap_checks")

--- a/backend/app/api/barcode_maps.py
+++ b/backend/app/api/barcode_maps.py
@@ -5,6 +5,7 @@ from app.api.dependencies import require_permission
 from app.database import get_session
 from app.schemas.barcode_map import (
     BarcodeCollisionEntry,
+    BarcodeFuzzyMatch,
     BarcodeMapBulkCreate,
     BarcodeMapCreate,
     BarcodeMapResponse,
@@ -69,6 +70,32 @@ async def lookup_barcode(
     org_id = int(current_user["org_id"])
     rows = await BarcodeService.lookup_by_sequence(session, org_id, sequence, barcode_type)
     return [BarcodeMapResponse.model_validate(r) for r in rows]
+
+
+@router.get("/api/barcodes/fuzzy-lookup", response_model=list[BarcodeFuzzyMatch])
+async def fuzzy_lookup_barcode(
+    sequence: str = Query(...),
+    barcode_type: str | None = Query(default=None),
+    max_mismatches: int = Query(default=1, ge=0, le=2),
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    pairs = await BarcodeService.fuzzy_lookup(
+        session, org_id, sequence, barcode_type, max_mismatches
+    )
+    return [
+        BarcodeFuzzyMatch(
+            id=row.id,
+            organization_id=row.organization_id,
+            library_id=row.library_id,
+            barcode_type=row.barcode_type,
+            sequence=row.sequence or "",
+            name=row.name,
+            distance=distance,
+        )
+        for row, distance in pairs
+    ]
 
 
 @router.get(

--- a/backend/app/api/barcode_maps.py
+++ b/backend/app/api/barcode_maps.py
@@ -81,9 +81,7 @@ async def fuzzy_lookup_barcode(
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
-    pairs = await BarcodeService.fuzzy_lookup(
-        session, org_id, sequence, barcode_type, max_mismatches
-    )
+    pairs = await BarcodeService.fuzzy_lookup(session, org_id, sequence, barcode_type, max_mismatches)
     return [
         BarcodeFuzzyMatch(
             id=row.id,
@@ -122,8 +120,6 @@ async def reconcile_batch(
 ):
     org_id = int(current_user["org_id"])
     user_id = int(current_user["sub"])
-    report = await DemuxReconciliationService.reconcile_batch(
-        session, org_id, batch_id, user_id=user_id
-    )
+    report = await DemuxReconciliationService.reconcile_batch(session, org_id, batch_id, user_id=user_id)
     await session.commit()
     return report

--- a/backend/app/api/barcode_maps.py
+++ b/backend/app/api/barcode_maps.py
@@ -23,7 +23,7 @@ router = APIRouter(tags=["barcode_maps"])
 async def create_barcode(
     library_id: int,
     body: BarcodeMapCreate,
-    current_user: dict = require_permission("libraries", "edit"),
+    current_user: dict = require_permission("barcodes", "create"),
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
@@ -39,7 +39,7 @@ async def create_barcode(
 async def bulk_create_barcodes(
     library_id: int,
     body: BarcodeMapBulkCreate,
-    current_user: dict = require_permission("libraries", "edit"),
+    current_user: dict = require_permission("barcodes", "create"),
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
@@ -52,7 +52,7 @@ async def bulk_create_barcodes(
 async def list_barcodes(
     library_id: int,
     barcode_type: str | None = Query(default=None),
-    current_user: dict = require_permission("libraries", "view"),
+    current_user: dict = require_permission("barcodes", "view"),
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
@@ -64,7 +64,7 @@ async def list_barcodes(
 async def lookup_barcode(
     sequence: str = Query(...),
     barcode_type: str | None = Query(default=None),
-    current_user: dict = require_permission("libraries", "view"),
+    current_user: dict = require_permission("barcodes", "view"),
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
@@ -77,7 +77,7 @@ async def fuzzy_lookup_barcode(
     sequence: str = Query(...),
     barcode_type: str | None = Query(default=None),
     max_mismatches: int = Query(default=1, ge=0, le=2),
-    current_user: dict = require_permission("libraries", "view"),
+    current_user: dict = require_permission("barcodes", "view"),
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])

--- a/backend/app/api/barcode_maps.py
+++ b/backend/app/api/barcode_maps.py
@@ -10,6 +10,10 @@ from app.schemas.barcode_map import (
     BarcodeMapResponse,
 )
 from app.services.barcode_service import BarcodeService
+from app.services.demux_reconciliation_service import (
+    DemuxReconciliationService,
+    ReconciliationReport,
+)
 
 router = APIRouter(tags=["barcode_maps"])
 
@@ -78,3 +82,21 @@ async def list_batch_collisions(
 ):
     org_id = int(current_user["org_id"])
     return await BarcodeService.detect_collisions_in_batch(session, org_id, batch_id)
+
+
+@router.post(
+    "/api/sequencing-batches/{batch_id}/reconcile",
+    response_model=ReconciliationReport,
+)
+async def reconcile_batch(
+    batch_id: int,
+    current_user: dict = require_permission("libraries", "edit"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    report = await DemuxReconciliationService.reconcile_batch(
+        session, org_id, batch_id, user_id=user_id
+    )
+    await session.commit()
+    return report

--- a/backend/app/api/libraries.py
+++ b/backend/app/api/libraries.py
@@ -5,6 +5,11 @@ from app.api.dependencies import require_permission
 from app.database import get_session
 from app.models.library import Library
 from app.schemas.library import LibraryCreate, LibraryResponse, LibraryUpdate
+from app.services.library_backfill_service import (
+    BackfillPreview,
+    BackfillResult,
+    LibraryBackfillService,
+)
 from app.services.library_service import LibraryService
 
 router = APIRouter(tags=["libraries"])
@@ -99,3 +104,32 @@ async def attach_file(
     lib = await LibraryService.attach_file(session, org_id, library_id, file_id, user_id=user_id)
     await session.commit()
     return _response(lib)
+
+
+@router.post(
+    "/api/experiments/{experiment_id}/backfill-libraries/preview",
+    response_model=BackfillPreview,
+)
+async def preview_backfill(
+    experiment_id: int,
+    current_user: dict = require_permission("libraries", "create"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    return await LibraryBackfillService.preview(session, org_id, experiment_id)
+
+
+@router.post(
+    "/api/experiments/{experiment_id}/backfill-libraries/commit",
+    response_model=BackfillResult,
+)
+async def commit_backfill(
+    experiment_id: int,
+    current_user: dict = require_permission("libraries", "create"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    result = await LibraryBackfillService.commit(session, org_id, experiment_id, user_id=user_id)
+    await session.commit()
+    return result

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -65,6 +65,7 @@ from app.api.experiment_auto_runs import router as experiment_auto_runs_router
 from app.api.content_tokens import router as content_tokens_router
 from app.api.libraries import router as libraries_router
 from app.api.barcode_maps import router as barcode_maps_router
+from app.api.sample_swap_checks import router as sample_swap_checks_router
 
 api_router = APIRouter()
 
@@ -133,3 +134,4 @@ api_router.include_router(experiment_auto_runs_router)
 api_router.include_router(content_tokens_router)
 api_router.include_router(libraries_router)
 api_router.include_router(barcode_maps_router)
+api_router.include_router(sample_swap_checks_router)

--- a/backend/app/api/sample_swap_checks.py
+++ b/backend/app/api/sample_swap_checks.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import require_permission
+from app.database import get_session
+from app.schemas.sample_swap_check import (
+    SampleSwapCheckCreate,
+    SampleSwapCheckResolve,
+    SampleSwapCheckResponse,
+)
+from app.services.sample_swap_service import SampleSwapService
+
+router = APIRouter(tags=["sample_swap_checks"])
+
+
+@router.get(
+    "/api/libraries/{library_id}/swap-checks",
+    response_model=list[SampleSwapCheckResponse],
+)
+async def list_swap_checks(
+    library_id: int,
+    unresolved_only: bool = Query(default=False),
+    current_user: dict = require_permission("libraries", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    rows = await SampleSwapService.list_checks(session, org_id, library_id, unresolved_only)
+    return [SampleSwapCheckResponse.model_validate(r) for r in rows]
+
+
+@router.post(
+    "/api/libraries/{library_id}/swap-checks",
+    response_model=SampleSwapCheckResponse,
+)
+async def create_swap_check(
+    library_id: int,
+    body: SampleSwapCheckCreate,
+    current_user: dict = require_permission("libraries", "edit"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    row = await SampleSwapService.create_check(session, org_id, library_id, body)
+    await session.commit()
+    return SampleSwapCheckResponse.model_validate(row)
+
+
+@router.patch(
+    "/api/swap-checks/{check_id}/resolve",
+    response_model=SampleSwapCheckResponse,
+)
+async def resolve_swap_check(
+    check_id: int,
+    body: SampleSwapCheckResolve,
+    current_user: dict = require_permission("libraries", "edit"),
+    session: AsyncSession = Depends(get_session),
+):
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    row = await SampleSwapService.resolve_check(session, org_id, check_id, body, user_id=user_id)
+    await session.commit()
+    return SampleSwapCheckResponse.model_validate(row)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -63,6 +63,7 @@ from app.models.experiment_auto_run import ExperimentAutoRun
 from app.models.pending_auto_run import PendingAutoRun
 from app.models.library import Library
 from app.models.barcode_map import BarcodeMap
+from app.models.sample_swap_check import SampleSwapCheck
 
 __all__ = [
     "User",
@@ -136,4 +137,5 @@ __all__ = [
     "PendingAutoRun",
     "Library",
     "BarcodeMap",
+    "SampleSwapCheck",
 ]

--- a/backend/app/models/barcode_map.py
+++ b/backend/app/models/barcode_map.py
@@ -49,9 +49,7 @@ class BarcodeMap(Base):
 
     # True for UMIs and other positional patterns that have no concrete sequence
     # (the reader just consumes ``length`` bases starting at ``offset_in_read``).
-    is_pattern_only: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default="false"
-    )
+    is_pattern_only: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/models/barcode_map.py
+++ b/backend/app/models/barcode_map.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy import (
+    Boolean,
     DateTime,
     ForeignKey,
     Index,
@@ -45,6 +46,12 @@ class BarcodeMap(Base):
 
     whitelist_reference: Mapped[str | None] = mapped_column(String(255), nullable=True)
     attributes_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # True for UMIs and other positional patterns that have no concrete sequence
+    # (the reader just consumes ``length`` bases starting at ``offset_in_read``).
+    is_pattern_only: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/models/library.py
+++ b/backend/app/models/library.py
@@ -57,6 +57,8 @@ class Library(Base):
     qc_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
     qc_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    expected_contamination_pct: Mapped[Decimal | None] = mapped_column(Numeric(5, 3), nullable=True)
+
     sequencing_batch_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("sequencing_batches.id"), nullable=True)
 
     status: Mapped[str] = mapped_column(String(50), nullable=False, server_default="planned")

--- a/backend/app/models/sample_swap_check.py
+++ b/backend/app/models/sample_swap_check.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+SWAP_CHECK_STATUSES = ["match", "mismatch", "inconclusive"]
+
+
+class SampleSwapCheck(Base):
+    __tablename__ = "sample_swap_checks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
+    library_id: Mapped[int] = mapped_column(Integer, ForeignKey("libraries.id"), nullable=False, index=True)
+    run_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("pipeline_runs.id"), nullable=True)
+
+    expected_attribute: Mapped[str] = mapped_column(String(255), nullable=False)
+    observed_attribute: Mapped[str] = mapped_column(String(255), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    evidence_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    resolved_by_user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"), nullable=True)
+    resolution_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    library = relationship("Library")
+    organization = relationship("Organization")

--- a/backend/app/schemas/barcode_map.py
+++ b/backend/app/schemas/barcode_map.py
@@ -58,3 +58,15 @@ class BarcodeCollisionEntry(BaseModel):
     library_b_id: int
     i5_sequence: str | None
     i7_sequence: str | None
+
+
+class BarcodeFuzzyMatch(BaseModel):
+    id: int
+    organization_id: int
+    library_id: int
+    barcode_type: str
+    sequence: str
+    name: str | None = None
+    distance: int
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/barcode_map.py
+++ b/backend/app/schemas/barcode_map.py
@@ -18,6 +18,16 @@ ReadPosition = Literal["R1", "R2", "I1", "I2"]
 
 
 class BarcodeMapCreate(BaseModel):
+    """A single barcode row.
+
+    Two modes:
+      - Explicit sequence (``is_pattern_only=False``, the default): ``sequence`` is
+        required unless ``whitelist_reference`` is set.
+      - Pattern-only (``is_pattern_only=True``): used for UMIs and other
+        positional patterns. ``read_position``, ``offset_in_read``, and ``length``
+        are required; ``sequence`` must be null.
+    """
+
     barcode_type: BarcodeType
     sequence: str | None = None
     name: str | None = None
@@ -27,6 +37,7 @@ class BarcodeMapCreate(BaseModel):
     allowed_mismatches: int | None = 1
     whitelist_reference: str | None = None
     attributes_json: dict | None = None
+    is_pattern_only: bool = False
 
 
 class BarcodeMapBulkCreate(BaseModel):
@@ -46,6 +57,7 @@ class BarcodeMapResponse(BaseModel):
     allowed_mismatches: int | None = None
     whitelist_reference: str | None = None
     attributes_json: dict | None = None
+    is_pattern_only: bool = False
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -25,6 +25,7 @@ class LibraryCreate(BaseModel):
     concentration_ng_ul: Decimal | None = None
     qc_status: Literal["pass", "warning", "fail"] | None = None
     qc_notes: str | None = None
+    expected_contamination_pct: Decimal | None = None
     sequencing_batch_id: int | None = None
     notes: str | None = None
 
@@ -48,6 +49,7 @@ class LibraryUpdate(BaseModel):
     concentration_ng_ul: Decimal | None = None
     qc_status: Literal["pass", "warning", "fail"] | None = None
     qc_notes: str | None = None
+    expected_contamination_pct: Decimal | None = None
     sequencing_batch_id: int | None = None
     status: str | None = None
     notes: str | None = None
@@ -75,6 +77,7 @@ class LibraryResponse(BaseModel):
     concentration_ng_ul: Decimal | None = None
     qc_status: str | None = None
     qc_notes: str | None = None
+    expected_contamination_pct: Decimal | None = None
     sequencing_batch_id: int | None = None
     status: str
     notes: str | None = None

--- a/backend/app/schemas/sample_swap_check.py
+++ b/backend/app/schemas/sample_swap_check.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+SwapCheckStatus = Literal["match", "mismatch", "inconclusive"]
+
+
+class SampleSwapCheckCreate(BaseModel):
+    expected_attribute: str
+    observed_attribute: str
+    status: SwapCheckStatus
+    evidence_json: dict | None = None
+    run_id: int | None = None
+
+
+class SampleSwapCheckResolve(BaseModel):
+    resolution_notes: str | None = None
+
+
+class SampleSwapCheckResponse(BaseModel):
+    id: int
+    organization_id: int
+    library_id: int
+    run_id: int | None = None
+    expected_attribute: str
+    observed_attribute: str
+    status: str
+    evidence_json: dict | None = None
+    created_at: datetime
+    resolved_at: datetime | None = None
+    resolved_by_user_id: int | None = None
+    resolution_notes: str | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/barcode_service.py
+++ b/backend/app/services/barcode_service.py
@@ -21,6 +21,34 @@ from app.services.library_service import LibraryService, _canonicalize
 
 MAX_BARCODES_PER_LIBRARY = 10_000
 
+# Neighbour enumeration grows as C(n, k) * 3^k for length n and k mismatches;
+# above this length the trigram-index path should be used (not yet implemented).
+FUZZY_MAX_LENGTH_WITH_MISMATCHES = 16
+_ACGTN = "ACGTN"
+
+
+def _hamming_neighbours(seq: str, max_mismatches: int) -> set[str]:
+    """All ACGTN strings within ``max_mismatches`` Hamming distance of ``seq``."""
+    results = {seq}
+    frontier = {seq}
+    for _ in range(max_mismatches):
+        next_frontier: set[str] = set()
+        for s in frontier:
+            for i in range(len(s)):
+                for c in _ACGTN:
+                    if c == s[i]:
+                        continue
+                    neighbour = s[:i] + c + s[i + 1 :]
+                    if neighbour not in results:
+                        results.add(neighbour)
+                        next_frontier.add(neighbour)
+        frontier = next_frontier
+    return results
+
+
+def _hamming_distance(a: str, b: str) -> int:
+    return sum(1 for x, y in zip(a, b) if x != y) + abs(len(a) - len(b))
+
 
 class BarcodeService:
     @staticmethod
@@ -125,6 +153,50 @@ class BarcodeService:
         if barcode_type is not None:
             stmt = stmt.where(BarcodeMap.barcode_type == barcode_type)
         return list((await session.execute(stmt)).scalars().all())
+
+    @staticmethod
+    async def fuzzy_lookup(
+        session: AsyncSession,
+        org_id: int,
+        sequence: str,
+        barcode_type: str | None = None,
+        max_mismatches: int = 1,
+    ) -> list[tuple[BarcodeMap, int]]:
+        """Return (BarcodeMap, distance) pairs with Hamming distance <= max_mismatches."""
+        canon = _canonicalize(sequence)
+        if canon is None:
+            raise HTTPException(status_code=422, detail="Empty sequence")
+        if max_mismatches < 0 or max_mismatches > 2:
+            raise HTTPException(
+                status_code=422,
+                detail="max_mismatches must be between 0 and 2",
+            )
+        if max_mismatches > 0 and len(canon) > FUZZY_MAX_LENGTH_WITH_MISMATCHES:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Fuzzy lookup with mismatches is not supported for sequences "
+                    f"longer than {FUZZY_MAX_LENGTH_WITH_MISMATCHES}bp. Use exact lookup "
+                    "or a whitelist-backed search."
+                ),
+            )
+
+        neighbours = _hamming_neighbours(canon, max_mismatches)
+        stmt = select(BarcodeMap).where(
+            BarcodeMap.organization_id == org_id,
+            BarcodeMap.sequence.in_(neighbours),
+        )
+        if barcode_type is not None:
+            stmt = stmt.where(BarcodeMap.barcode_type == barcode_type)
+        rows = list((await session.execute(stmt)).scalars().all())
+        out: list[tuple[BarcodeMap, int]] = []
+        for row in rows:
+            if row.sequence is None or len(row.sequence) != len(canon):
+                continue
+            d = _hamming_distance(row.sequence, canon)
+            if d <= max_mismatches:
+                out.append((row, d))
+        return out
 
     @staticmethod
     async def detect_collisions_in_batch(

--- a/backend/app/services/barcode_service.py
+++ b/backend/app/services/barcode_service.py
@@ -63,19 +63,13 @@ class BarcodeService:
             if payload.read_position is None or payload.offset_in_read is None or payload.length is None:
                 raise HTTPException(
                     status_code=422,
-                    detail=(
-                        "is_pattern_only rows require read_position, "
-                        "offset_in_read, and length"
-                    ),
+                    detail=("is_pattern_only rows require read_position, offset_in_read, and length"),
                 )
         else:
             if seq is None and not payload.whitelist_reference:
                 raise HTTPException(
                     status_code=422,
-                    detail=(
-                        "Explicit-sequence rows require either a sequence or a "
-                        "whitelist_reference"
-                    ),
+                    detail=("Explicit-sequence rows require either a sequence or a whitelist_reference"),
                 )
         if payload.barcode_type == "library_index" and seq is None:
             raise HTTPException(

--- a/backend/app/services/barcode_service.py
+++ b/backend/app/services/barcode_service.py
@@ -54,6 +54,29 @@ class BarcodeService:
     @staticmethod
     def _build_row(org_id: int, library_id: int, payload: BarcodeMapCreate) -> BarcodeMap:
         seq = _canonicalize(payload.sequence)
+        if payload.is_pattern_only:
+            if seq is not None:
+                raise HTTPException(
+                    status_code=422,
+                    detail="is_pattern_only rows must not carry a sequence",
+                )
+            if payload.read_position is None or payload.offset_in_read is None or payload.length is None:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "is_pattern_only rows require read_position, "
+                        "offset_in_read, and length"
+                    ),
+                )
+        else:
+            if seq is None and not payload.whitelist_reference:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Explicit-sequence rows require either a sequence or a "
+                        "whitelist_reference"
+                    ),
+                )
         if payload.barcode_type == "library_index" and seq is None:
             raise HTTPException(
                 status_code=422,
@@ -84,6 +107,7 @@ class BarcodeService:
             allowed_mismatches=payload.allowed_mismatches,
             whitelist_reference=payload.whitelist_reference,
             attributes_json=payload.attributes_json,
+            is_pattern_only=payload.is_pattern_only,
         )
 
     @staticmethod

--- a/backend/app/services/bootstrap_roles.py
+++ b/backend/app/services/bootstrap_roles.py
@@ -21,6 +21,7 @@ ALL_RESOURCES_ACTIONS: dict[str, list[str]] = {
     "quotas": ["view", "configure"],
     "settings": ["view", "configure"],
     "libraries": ["view", "create", "edit", "delete"],
+    "barcodes": ["view", "create", "edit", "delete"],
 }
 
 BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
@@ -44,6 +45,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "audit_log": ["view"],
             "cost_center": ["view"],
             "libraries": ["view", "create", "edit"],
+            "barcodes": ["view", "create", "edit", "delete"],
         },
     ),
     "bench": (
@@ -57,6 +59,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "files": ["view", "upload"],
             "projects": ["view"],
             "libraries": ["view", "create", "edit"],
+            "barcodes": ["view", "create"],
         },
     ),
     "viewer": (
@@ -68,6 +71,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "files": ["view"],
             "projects": ["view"],
             "libraries": ["view"],
+            "barcodes": ["view"],
         },
     ),
 }

--- a/backend/app/services/demux_reconciliation_service.py
+++ b/backend/app/services/demux_reconciliation_service.py
@@ -1,0 +1,202 @@
+"""Demux reconciliation: attach newly ingested files to Libraries in a sequencing batch.
+
+Reads all unlinked files in the batch, extracts library identifiers from
+each filename, and matches against Libraries in the same batch. Unambiguous
+matches set ``File.library_id``; ambiguous or missing matches are reported
+so a human can resolve them.
+"""
+
+import asyncio
+import re
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.component import PlatformConfig
+from app.models.file import File
+from app.models.library import Library
+from app.models.sequencing_batch import SequencingBatch
+from app.services import event_types
+from app.services.audit_service import log_action
+from app.services.event_bus import event_bus
+
+
+DEMUX_FILENAME_PATTERN_KEY = "demux.filename_pattern"
+
+# Default patterns (tried in order):
+#  1. Library external id at the start of the filename (bcl-convert / bcl2fastq).
+#     Example: ``LIB-001_S1_L001_R1_001.fastq.gz``.
+#  2. Illumina dual-index pair inside the filename: ``_I7+I5_`` or ``_I7-I5_``.
+#     Example: ``sample_AAGTCCGT+GCATACGA_L001_R1_001.fastq.gz``.
+_DEFAULT_LIBRARY_ID_PATTERN = re.compile(r"^(?P<library_external_id>[^_]+)_")
+_DEFAULT_INDEX_PAIR_PATTERN = re.compile(
+    r"_(?P<i7>[ACGTN]{4,16})[+\-](?P<i5>[ACGTN]{4,16})_"
+)
+
+
+class FileReconciliationOutcome(BaseModel):
+    file_id: int
+    filename: str
+    status: str  # matched | ambiguous | unmatched
+    library_id: int | None = None
+    reason: str | None = None
+
+
+class ReconciliationReport(BaseModel):
+    sequencing_batch_id: int
+    matched: int = 0
+    ambiguous: int = 0
+    unmatched: int = 0
+    outcomes: list[FileReconciliationOutcome] = []
+
+
+async def _load_custom_pattern(session: AsyncSession) -> re.Pattern | None:
+    row = (
+        await session.execute(
+            select(PlatformConfig).where(PlatformConfig.key == DEMUX_FILENAME_PATTERN_KEY)
+        )
+    ).scalar_one_or_none()
+    if row is None or not row.value:
+        return None
+    try:
+        return re.compile(row.value)
+    except re.error:
+        return None
+
+
+def _extract_identifiers(
+    filename: str, custom: re.Pattern | None
+) -> dict[str, str]:
+    """Return any of library_external_id, i5, i7 that the filename exposes."""
+    out: dict[str, str] = {}
+    if custom is not None:
+        m = custom.search(filename)
+        if m:
+            out.update({k: v for k, v in m.groupdict().items() if v})
+    m1 = _DEFAULT_LIBRARY_ID_PATTERN.match(filename)
+    if m1:
+        out.setdefault("library_external_id", m1.group("library_external_id"))
+    m2 = _DEFAULT_INDEX_PAIR_PATTERN.search(filename)
+    if m2:
+        out.setdefault("i5", m2.group("i5").upper())
+        out.setdefault("i7", m2.group("i7").upper())
+    return out
+
+
+class DemuxReconciliationService:
+    @staticmethod
+    async def reconcile_batch(
+        session: AsyncSession,
+        org_id: int,
+        batch_id: int,
+        user_id: int | None = None,
+    ) -> ReconciliationReport:
+        batch = await session.get(SequencingBatch, batch_id)
+        if batch is None or batch.organization_id != org_id:
+            raise HTTPException(status_code=404, detail="Sequencing batch not found")
+
+        libraries = list(
+            (
+                await session.execute(
+                    select(Library).where(
+                        Library.organization_id == org_id,
+                        Library.sequencing_batch_id == batch_id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        files = list(
+            (
+                await session.execute(
+                    select(File).where(
+                        File.organization_id == org_id,
+                        File.sequencing_batch_id == batch_id,
+                        File.library_id.is_(None),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        custom = await _load_custom_pattern(session)
+        report = ReconciliationReport(sequencing_batch_id=batch_id)
+
+        for f in files:
+            ids = _extract_identifiers(f.filename, custom)
+            candidates: list[Library] = []
+            if "library_external_id" in ids:
+                ext = ids["library_external_id"]
+                candidates = [
+                    lib for lib in libraries if lib.library_id_external == ext
+                ]
+            if not candidates and "i5" in ids and "i7" in ids:
+                i5, i7 = ids["i5"], ids["i7"]
+                candidates = [
+                    lib
+                    for lib in libraries
+                    if lib.i5_sequence == i5 and lib.i7_sequence == i7
+                ]
+
+            if len(candidates) == 1:
+                lib = candidates[0]
+                f.library_id = lib.id
+                report.matched += 1
+                report.outcomes.append(
+                    FileReconciliationOutcome(
+                        file_id=f.id,
+                        filename=f.filename,
+                        status="matched",
+                        library_id=lib.id,
+                    )
+                )
+                await log_action(
+                    session,
+                    user_id,
+                    "file",
+                    f.id,
+                    "library_linked",
+                    details={"library_id": lib.id, "source": "demux_reconciliation"},
+                )
+            elif len(candidates) > 1:
+                report.ambiguous += 1
+                report.outcomes.append(
+                    FileReconciliationOutcome(
+                        file_id=f.id,
+                        filename=f.filename,
+                        status="ambiguous",
+                        reason=f"{len(candidates)} candidate libraries in batch",
+                    )
+                )
+            else:
+                report.unmatched += 1
+                report.outcomes.append(
+                    FileReconciliationOutcome(
+                        file_id=f.id,
+                        filename=f.filename,
+                        status="unmatched",
+                        reason="no candidate library found in batch",
+                    )
+                )
+
+        await session.flush()
+
+        asyncio.create_task(
+            event_bus.emit(
+                event_types.DEMUX_RECONCILED,
+                {
+                    "event_type": event_types.DEMUX_RECONCILED,
+                    "org_id": org_id,
+                    "entity_type": "sequencing_batch",
+                    "entity_id": batch_id,
+                    "matched": report.matched,
+                    "ambiguous": report.ambiguous,
+                    "unmatched": report.unmatched,
+                },
+            )
+        )
+        return report

--- a/backend/app/services/demux_reconciliation_service.py
+++ b/backend/app/services/demux_reconciliation_service.py
@@ -31,9 +31,7 @@ DEMUX_FILENAME_PATTERN_KEY = "demux.filename_pattern"
 #  2. Illumina dual-index pair inside the filename: ``_I7+I5_`` or ``_I7-I5_``.
 #     Example: ``sample_AAGTCCGT+GCATACGA_L001_R1_001.fastq.gz``.
 _DEFAULT_LIBRARY_ID_PATTERN = re.compile(r"^(?P<library_external_id>[^_]+)_")
-_DEFAULT_INDEX_PAIR_PATTERN = re.compile(
-    r"_(?P<i7>[ACGTN]{4,16})[+\-](?P<i5>[ACGTN]{4,16})_"
-)
+_DEFAULT_INDEX_PAIR_PATTERN = re.compile(r"_(?P<i7>[ACGTN]{4,16})[+\-](?P<i5>[ACGTN]{4,16})_")
 
 
 class FileReconciliationOutcome(BaseModel):
@@ -54,9 +52,7 @@ class ReconciliationReport(BaseModel):
 
 async def _load_custom_pattern(session: AsyncSession) -> re.Pattern | None:
     row = (
-        await session.execute(
-            select(PlatformConfig).where(PlatformConfig.key == DEMUX_FILENAME_PATTERN_KEY)
-        )
+        await session.execute(select(PlatformConfig).where(PlatformConfig.key == DEMUX_FILENAME_PATTERN_KEY))
     ).scalar_one_or_none()
     if row is None or not row.value:
         return None
@@ -66,9 +62,7 @@ async def _load_custom_pattern(session: AsyncSession) -> re.Pattern | None:
         return None
 
 
-def _extract_identifiers(
-    filename: str, custom: re.Pattern | None
-) -> dict[str, str]:
+def _extract_identifiers(filename: str, custom: re.Pattern | None) -> dict[str, str]:
     """Return any of library_external_id, i5, i7 that the filename exposes."""
     out: dict[str, str] = {}
     if custom is not None:
@@ -131,16 +125,10 @@ class DemuxReconciliationService:
             candidates: list[Library] = []
             if "library_external_id" in ids:
                 ext = ids["library_external_id"]
-                candidates = [
-                    lib for lib in libraries if lib.library_id_external == ext
-                ]
+                candidates = [lib for lib in libraries if lib.library_id_external == ext]
             if not candidates and "i5" in ids and "i7" in ids:
                 i5, i7 = ids["i5"], ids["i7"]
-                candidates = [
-                    lib
-                    for lib in libraries
-                    if lib.i5_sequence == i5 and lib.i7_sequence == i7
-                ]
+                candidates = [lib for lib in libraries if lib.i5_sequence == i5 and lib.i7_sequence == i7]
 
             if len(candidates) == 1:
                 lib = candidates[0]

--- a/backend/app/services/event_types.py
+++ b/backend/app/services/event_types.py
@@ -94,6 +94,7 @@ LIBRARY_CREATED = "library.created"
 LIBRARY_UPDATED = "library.updated"
 LIBRARY_FILE_ATTACHED = "library.file_attached"
 BARCODE_COLLISION_DETECTED = "barcode.collision_detected"
+DEMUX_RECONCILED = "demux.reconciled"
 
 ALL_EVENT_TYPES = [
     PIPELINE_STARTED,
@@ -147,6 +148,7 @@ ALL_EVENT_TYPES = [
     LIBRARY_UPDATED,
     LIBRARY_FILE_ATTACHED,
     BARCODE_COLLISION_DETECTED,
+    DEMUX_RECONCILED,
 ]
 
 # Severity mapping for event types
@@ -202,4 +204,5 @@ EVENT_SEVERITY = {
     LIBRARY_UPDATED: "info",
     LIBRARY_FILE_ATTACHED: "info",
     BARCODE_COLLISION_DETECTED: "warning",
+    DEMUX_RECONCILED: "info",
 }

--- a/backend/app/services/event_types.py
+++ b/backend/app/services/event_types.py
@@ -95,6 +95,7 @@ LIBRARY_UPDATED = "library.updated"
 LIBRARY_FILE_ATTACHED = "library.file_attached"
 BARCODE_COLLISION_DETECTED = "barcode.collision_detected"
 DEMUX_RECONCILED = "demux.reconciled"
+LIBRARY_BACKFILLED = "library.backfilled"
 
 ALL_EVENT_TYPES = [
     PIPELINE_STARTED,
@@ -149,6 +150,7 @@ ALL_EVENT_TYPES = [
     LIBRARY_FILE_ATTACHED,
     BARCODE_COLLISION_DETECTED,
     DEMUX_RECONCILED,
+    LIBRARY_BACKFILLED,
 ]
 
 # Severity mapping for event types
@@ -205,4 +207,5 @@ EVENT_SEVERITY = {
     LIBRARY_FILE_ATTACHED: "info",
     BARCODE_COLLISION_DETECTED: "warning",
     DEMUX_RECONCILED: "info",
+    LIBRARY_BACKFILLED: "info",
 }

--- a/backend/app/services/library_backfill_service.py
+++ b/backend/app/services/library_backfill_service.py
@@ -1,0 +1,171 @@
+"""Library backfill: one-shot Library creation for legacy Sample -> File data.
+
+Generates one Library per sample that doesn't already have one, carrying
+prep metadata forward from the legacy Sample columns and attaching any
+existing sample_files rows to the new Library. Preview-then-commit, so
+admins can see what will change before any writes land.
+"""
+
+import asyncio
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.experiment import Experiment
+from app.models.file import File
+from app.models.library import Library
+from app.models.sample import Sample, sample_files
+from app.services import event_types
+from app.services.audit_service import log_action
+from app.services.event_bus import event_bus
+
+
+class BackfillEntry(BaseModel):
+    sample_id: int
+    prep_kit: str | None = None
+    read_layout: str | None = None
+    file_ids: list[int] = []
+
+
+class BackfillPreview(BaseModel):
+    experiment_id: int
+    libraries_to_create: int = 0
+    files_to_attach: int = 0
+    samples_skipped: int = 0
+    entries: list[BackfillEntry] = []
+
+
+class BackfillResult(BaseModel):
+    experiment_id: int
+    libraries_created: int = 0
+    files_attached: int = 0
+    samples_skipped: int = 0
+
+
+async def _plan(
+    session: AsyncSession, org_id: int, experiment_id: int
+) -> tuple[BackfillPreview, list[Sample], dict[int, list[File]]]:
+    exp = await session.get(Experiment, experiment_id)
+    if exp is None or exp.organization_id != org_id:
+        raise HTTPException(status_code=404, detail="Experiment not found")
+
+    samples = list(
+        (
+            await session.execute(
+                select(Sample).where(Sample.experiment_id == experiment_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    existing_library_sample_ids = set(
+        (
+            await session.execute(
+                select(Library.sample_id).where(
+                    Library.organization_id == org_id,
+                    Library.sample_id.in_([s.id for s in samples]) if samples else select(Library.sample_id),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    preview = BackfillPreview(experiment_id=experiment_id)
+    candidates: list[Sample] = []
+    files_by_sample: dict[int, list[File]] = {}
+
+    for s in samples:
+        if s.id in existing_library_sample_ids:
+            preview.samples_skipped += 1
+            continue
+        linked_files = list(
+            (
+                await session.execute(
+                    select(File)
+                    .join(sample_files, sample_files.c.file_id == File.id)
+                    .where(sample_files.c.sample_id == s.id, File.library_id.is_(None))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        candidates.append(s)
+        files_by_sample[s.id] = linked_files
+        preview.libraries_to_create += 1
+        preview.files_to_attach += len(linked_files)
+        preview.entries.append(
+            BackfillEntry(
+                sample_id=s.id,
+                prep_kit=s.library_prep_method,
+                read_layout=s.library_layout,
+                file_ids=[f.id for f in linked_files],
+            )
+        )
+
+    return preview, candidates, files_by_sample
+
+
+class LibraryBackfillService:
+    @staticmethod
+    async def preview(
+        session: AsyncSession, org_id: int, experiment_id: int
+    ) -> BackfillPreview:
+        preview, _, _ = await _plan(session, org_id, experiment_id)
+        return preview
+
+    @staticmethod
+    async def commit(
+        session: AsyncSession,
+        org_id: int,
+        experiment_id: int,
+        user_id: int | None = None,
+    ) -> BackfillResult:
+        preview, candidates, files_by_sample = await _plan(session, org_id, experiment_id)
+        result = BackfillResult(
+            experiment_id=experiment_id,
+            samples_skipped=preview.samples_skipped,
+        )
+
+        for s in candidates:
+            lib = Library(
+                organization_id=org_id,
+                sample_id=s.id,
+                prep_kit=s.library_prep_method,
+                read_layout=s.library_layout,
+                status="planned",
+            )
+            session.add(lib)
+            await session.flush()
+            result.libraries_created += 1
+
+            for f in files_by_sample.get(s.id, []):
+                f.library_id = lib.id
+                result.files_attached += 1
+            await session.flush()
+
+            await log_action(
+                session,
+                user_id,
+                "library",
+                lib.id,
+                "backfilled",
+                details={"sample_id": s.id, "files_attached": len(files_by_sample.get(s.id, []))},
+            )
+            asyncio.create_task(
+                event_bus.emit(
+                    event_types.LIBRARY_BACKFILLED,
+                    {
+                        "event_type": event_types.LIBRARY_BACKFILLED,
+                        "org_id": org_id,
+                        "entity_type": "library",
+                        "entity_id": lib.id,
+                        "sample_id": s.id,
+                    },
+                )
+            )
+
+        return result

--- a/backend/app/services/library_backfill_service.py
+++ b/backend/app/services/library_backfill_service.py
@@ -51,15 +51,7 @@ async def _plan(
     if exp is None or exp.organization_id != org_id:
         raise HTTPException(status_code=404, detail="Experiment not found")
 
-    samples = list(
-        (
-            await session.execute(
-                select(Sample).where(Sample.experiment_id == experiment_id)
-            )
-        )
-        .scalars()
-        .all()
-    )
+    samples = list((await session.execute(select(Sample).where(Sample.experiment_id == experiment_id))).scalars().all())
 
     existing_library_sample_ids = set(
         (
@@ -111,9 +103,7 @@ async def _plan(
 
 class LibraryBackfillService:
     @staticmethod
-    async def preview(
-        session: AsyncSession, org_id: int, experiment_id: int
-    ) -> BackfillPreview:
+    async def preview(session: AsyncSession, org_id: int, experiment_id: int) -> BackfillPreview:
         preview, _, _ = await _plan(session, org_id, experiment_id)
         return preview
 

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -19,6 +19,7 @@ from app.schemas.library import LibraryCreate, LibraryUpdate
 from app.services import event_types
 from app.services.audit_service import log_action
 from app.services.event_bus import event_bus
+from app.services.sequencing_conventions import infer_i5_orientation
 
 
 _SEQ_RE = re.compile(r"^[ACGTN]+$")
@@ -121,6 +122,14 @@ class LibraryService:
         i5 = _canonicalize(payload.i5_sequence)
         i7 = _canonicalize(payload.i7_sequence)
 
+        i5_orientation = payload.i5_orientation_convention
+        if i5_orientation is None and payload.sequencing_batch_id is not None:
+            from app.models.sequencing_batch import SequencingBatch
+
+            batch = await session.get(SequencingBatch, payload.sequencing_batch_id)
+            if batch is not None:
+                i5_orientation = infer_i5_orientation(batch.instrument_model)
+
         lib = Library(
             organization_id=org_id,
             sample_id=payload.sample_id,
@@ -136,7 +145,7 @@ class LibraryService:
             index_type=payload.index_type,
             i5_sequence=i5,
             i7_sequence=i7,
-            i5_orientation_convention=payload.i5_orientation_convention,
+            i5_orientation_convention=i5_orientation,
             insert_size_mean=payload.insert_size_mean,
             molarity_nm=payload.molarity_nm,
             concentration_ng_ul=payload.concentration_ng_ul,

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -27,6 +27,14 @@ from app.services.sequencing_conventions import (
 
 _SEQ_RE = re.compile(r"^[ACGTN]+$")
 
+# Workspace-level toggle recognising that some lab workflows ingest FASTQs
+# before demultiplexing, so one file may carry reads for multiple libraries.
+# Default is False — v1 assumes one-file-one-library (the 10x post-demux
+# case). When a real workflow requires multi-library attribution, a follow-up
+# migration introduces the ``file_libraries`` junction table and this toggle
+# gates the service / API paths that use it.
+PRE_DEMUX_ENABLED_KEY = "ingest.pre_demux_enabled"
+
 
 def _canonicalize(seq: str | None) -> str | None:
     if seq is None:
@@ -43,6 +51,26 @@ def _canonicalize(seq: str | None) -> str | None:
 
 
 class LibraryService:
+    @staticmethod
+    async def is_pre_demux_enabled(session: AsyncSession) -> bool:
+        """Workspace-level flag for pre-demux (multi-library) FASTQ ingest.
+
+        Currently scaffolding only: the junction table and multi-library
+        attachment paths will be added when a concrete lab workflow requires
+        them. Kept here as a single read point so the future work only has
+        to wire the new paths against this getter.
+        """
+        from app.models.component import PlatformConfig
+
+        row = (
+            await session.execute(
+                select(PlatformConfig).where(PlatformConfig.key == PRE_DEMUX_ENABLED_KEY)
+            )
+        ).scalar_one_or_none()
+        if row is None or row.value is None:
+            return False
+        return row.value.strip().lower() in ("true", "1", "yes", "on")
+
     @staticmethod
     async def _assert_sample_in_org(session: AsyncSession, org_id: int, sample_id: int) -> Sample:
         """Verify sample belongs to an experiment in the caller's organization."""

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -63,9 +63,7 @@ class LibraryService:
         from app.models.component import PlatformConfig
 
         row = (
-            await session.execute(
-                select(PlatformConfig).where(PlatformConfig.key == PRE_DEMUX_ENABLED_KEY)
-            )
+            await session.execute(select(PlatformConfig).where(PlatformConfig.key == PRE_DEMUX_ENABLED_KEY))
         ).scalar_one_or_none()
         if row is None or row.value is None:
             return False
@@ -155,9 +153,7 @@ class LibraryService:
 
         i5_orientation = payload.i5_orientation_convention
         contamination_pct = payload.expected_contamination_pct
-        if payload.sequencing_batch_id is not None and (
-            i5_orientation is None or contamination_pct is None
-        ):
+        if payload.sequencing_batch_id is not None and (i5_orientation is None or contamination_pct is None):
             from decimal import Decimal as _D
 
             from app.models.sequencing_batch import SequencingBatch

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -19,7 +19,10 @@ from app.schemas.library import LibraryCreate, LibraryUpdate
 from app.services import event_types
 from app.services.audit_service import log_action
 from app.services.event_bus import event_bus
-from app.services.sequencing_conventions import infer_i5_orientation
+from app.services.sequencing_conventions import (
+    infer_expected_contamination_pct,
+    infer_i5_orientation,
+)
 
 
 _SEQ_RE = re.compile(r"^[ACGTN]+$")
@@ -123,12 +126,22 @@ class LibraryService:
         i7 = _canonicalize(payload.i7_sequence)
 
         i5_orientation = payload.i5_orientation_convention
-        if i5_orientation is None and payload.sequencing_batch_id is not None:
+        contamination_pct = payload.expected_contamination_pct
+        if payload.sequencing_batch_id is not None and (
+            i5_orientation is None or contamination_pct is None
+        ):
+            from decimal import Decimal as _D
+
             from app.models.sequencing_batch import SequencingBatch
 
             batch = await session.get(SequencingBatch, payload.sequencing_batch_id)
             if batch is not None:
-                i5_orientation = infer_i5_orientation(batch.instrument_model)
+                if i5_orientation is None:
+                    i5_orientation = infer_i5_orientation(batch.instrument_model)
+                if contamination_pct is None:
+                    inferred = infer_expected_contamination_pct(batch.instrument_model)
+                    if inferred is not None:
+                        contamination_pct = _D(inferred)
 
         lib = Library(
             organization_id=org_id,
@@ -151,6 +164,7 @@ class LibraryService:
             concentration_ng_ul=payload.concentration_ng_ul,
             qc_status=payload.qc_status,
             qc_notes=payload.qc_notes,
+            expected_contamination_pct=contamination_pct,
             sequencing_batch_id=payload.sequencing_batch_id,
             notes=payload.notes,
         )

--- a/backend/app/services/sample_service.py
+++ b/backend/app/services/sample_service.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -6,6 +8,7 @@ from fastapi import HTTPException
 from app.models.experiment import Experiment
 from app.models.experiment_field_default import ExperimentFieldDefault, DEFAULTABLE_SAMPLE_FIELDS
 from app.models.experiment_template import ExperimentTemplate
+from app.models.library import Library
 from app.models.sample import Sample
 from app.models.sample_batch import SampleBatch
 from app.models.sample_custom_field import SampleCustomField
@@ -14,6 +17,11 @@ from app.schemas.sample import SampleCreate, SampleUpdate
 from app.services.audit_service import log_action
 from app.services.snapshot_utils import serialize_entity
 from app.services.vocabulary_validator import VocabularyValidator
+
+
+_deprecation_logger = logging.getLogger("bioaf.sample_deprecation")
+
+DEPRECATED_SAMPLE_PREP_FIELDS = ("library_prep_method", "library_layout")
 
 
 SAMPLE_STATUS_TRANSITIONS = {
@@ -75,6 +83,49 @@ class SampleService:
             ).bindparams(bid=sequencing_batch_id)
         )
         return result.scalar_one()
+
+    @staticmethod
+    async def get_prep_metadata(
+        session: AsyncSession, org_id: int, sample_id: int
+    ) -> dict:
+        """Return prep metadata preferring Library fields when a Library exists.
+
+        Shape: ``{"source": "library"|"sample", "prep_kit": ..., "read_layout": ...,
+        "library_count": int}``. Callers that need the full Library row should
+        go through LibraryService directly.
+        """
+        sample = await session.get(Sample, sample_id)
+        if sample is None:
+            raise HTTPException(status_code=404, detail="Sample not found")
+        exp = await session.get(Experiment, sample.experiment_id)
+        if exp is None or exp.organization_id != org_id:
+            raise HTTPException(status_code=404, detail="Sample not found")
+
+        libs = list(
+            (
+                await session.execute(
+                    select(Library)
+                    .where(Library.sample_id == sample_id)
+                    .order_by(Library.created_at.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if libs:
+            lib = libs[0]
+            return {
+                "source": "library",
+                "prep_kit": lib.prep_kit,
+                "read_layout": lib.read_layout,
+                "library_count": len(libs),
+            }
+        return {
+            "source": "sample",
+            "prep_kit": sample.library_prep_method,
+            "read_layout": sample.library_layout,
+            "library_count": 0,
+        }
 
     @staticmethod
     async def resolve_by_batch_position(
@@ -411,6 +462,14 @@ class SampleService:
         ]:
             new_val = getattr(data, field, None)
             if new_val is not None:
+                if field in DEPRECATED_SAMPLE_PREP_FIELDS:
+                    _deprecation_logger.warning(
+                        "Write to deprecated Sample.%s on sample %s. "
+                        "New callers should populate Library.%s instead.",
+                        field,
+                        sample_id,
+                        "prep_kit" if field == "library_prep_method" else "read_layout",
+                    )
                 old_val = getattr(sample, field)
                 previous[field] = str(old_val) if old_val is not None else None
                 setattr(sample, field, new_val)

--- a/backend/app/services/sample_service.py
+++ b/backend/app/services/sample_service.py
@@ -85,9 +85,7 @@ class SampleService:
         return result.scalar_one()
 
     @staticmethod
-    async def get_prep_metadata(
-        session: AsyncSession, org_id: int, sample_id: int
-    ) -> dict:
+    async def get_prep_metadata(session: AsyncSession, org_id: int, sample_id: int) -> dict:
         """Return prep metadata preferring Library fields when a Library exists.
 
         Shape: ``{"source": "library"|"sample", "prep_kit": ..., "read_layout": ...,
@@ -104,9 +102,7 @@ class SampleService:
         libs = list(
             (
                 await session.execute(
-                    select(Library)
-                    .where(Library.sample_id == sample_id)
-                    .order_by(Library.created_at.asc())
+                    select(Library).where(Library.sample_id == sample_id).order_by(Library.created_at.asc())
                 )
             )
             .scalars()
@@ -464,8 +460,7 @@ class SampleService:
             if new_val is not None:
                 if field in DEPRECATED_SAMPLE_PREP_FIELDS:
                     _deprecation_logger.warning(
-                        "Write to deprecated Sample.%s on sample %s. "
-                        "New callers should populate Library.%s instead.",
+                        "Write to deprecated Sample.%s on sample %s. New callers should populate Library.%s instead.",
                         field,
                         sample_id,
                         "prep_kit" if field == "library_prep_method" else "read_layout",

--- a/backend/app/services/sample_swap_service.py
+++ b/backend/app/services/sample_swap_service.py
@@ -1,0 +1,76 @@
+"""Sample swap detection service.
+
+Stores per-library attribute mismatches surfaced by post-ingest QC. The
+pipeline step that produces these rows is out of scope; this service
+owns the data-model and API surface.
+"""
+
+from datetime import UTC, datetime
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sample_swap_check import SampleSwapCheck
+from app.schemas.sample_swap_check import (
+    SampleSwapCheckCreate,
+    SampleSwapCheckResolve,
+)
+from app.services.library_service import LibraryService
+
+
+class SampleSwapService:
+    @staticmethod
+    async def list_checks(
+        session: AsyncSession,
+        org_id: int,
+        library_id: int,
+        unresolved_only: bool = False,
+    ) -> list[SampleSwapCheck]:
+        await LibraryService._get_library_in_org(session, org_id, library_id)
+        stmt = select(SampleSwapCheck).where(
+            SampleSwapCheck.organization_id == org_id,
+            SampleSwapCheck.library_id == library_id,
+        )
+        if unresolved_only:
+            stmt = stmt.where(SampleSwapCheck.resolved_at.is_(None))
+        stmt = stmt.order_by(SampleSwapCheck.created_at.desc())
+        return list((await session.execute(stmt)).scalars().all())
+
+    @staticmethod
+    async def create_check(
+        session: AsyncSession,
+        org_id: int,
+        library_id: int,
+        payload: SampleSwapCheckCreate,
+    ) -> SampleSwapCheck:
+        await LibraryService._get_library_in_org(session, org_id, library_id)
+        row = SampleSwapCheck(
+            organization_id=org_id,
+            library_id=library_id,
+            run_id=payload.run_id,
+            expected_attribute=payload.expected_attribute,
+            observed_attribute=payload.observed_attribute,
+            status=payload.status,
+            evidence_json=payload.evidence_json,
+        )
+        session.add(row)
+        await session.flush()
+        return row
+
+    @staticmethod
+    async def resolve_check(
+        session: AsyncSession,
+        org_id: int,
+        check_id: int,
+        payload: SampleSwapCheckResolve,
+        user_id: int | None = None,
+    ) -> SampleSwapCheck:
+        row = await session.get(SampleSwapCheck, check_id)
+        if row is None or row.organization_id != org_id:
+            raise HTTPException(status_code=404, detail="Swap check not found")
+        row.resolved_at = datetime.now(UTC)
+        row.resolved_by_user_id = user_id
+        row.resolution_notes = payload.resolution_notes
+        await session.flush()
+        return row

--- a/backend/app/services/sequencing_conventions.py
+++ b/backend/app/services/sequencing_conventions.py
@@ -1,0 +1,43 @@
+"""Sequencer-model conventions used to infer defaults for Libraries.
+
+`infer_i5_orientation` maps a raw `instrument_model` string (as recorded on
+`SequencingBatch.instrument_model`) to the i5 orientation convention that
+the sequencer's demultiplexer expects.
+
+Conventions follow Illumina's published guidance — NovaSeq, NextSeq, iSeq,
+and HiSeq 3000/4000 use reverse_complement i5; MiSeq and HiSeq 2500/2000
+use forward i5. Unknown models return ``None`` so the caller can preserve
+the null value.
+"""
+
+from __future__ import annotations
+
+
+_REVERSE_COMPLEMENT_PREFIXES = (
+    "novaseq",
+    "nextseq",
+    "iseq",
+    "hiseq 3",
+    "hiseq 4",
+)
+
+_FORWARD_PREFIXES = (
+    "miseq",
+    "hiseq 2",
+    "hiseq 1",
+    "hiseq",  # bare "HiSeq" with no numeric suffix defaults to forward
+)
+
+
+def infer_i5_orientation(instrument_model: str | None) -> str | None:
+    """Return "forward" or "reverse_complement" or None for unknown models."""
+    if not instrument_model:
+        return None
+    needle = instrument_model.strip().lower()
+    for prefix in _REVERSE_COMPLEMENT_PREFIXES:
+        if needle.startswith(prefix):
+            return "reverse_complement"
+    for prefix in _FORWARD_PREFIXES:
+        if needle.startswith(prefix):
+            return "forward"
+    return None

--- a/backend/app/services/sequencing_conventions.py
+++ b/backend/app/services/sequencing_conventions.py
@@ -41,3 +41,30 @@ def infer_i5_orientation(instrument_model: str | None) -> str | None:
         if needle.startswith(prefix):
             return "forward"
     return None
+
+
+# Expected cross-library contamination from index hopping, by sequencer model.
+# Patterned flow cells (NovaSeq, NextSeq 2000) misassign a small percentage of
+# reads across libraries on the same lane; non-patterned machines are lower.
+# Values are percentages (0.5 == 0.5%).
+_CONTAMINATION_BY_PREFIX: list[tuple[str, str]] = [
+    ("nextseq 2", "1.000"),
+    ("nextseq 1", "1.000"),
+    ("novaseq", "0.500"),
+    ("hiseq 3", "0.200"),
+    ("hiseq 4", "0.200"),
+    ("miseq", "0.050"),
+    ("iseq", "0.050"),
+    ("nextseq", "0.500"),
+]
+
+
+def infer_expected_contamination_pct(instrument_model: str | None) -> str | None:
+    """Return a string-formatted Numeric(5,3) default, or None for unknown models."""
+    if not instrument_model:
+        return None
+    needle = instrument_model.strip().lower()
+    for prefix, pct in _CONTAMINATION_BY_PREFIX:
+        if needle.startswith(prefix):
+            return pct
+    return None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.8.0"
+version = "0.8.1"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_barcode_pattern_only.py
+++ b/backend/tests/test_barcode_pattern_only.py
@@ -1,0 +1,161 @@
+"""Tests for BarcodeMap.is_pattern_only validation (issue #244 §4.5)."""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_library(session):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org = Organization(name="Pattern Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Pattern Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    lib = await LibraryService.create_library(
+        session, org.id, LibraryCreate(sample_id=sample.id)
+    )
+    await session.commit()
+    return org, lib
+
+
+async def test_pattern_only_umi_row_passes(session):
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, lib = await _make_library(session)
+    bm = await BarcodeService.create_barcode_map(
+        session,
+        org.id,
+        lib.id,
+        BarcodeMapCreate(
+            barcode_type="umi",
+            is_pattern_only=True,
+            read_position="R1",
+            offset_in_read=16,
+            length=12,
+        ),
+    )
+    await session.commit()
+    assert bm.is_pattern_only is True
+    assert bm.sequence is None
+
+
+async def test_pattern_only_row_with_sequence_fails(session):
+    from fastapi import HTTPException
+
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, lib = await _make_library(session)
+    with pytest.raises(HTTPException) as exc:
+        await BarcodeService.create_barcode_map(
+            session,
+            org.id,
+            lib.id,
+            BarcodeMapCreate(
+                barcode_type="umi",
+                is_pattern_only=True,
+                sequence="AAAA",
+                read_position="R1",
+                offset_in_read=16,
+                length=12,
+            ),
+        )
+    assert exc.value.status_code == 422
+
+
+async def test_pattern_only_missing_position_fails(session):
+    from fastapi import HTTPException
+
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, lib = await _make_library(session)
+    with pytest.raises(HTTPException) as exc:
+        await BarcodeService.create_barcode_map(
+            session,
+            org.id,
+            lib.id,
+            BarcodeMapCreate(
+                barcode_type="umi",
+                is_pattern_only=True,
+                offset_in_read=16,
+                length=12,
+            ),
+        )
+    assert exc.value.status_code == 422
+
+
+async def test_explicit_row_without_sequence_fails(session):
+    from fastapi import HTTPException
+
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, lib = await _make_library(session)
+    with pytest.raises(HTTPException) as exc:
+        await BarcodeService.create_barcode_map(
+            session,
+            org.id,
+            lib.id,
+            BarcodeMapCreate(
+                barcode_type="cell_barcode",
+                is_pattern_only=False,
+                read_position="R1",
+            ),
+        )
+    assert exc.value.status_code == 422
+
+
+async def test_explicit_row_with_sequence_passes(session):
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, lib = await _make_library(session)
+    bm = await BarcodeService.create_barcode_map(
+        session,
+        org.id,
+        lib.id,
+        BarcodeMapCreate(
+            barcode_type="cell_barcode",
+            is_pattern_only=False,
+            sequence="AAAAAAAAAAAAAAAA",
+            read_position="R1",
+            length=16,
+        ),
+    )
+    await session.commit()
+    assert bm.is_pattern_only is False
+    assert bm.sequence == "AAAAAAAAAAAAAAAA"
+
+
+async def test_whitelist_reference_bypasses_sequence_requirement(session):
+    """is_pattern_only=False + whitelist_reference is still a valid config."""
+    from app.schemas.barcode_map import BarcodeMapCreate
+    from app.services.barcode_service import BarcodeService
+
+    org, lib = await _make_library(session)
+    bm = await BarcodeService.create_barcode_map(
+        session,
+        org.id,
+        lib.id,
+        BarcodeMapCreate(
+            barcode_type="cell_barcode",
+            is_pattern_only=False,
+            whitelist_reference="10x:737K-august-2016",
+            read_position="R1",
+        ),
+    )
+    await session.commit()
+    assert bm.sequence is None
+    assert bm.whitelist_reference == "10x:737K-august-2016"

--- a/backend/tests/test_barcode_pattern_only.py
+++ b/backend/tests/test_barcode_pattern_only.py
@@ -21,9 +21,7 @@ async def _make_library(session):
     sample = Sample(experiment_id=exp.id)
     session.add(sample)
     await session.flush()
-    lib = await LibraryService.create_library(
-        session, org.id, LibraryCreate(sample_id=sample.id)
-    )
+    lib = await LibraryService.create_library(session, org.id, LibraryCreate(sample_id=sample.id))
     await session.commit()
     return org, lib
 

--- a/backend/tests/test_barcode_permissions.py
+++ b/backend/tests/test_barcode_permissions.py
@@ -1,0 +1,212 @@
+"""Tests for barcodes:* permission granularity (issue #244 §4.7) and
+bulk-insert guardrail (§4.8)."""
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_library(client, token) -> int:
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "Perm Test"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    exp_id = exp.json()["id"]
+    smp = await client.post(
+        f"/api/experiments/{exp_id}/samples",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    sid = smp.json()["id"]
+    lib = await client.post(
+        "/api/libraries",
+        json={"sample_id": sid},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    return lib.json()["id"]
+
+
+async def test_bench_user_can_view_and_create_barcodes(
+    client, admin_token, session
+):
+    from app.models.user import User
+    from app.services.auth_service import AuthService
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+    role_map = {
+        r.name: r.id
+        for r in (
+            await session.execute(
+                select(__import__("app.models", fromlist=["Role"]).Role).where(
+                    __import__("app.models", fromlist=["Role"]).Role.organization_id
+                    == admin.organization_id
+                )
+            )
+        ).scalars()
+    }
+    password_hash = AuthService.hash_password("benchpass123")
+    bench = User(
+        email="bench@test.com",
+        password_hash=password_hash,
+        role_id=role_map["bench"],
+        organization_id=admin.organization_id,
+        status="active",
+    )
+    session.add(bench)
+    await session.flush()
+    await session.commit()
+    bench_token = AuthService.create_token(
+        bench.id, bench.email, bench.role_id, bench.organization_id, role_name="bench"
+    )
+
+    lib_id = await _create_library(client, admin_token)
+
+    # Bench can read barcodes.
+    r = await client.get(
+        f"/api/libraries/{lib_id}/barcodes",
+        headers={"Authorization": f"Bearer {bench_token}"},
+    )
+    assert r.status_code == 200
+
+    # Bench can create a library_index-style barcode.
+    r = await client.post(
+        f"/api/libraries/{lib_id}/barcodes",
+        json={
+            "barcode_type": "other",
+            "sequence": "ACGTACGT",
+            "read_position": "R1",
+        },
+        headers={"Authorization": f"Bearer {bench_token}"},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def test_viewer_cannot_create_barcode(client, admin_token, viewer_token):
+    lib_id = await _create_library(client, admin_token)
+    r = await client.post(
+        f"/api/libraries/{lib_id}/barcodes",
+        json={
+            "barcode_type": "other",
+            "sequence": "ACGT",
+            "read_position": "R1",
+        },
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 403
+
+
+async def test_viewer_can_list_barcodes(client, admin_token, viewer_token):
+    lib_id = await _create_library(client, admin_token)
+    r = await client.get(
+        f"/api/libraries/{lib_id}/barcodes",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200
+
+
+async def test_library_index_barcodes_auto_created_without_barcode_permission(
+    session,
+):
+    """Service layer creates library_index rows from Library fields; no barcodes
+    permission is required because the call bypasses the API layer entirely."""
+    from app.models.barcode_map import BarcodeMap
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org = Organization(name="No Barcode Perm", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Auto", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            index_type="dual",
+            i5_sequence="AAAA",
+            i7_sequence="TTTT",
+        ),
+    )
+    await session.commit()
+
+    rows = (
+        (
+            await session.execute(
+                select(BarcodeMap).where(
+                    BarcodeMap.library_id == lib.id,
+                    BarcodeMap.barcode_type == "library_index",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+
+
+async def test_bulk_guardrail_rejects_above_limit(session):
+    """§4.8: bulk create rejects once the library would exceed the cap."""
+    from fastapi import HTTPException
+
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.schemas.barcode_map import BarcodeMapBulkCreate, BarcodeMapCreate
+    from app.schemas.library import LibraryCreate
+    from app.services.barcode_service import (
+        MAX_BARCODES_PER_LIBRARY,
+        BarcodeService,
+    )
+    from app.services.library_service import LibraryService
+
+    org = Organization(name="Guardrail", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="GR", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    lib = await LibraryService.create_library(
+        session, org.id, LibraryCreate(sample_id=sample.id)
+    )
+    await session.commit()
+
+    # Build a payload just over the cap. Use distinct sequences per entry so the
+    # uniqueness constraint doesn't fire first.
+    def _seq(i: int) -> str:
+        letters = "ACGT"
+        s = ""
+        n = i
+        for _ in range(8):
+            s = letters[n % 4] + s
+            n //= 4
+        return s
+
+    entries = [
+        BarcodeMapCreate(
+            barcode_type="sgrna",
+            sequence=_seq(i),
+            name=f"g{i}",
+            read_position="R1",
+        )
+        for i in range(MAX_BARCODES_PER_LIBRARY + 1)
+    ]
+    with pytest.raises(HTTPException) as exc:
+        await BarcodeService.bulk_create_barcode_maps(
+            session, org.id, lib.id, BarcodeMapBulkCreate(entries=entries)
+        )
+    assert exc.value.status_code == 422
+    assert "whitelist_reference" in exc.value.detail

--- a/backend/tests/test_barcode_permissions.py
+++ b/backend/tests/test_barcode_permissions.py
@@ -28,9 +28,7 @@ async def _create_library(client, token) -> int:
     return lib.json()["id"]
 
 
-async def test_bench_user_can_view_and_create_barcodes(
-    client, admin_token, session
-):
+async def test_bench_user_can_view_and_create_barcodes(client, admin_token, session):
     from app.models.user import User
     from app.services.auth_service import AuthService
 
@@ -40,8 +38,7 @@ async def test_bench_user_can_view_and_create_barcodes(
         for r in (
             await session.execute(
                 select(__import__("app.models", fromlist=["Role"]).Role).where(
-                    __import__("app.models", fromlist=["Role"]).Role.organization_id
-                    == admin.organization_id
+                    __import__("app.models", fromlist=["Role"]).Role.organization_id == admin.organization_id
                 )
             )
         ).scalars()
@@ -179,9 +176,7 @@ async def test_bulk_guardrail_rejects_above_limit(session):
     sample = Sample(experiment_id=exp.id)
     session.add(sample)
     await session.flush()
-    lib = await LibraryService.create_library(
-        session, org.id, LibraryCreate(sample_id=sample.id)
-    )
+    lib = await LibraryService.create_library(session, org.id, LibraryCreate(sample_id=sample.id))
     await session.commit()
 
     # Build a payload just over the cap. Use distinct sequences per entry so the
@@ -205,8 +200,6 @@ async def test_bulk_guardrail_rejects_above_limit(session):
         for i in range(MAX_BARCODES_PER_LIBRARY + 1)
     ]
     with pytest.raises(HTTPException) as exc:
-        await BarcodeService.bulk_create_barcode_maps(
-            session, org.id, lib.id, BarcodeMapBulkCreate(entries=entries)
-        )
+        await BarcodeService.bulk_create_barcode_maps(session, org.id, lib.id, BarcodeMapBulkCreate(entries=entries))
     assert exc.value.status_code == 422
     assert "whitelist_reference" in exc.value.detail

--- a/backend/tests/test_demux_reconciliation.py
+++ b/backend/tests/test_demux_reconciliation.py
@@ -272,9 +272,7 @@ async def test_reconcile_api_endpoint(client, admin_token, session):
 
     admin = (await session.execute(select(User).limit(1))).scalar_one()
 
-    batch = SequencingBatch(
-        organization_id=admin.organization_id, code="RC-API", status="pending"
-    )
+    batch = SequencingBatch(organization_id=admin.organization_id, code="RC-API", status="pending")
     session.add(batch)
     await session.flush()
     await session.commit()

--- a/backend/tests/test_demux_reconciliation.py
+++ b/backend/tests/test_demux_reconciliation.py
@@ -1,0 +1,327 @@
+"""Tests for DemuxReconciliationService (issue #244 §4.3)."""
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _bootstrap(session):
+    """Create an org, experiment, sample, and a sequencing batch."""
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.models.sequencing_batch import SequencingBatch
+
+    org = Organization(name="Reconcile Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Reconcile Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    batch = SequencingBatch(organization_id=org.id, code="RC-1", status="pending")
+    session.add(batch)
+    await session.flush()
+    await session.commit()
+    return org, exp, sample, batch
+
+
+async def _library(session, org_id, sample_id, batch_id, **kw):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    lib = await LibraryService.create_library(
+        session,
+        org_id,
+        LibraryCreate(sample_id=sample_id, sequencing_batch_id=batch_id, **kw),
+    )
+    await session.commit()
+    return lib
+
+
+async def _file(session, org_id, batch_id, filename: str):
+    from app.models.file import File
+
+    f = File(
+        organization_id=org_id,
+        gcs_uri=f"gs://rc/{filename}",
+        filename=filename,
+        file_type="fastq",
+        sequencing_batch_id=batch_id,
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+    return f
+
+
+async def test_reconcile_unambiguous_external_id_match(session):
+    from app.models.file import File
+    from app.services.demux_reconciliation_service import (
+        DemuxReconciliationService,
+    )
+
+    org, _, sample, batch = await _bootstrap(session)
+    lib = await _library(
+        session,
+        org.id,
+        sample.id,
+        batch.id,
+        library_id_external="LIB-001",
+        index_type="dual",
+        i5_sequence="AAAA",
+        i7_sequence="TTTT",
+    )
+    f = await _file(session, org.id, batch.id, "LIB-001_S1_L001_R1_001.fastq.gz")
+
+    report = await DemuxReconciliationService.reconcile_batch(session, org.id, batch.id)
+    await session.commit()
+
+    fetched = await session.get(File, f.id)
+    assert fetched.library_id == lib.id
+    assert report.matched == 1
+    assert report.ambiguous == 0
+    assert report.unmatched == 0
+
+
+async def test_reconcile_unambiguous_index_pair_match(session):
+    from app.models.file import File
+    from app.services.demux_reconciliation_service import (
+        DemuxReconciliationService,
+    )
+
+    org, _, sample, batch = await _bootstrap(session)
+    lib = await _library(
+        session,
+        org.id,
+        sample.id,
+        batch.id,
+        index_type="dual",
+        i5_sequence="CCCC",
+        i7_sequence="GGGG",
+    )
+    f = await _file(session, org.id, batch.id, "sample_GGGG+CCCC_L001_R1_001.fastq.gz")
+
+    report = await DemuxReconciliationService.reconcile_batch(session, org.id, batch.id)
+    await session.commit()
+
+    fetched = await session.get(File, f.id)
+    assert fetched.library_id == lib.id
+    assert report.matched == 1
+
+
+async def test_reconcile_ambiguous_leaves_file_unlinked(session):
+    from app.models.file import File
+    from app.models.sample import Sample
+    from app.services.demux_reconciliation_service import (
+        DemuxReconciliationService,
+    )
+
+    org, exp, sample, batch = await _bootstrap(session)
+    # Two libraries share the same indices in the same batch (collision).
+    s2 = Sample(experiment_id=exp.id)
+    session.add(s2)
+    await session.flush()
+    await session.commit()
+
+    await _library(
+        session,
+        org.id,
+        sample.id,
+        batch.id,
+        index_type="dual",
+        i5_sequence="AAAA",
+        i7_sequence="TTTT",
+    )
+    await _library(
+        session,
+        org.id,
+        s2.id,
+        batch.id,
+        index_type="dual",
+        i5_sequence="AAAA",
+        i7_sequence="TTTT",
+    )
+    f = await _file(session, org.id, batch.id, "x_TTTT+AAAA_L001_R1_001.fastq.gz")
+
+    report = await DemuxReconciliationService.reconcile_batch(session, org.id, batch.id)
+    await session.commit()
+
+    fetched = await session.get(File, f.id)
+    assert fetched.library_id is None
+    assert report.ambiguous == 1
+    assert report.matched == 0
+
+
+async def test_reconcile_no_match_leaves_file_unlinked(session):
+    from app.models.file import File
+    from app.services.demux_reconciliation_service import (
+        DemuxReconciliationService,
+    )
+
+    org, _, sample, batch = await _bootstrap(session)
+    await _library(
+        session,
+        org.id,
+        sample.id,
+        batch.id,
+        library_id_external="LIB-042",
+        index_type="dual",
+        i5_sequence="AAAA",
+        i7_sequence="TTTT",
+    )
+    f = await _file(session, org.id, batch.id, "LIB-999_S1_L001_R1_001.fastq.gz")
+
+    report = await DemuxReconciliationService.reconcile_batch(session, org.id, batch.id)
+    await session.commit()
+
+    fetched = await session.get(File, f.id)
+    assert fetched.library_id is None
+    assert report.unmatched == 1
+
+
+async def test_reconcile_is_idempotent(session):
+    from app.models.file import File
+    from app.services.demux_reconciliation_service import (
+        DemuxReconciliationService,
+    )
+
+    org, _, sample, batch = await _bootstrap(session)
+    lib = await _library(
+        session,
+        org.id,
+        sample.id,
+        batch.id,
+        library_id_external="LIB-IDEM",
+        index_type="dual",
+        i5_sequence="AAAA",
+        i7_sequence="TTTT",
+    )
+    f = await _file(session, org.id, batch.id, "LIB-IDEM_S1_L001_R1_001.fastq.gz")
+
+    await DemuxReconciliationService.reconcile_batch(session, org.id, batch.id)
+    await session.commit()
+    first = (await session.get(File, f.id)).library_id
+    assert first == lib.id
+
+    # Second run: no change, and the file count linked to the batch stays 1.
+    second_report = await DemuxReconciliationService.reconcile_batch(session, org.id, batch.id)
+    await session.commit()
+    second = (await session.get(File, f.id)).library_id
+    assert second == lib.id
+    # Already-linked files are excluded from the reconciliation pool.
+    assert second_report.matched == 0
+    assert second_report.ambiguous == 0
+    assert second_report.unmatched == 0
+
+
+async def test_reconcile_skips_already_linked_files(session):
+    from app.services.demux_reconciliation_service import (
+        DemuxReconciliationService,
+    )
+
+    org, _, sample, batch = await _bootstrap(session)
+    lib = await _library(session, org.id, sample.id, batch.id, library_id_external="LIB-PRE")
+
+    # Pre-linked file; filename matches a different lib pattern but should not be touched.
+    from app.models.file import File
+
+    f = File(
+        organization_id=org.id,
+        gcs_uri="gs://rc/pre.fq.gz",
+        filename="LIB-OTHER_S1_L001_R1_001.fastq.gz",
+        file_type="fastq",
+        sequencing_batch_id=batch.id,
+        library_id=lib.id,
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+
+    report = await DemuxReconciliationService.reconcile_batch(session, org.id, batch.id)
+    await session.commit()
+    assert report.matched + report.ambiguous + report.unmatched == 0
+
+
+async def test_reconcile_is_org_scoped(session):
+    from fastapi import HTTPException
+
+    from app.models.organization import Organization
+    from app.services.demux_reconciliation_service import (
+        DemuxReconciliationService,
+    )
+
+    org, _, _, batch = await _bootstrap(session)
+    other_org = Organization(name="Other Reconcile", setup_complete=True)
+    session.add(other_org)
+    await session.flush()
+    await session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await DemuxReconciliationService.reconcile_batch(session, other_org.id, batch.id)
+    assert exc.value.status_code == 404
+
+
+async def test_reconcile_api_endpoint(client, admin_token, session):
+    from app.models.file import File
+    from app.models.sequencing_batch import SequencingBatch
+    from app.models.user import User
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+
+    batch = SequencingBatch(
+        organization_id=admin.organization_id, code="RC-API", status="pending"
+    )
+    session.add(batch)
+    await session.flush()
+    await session.commit()
+
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "RC API Exp"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = exp.json()["id"]
+    smp = await client.post(
+        f"/api/experiments/{exp_id}/samples",
+        json={},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    sample_id = smp.json()["id"]
+
+    await client.post(
+        "/api/libraries",
+        json={
+            "sample_id": sample_id,
+            "library_id_external": "API-LIB",
+            "index_type": "dual",
+            "i5_sequence": "AAAA",
+            "i7_sequence": "TTTT",
+            "sequencing_batch_id": batch.id,
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    f = File(
+        organization_id=admin.organization_id,
+        gcs_uri="gs://rc/api.fq.gz",
+        filename="API-LIB_S1_L001_R1_001.fastq.gz",
+        file_type="fastq",
+        sequencing_batch_id=batch.id,
+    )
+    session.add(f)
+    await session.flush()
+    await session.commit()
+
+    r = await client.post(
+        f"/api/sequencing-batches/{batch.id}/reconcile",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["matched"] == 1
+    assert body["unmatched"] == 0
+    assert body["ambiguous"] == 0

--- a/backend/tests/test_fuzzy_barcode_lookup.py
+++ b/backend/tests/test_fuzzy_barcode_lookup.py
@@ -34,9 +34,7 @@ async def test_fuzzy_lookup_hamming_zero(session):
     from app.services.barcode_service import BarcodeService
 
     org, lib = await _setup_lib(session)
-    matches = await BarcodeService.fuzzy_lookup(
-        session, org.id, "AAAACCCC", max_mismatches=1
-    )
+    matches = await BarcodeService.fuzzy_lookup(session, org.id, "AAAACCCC", max_mismatches=1)
     assert any(m.sequence == "AAAACCCC" and d == 0 for m, d in matches)
 
 
@@ -45,9 +43,7 @@ async def test_fuzzy_lookup_hamming_one(session):
 
     org, _ = await _setup_lib(session)
     # Query one base off: expect distance 1 match.
-    matches = await BarcodeService.fuzzy_lookup(
-        session, org.id, "AAAACCCG", max_mismatches=1
-    )
+    matches = await BarcodeService.fuzzy_lookup(session, org.id, "AAAACCCG", max_mismatches=1)
     distances = [d for m, d in matches if m.sequence == "AAAACCCC"]
     assert 1 in distances
 
@@ -57,9 +53,7 @@ async def test_fuzzy_lookup_rejects_beyond_budget(session):
 
     org, _ = await _setup_lib(session)
     # Two bases off with max=1 should return no match.
-    matches = await BarcodeService.fuzzy_lookup(
-        session, org.id, "AAAAGGGG", max_mismatches=1
-    )
+    matches = await BarcodeService.fuzzy_lookup(session, org.id, "AAAAGGGG", max_mismatches=1)
     assert [(m, d) for m, d in matches if m.sequence == "AAAACCCC"] == []
 
 
@@ -68,9 +62,7 @@ async def test_fuzzy_lookup_hamming_two(session):
 
     org, _ = await _setup_lib(session)
     # Two bases off with max=2 returns distance 2 match.
-    matches = await BarcodeService.fuzzy_lookup(
-        session, org.id, "AAAACCGG", max_mismatches=2
-    )
+    matches = await BarcodeService.fuzzy_lookup(session, org.id, "AAAACCGG", max_mismatches=2)
     distances = [d for m, d in matches if m.sequence == "AAAACCCC"]
     assert 2 in distances
 
@@ -81,9 +73,7 @@ async def test_fuzzy_lookup_is_org_scoped(session):
     _, lib_a = await _setup_lib(session, org_name="Fuzzy A")
     org_b, lib_b = await _setup_lib(session, org_name="Fuzzy B")
 
-    matches = await BarcodeService.fuzzy_lookup(
-        session, org_b.id, "AAAACCCC", max_mismatches=1
-    )
+    matches = await BarcodeService.fuzzy_lookup(session, org_b.id, "AAAACCCC", max_mismatches=1)
     for m, _d in matches:
         assert m.library_id == lib_b.id
 
@@ -106,9 +96,7 @@ async def test_fuzzy_lookup_rejects_long_sequence_with_mismatches(session):
 
     org, _ = await _setup_lib(session)
     with pytest.raises(HTTPException) as exc:
-        await BarcodeService.fuzzy_lookup(
-            session, org.id, "A" * 24, max_mismatches=1
-        )
+        await BarcodeService.fuzzy_lookup(session, org.id, "A" * 24, max_mismatches=1)
     assert exc.value.status_code == 422
 
 

--- a/backend/tests/test_fuzzy_barcode_lookup.py
+++ b/backend/tests/test_fuzzy_barcode_lookup.py
@@ -1,0 +1,191 @@
+"""Tests for fuzzy (Hamming-distance) barcode lookup (issue #244 §4.1)."""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup_lib(session, org_name="Fuzzy Org"):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org = Organization(name=org_name, setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Fuzzy Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, index_type="single", i7_sequence="AAAACCCC"),
+    )
+    await session.commit()
+    return org, lib
+
+
+async def test_fuzzy_lookup_hamming_zero(session):
+    from app.services.barcode_service import BarcodeService
+
+    org, lib = await _setup_lib(session)
+    matches = await BarcodeService.fuzzy_lookup(
+        session, org.id, "AAAACCCC", max_mismatches=1
+    )
+    assert any(m.sequence == "AAAACCCC" and d == 0 for m, d in matches)
+
+
+async def test_fuzzy_lookup_hamming_one(session):
+    from app.services.barcode_service import BarcodeService
+
+    org, _ = await _setup_lib(session)
+    # Query one base off: expect distance 1 match.
+    matches = await BarcodeService.fuzzy_lookup(
+        session, org.id, "AAAACCCG", max_mismatches=1
+    )
+    distances = [d for m, d in matches if m.sequence == "AAAACCCC"]
+    assert 1 in distances
+
+
+async def test_fuzzy_lookup_rejects_beyond_budget(session):
+    from app.services.barcode_service import BarcodeService
+
+    org, _ = await _setup_lib(session)
+    # Two bases off with max=1 should return no match.
+    matches = await BarcodeService.fuzzy_lookup(
+        session, org.id, "AAAAGGGG", max_mismatches=1
+    )
+    assert [(m, d) for m, d in matches if m.sequence == "AAAACCCC"] == []
+
+
+async def test_fuzzy_lookup_hamming_two(session):
+    from app.services.barcode_service import BarcodeService
+
+    org, _ = await _setup_lib(session)
+    # Two bases off with max=2 returns distance 2 match.
+    matches = await BarcodeService.fuzzy_lookup(
+        session, org.id, "AAAACCGG", max_mismatches=2
+    )
+    distances = [d for m, d in matches if m.sequence == "AAAACCCC"]
+    assert 2 in distances
+
+
+async def test_fuzzy_lookup_is_org_scoped(session):
+    from app.services.barcode_service import BarcodeService
+
+    _, lib_a = await _setup_lib(session, org_name="Fuzzy A")
+    org_b, lib_b = await _setup_lib(session, org_name="Fuzzy B")
+
+    matches = await BarcodeService.fuzzy_lookup(
+        session, org_b.id, "AAAACCCC", max_mismatches=1
+    )
+    for m, _d in matches:
+        assert m.library_id == lib_b.id
+
+
+async def test_fuzzy_lookup_rejects_invalid_sequence(session):
+    from fastapi import HTTPException
+
+    from app.services.barcode_service import BarcodeService
+
+    org, _ = await _setup_lib(session)
+    with pytest.raises(HTTPException) as exc:
+        await BarcodeService.fuzzy_lookup(session, org.id, "BAD!", max_mismatches=1)
+    assert exc.value.status_code == 422
+
+
+async def test_fuzzy_lookup_rejects_long_sequence_with_mismatches(session):
+    from fastapi import HTTPException
+
+    from app.services.barcode_service import BarcodeService
+
+    org, _ = await _setup_lib(session)
+    with pytest.raises(HTTPException) as exc:
+        await BarcodeService.fuzzy_lookup(
+            session, org.id, "A" * 24, max_mismatches=1
+        )
+    assert exc.value.status_code == 422
+
+
+async def test_fuzzy_lookup_long_sequence_exact_match_ok(session):
+    """Length > 16 is permitted at max_mismatches=0 (degrades to exact match)."""
+    from app.models.library import Library
+    from app.models.barcode_map import BarcodeMap
+    from app.services.barcode_service import BarcodeService
+
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+
+    org = Organization(name="Long Fuzzy", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="LF", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    lib = Library(organization_id=org.id, sample_id=sample.id)
+    session.add(lib)
+    await session.flush()
+    long_seq = "A" * 24
+    session.add(
+        BarcodeMap(
+            organization_id=org.id,
+            library_id=lib.id,
+            barcode_type="cell_barcode",
+            sequence=long_seq,
+            read_position="R1",
+        )
+    )
+    await session.commit()
+
+    matches = await BarcodeService.fuzzy_lookup(session, org.id, long_seq, max_mismatches=0)
+    assert any(m.sequence == long_seq and d == 0 for m, d in matches)
+
+
+async def test_fuzzy_lookup_api_endpoint(client, admin_token, session):
+    from sqlalchemy import select
+
+    from app.models.user import User
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "FZ API"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = exp.json()["id"]
+    smp = await client.post(
+        f"/api/experiments/{exp_id}/samples",
+        json={},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    sid = smp.json()["id"]
+    await client.post(
+        "/api/libraries",
+        json={
+            "sample_id": sid,
+            "index_type": "single",
+            "i7_sequence": "AAAACCCC",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    r = await client.get(
+        "/api/barcodes/fuzzy-lookup?sequence=AAAACCCG&max_mismatches=1",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert any(entry["sequence"] == "AAAACCCC" and entry["distance"] == 1 for entry in body)
+    # Ensure org_id is the admin's.
+    for entry in body:
+        assert entry["organization_id"] == admin.organization_id

--- a/backend/tests/test_i5_orientation_inference.py
+++ b/backend/tests/test_i5_orientation_inference.py
@@ -1,0 +1,154 @@
+"""Tests for i5 orientation inference (issue #244 §3.4)."""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _bootstrap(session, instrument_model: str | None = None):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.models.sequencing_batch import SequencingBatch
+
+    org = Organization(name="I5 Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="I5 Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    batch = None
+    if instrument_model is not None:
+        batch = SequencingBatch(
+            organization_id=org.id,
+            code="I5-BATCH",
+            status="pending",
+            instrument_model=instrument_model,
+        )
+        session.add(batch)
+        await session.flush()
+    await session.commit()
+    return org, sample, batch
+
+
+async def test_novaseq_batch_infers_reverse_complement(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "NovaSeq 6000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            sequencing_batch_id=batch.id,
+            index_type="dual",
+            i5_sequence="AAAA",
+            i7_sequence="TTTT",
+        ),
+    )
+    await session.commit()
+    assert lib.i5_orientation_convention == "reverse_complement"
+
+
+async def test_miseq_batch_infers_forward(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "MiSeq")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            sequencing_batch_id=batch.id,
+            index_type="dual",
+            i5_sequence="AAAA",
+            i7_sequence="TTTT",
+        ),
+    )
+    await session.commit()
+    assert lib.i5_orientation_convention == "forward"
+
+
+async def test_user_supplied_value_is_never_overridden(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "NovaSeq 6000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            sequencing_batch_id=batch.id,
+            index_type="dual",
+            i5_sequence="AAAA",
+            i7_sequence="TTTT",
+            i5_orientation_convention="forward",
+        ),
+    )
+    await session.commit()
+    assert lib.i5_orientation_convention == "forward"
+
+
+async def test_no_batch_no_inference(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, _ = await _bootstrap(session, instrument_model=None)
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            index_type="dual",
+            i5_sequence="AAAA",
+            i7_sequence="TTTT",
+        ),
+    )
+    await session.commit()
+    assert lib.i5_orientation_convention is None
+
+
+async def test_unknown_sequencer_leaves_null(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "MysteryMachine 3000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            sequencing_batch_id=batch.id,
+            index_type="dual",
+            i5_sequence="AAAA",
+            i7_sequence="TTTT",
+        ),
+    )
+    await session.commit()
+    assert lib.i5_orientation_convention is None
+
+
+async def test_nextseq_2000_infers_reverse_complement(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "NextSeq 2000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            sequencing_batch_id=batch.id,
+            index_type="dual",
+            i5_sequence="AAAA",
+            i7_sequence="TTTT",
+        ),
+    )
+    await session.commit()
+    assert lib.i5_orientation_convention == "reverse_complement"

--- a/backend/tests/test_index_hopping.py
+++ b/backend/tests/test_index_hopping.py
@@ -1,0 +1,137 @@
+"""Tests for Library.expected_contamination_pct (issue #244 §4.2)."""
+
+from decimal import Decimal
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _bootstrap(session, instrument_model: str | None = None):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.models.sequencing_batch import SequencingBatch
+
+    org = Organization(name="Hop Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Hop Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    batch = None
+    if instrument_model is not None:
+        batch = SequencingBatch(
+            organization_id=org.id,
+            code="HP-BATCH",
+            status="pending",
+            instrument_model=instrument_model,
+        )
+        session.add(batch)
+        await session.flush()
+    await session.commit()
+    return org, sample, batch
+
+
+async def test_novaseq_default_contamination(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "NovaSeq 6000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, sequencing_batch_id=batch.id),
+    )
+    await session.commit()
+    assert lib.expected_contamination_pct == Decimal("0.500")
+
+
+async def test_nextseq_2000_default_contamination(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "NextSeq 2000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, sequencing_batch_id=batch.id),
+    )
+    await session.commit()
+    assert lib.expected_contamination_pct == Decimal("1.000")
+
+
+async def test_miseq_default_contamination(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "MiSeq")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, sequencing_batch_id=batch.id),
+    )
+    await session.commit()
+    assert lib.expected_contamination_pct == Decimal("0.050")
+
+
+async def test_user_supplied_contamination_wins(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "NovaSeq 6000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=sample.id,
+            sequencing_batch_id=batch.id,
+            expected_contamination_pct=Decimal("2.500"),
+        ),
+    )
+    await session.commit()
+    assert lib.expected_contamination_pct == Decimal("2.500")
+
+
+async def test_no_batch_no_contamination_inference(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, _ = await _bootstrap(session, instrument_model=None)
+    lib = await LibraryService.create_library(
+        session, org.id, LibraryCreate(sample_id=sample.id)
+    )
+    await session.commit()
+    assert lib.expected_contamination_pct is None
+
+
+async def test_unknown_instrument_no_contamination_inference(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "Unknown-X")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, sequencing_batch_id=batch.id),
+    )
+    await session.commit()
+    assert lib.expected_contamination_pct is None
+
+
+async def test_contamination_pct_in_library_response(session):
+    from app.schemas.library import LibraryCreate, LibraryResponse
+    from app.services.library_service import LibraryService
+
+    org, sample, batch = await _bootstrap(session, "NovaSeq 6000")
+    lib = await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(sample_id=sample.id, sequencing_batch_id=batch.id),
+    )
+    await session.commit()
+    out = LibraryResponse.model_validate(lib)
+    assert out.expected_contamination_pct == Decimal("0.500")

--- a/backend/tests/test_index_hopping.py
+++ b/backend/tests/test_index_hopping.py
@@ -101,9 +101,7 @@ async def test_no_batch_no_contamination_inference(session):
     from app.services.library_service import LibraryService
 
     org, sample, _ = await _bootstrap(session, instrument_model=None)
-    lib = await LibraryService.create_library(
-        session, org.id, LibraryCreate(sample_id=sample.id)
-    )
+    lib = await LibraryService.create_library(session, org.id, LibraryCreate(sample_id=sample.id))
     await session.commit()
     assert lib.expected_contamination_pct is None
 

--- a/backend/tests/test_library_backfill.py
+++ b/backend/tests/test_library_backfill.py
@@ -41,9 +41,7 @@ async def _file_on_sample(session, org_id, sample_id, filename):
     )
     session.add(f)
     await session.flush()
-    await session.execute(
-        sample_files.insert().values(sample_id=sample_id, file_id=f.id)
-    )
+    await session.execute(sample_files.insert().values(sample_id=sample_id, file_id=f.id))
     await session.flush()
     return f
 
@@ -150,9 +148,7 @@ async def test_commit_leaves_already_linked_files_untouched(session):
     from app.services.library_service import LibraryService
 
     s_other = await _sample(session, exp.id)
-    existing_lib = await LibraryService.create_library(
-        session, org.id, LibraryCreate(sample_id=s_other.id)
-    )
+    existing_lib = await LibraryService.create_library(session, org.id, LibraryCreate(sample_id=s_other.id))
     await session.commit()
 
     f = await _file_on_sample(session, org.id, s1.id, "linked.fastq.gz")

--- a/backend/tests/test_library_backfill.py
+++ b/backend/tests/test_library_backfill.py
@@ -1,0 +1,251 @@
+"""Tests for library backfill wizard (issue #244 §4.4, backend only)."""
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _bootstrap(session):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+
+    org = Organization(name="Backfill Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Backfill Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    await session.commit()
+    return org, exp
+
+
+async def _sample(session, experiment_id, **kw):
+    from app.models.sample import Sample
+
+    s = Sample(experiment_id=experiment_id, **kw)
+    session.add(s)
+    await session.flush()
+    return s
+
+
+async def _file_on_sample(session, org_id, sample_id, filename):
+    from app.models.file import File
+    from app.models.sample import sample_files
+
+    f = File(
+        organization_id=org_id,
+        gcs_uri=f"gs://bf/{filename}",
+        filename=filename,
+        file_type="fastq",
+    )
+    session.add(f)
+    await session.flush()
+    await session.execute(
+        sample_files.insert().values(sample_id=sample_id, file_id=f.id)
+    )
+    await session.flush()
+    return f
+
+
+async def test_preview_returns_planned_rows_without_writes(session):
+    from app.models.library import Library
+    from app.services.library_backfill_service import LibraryBackfillService
+
+    org, exp = await _bootstrap(session)
+    s1 = await _sample(session, exp.id, library_prep_method="TruSeq", library_layout="paired")
+    s2 = await _sample(session, exp.id, library_prep_method="SMART-seq", library_layout="single")
+    await _file_on_sample(session, org.id, s1.id, "s1_r1.fastq.gz")
+    await _file_on_sample(session, org.id, s2.id, "s2_r1.fastq.gz")
+    await session.commit()
+
+    preview = await LibraryBackfillService.preview(session, org.id, exp.id)
+
+    assert preview.libraries_to_create == 2
+    assert preview.files_to_attach == 2
+    assert preview.samples_skipped == 0
+    sample_ids = sorted(entry.sample_id for entry in preview.entries)
+    assert sample_ids == sorted([s1.id, s2.id])
+
+    # Preview must not write anything.
+    count = (await session.execute(select(Library))).scalars().all()
+    assert len(count) == 0
+
+
+async def test_commit_creates_libraries_and_attaches_files(session):
+    from app.models.file import File
+    from app.models.library import Library
+    from app.services.library_backfill_service import LibraryBackfillService
+
+    org, exp = await _bootstrap(session)
+    s1 = await _sample(session, exp.id, library_prep_method="TruSeq", library_layout="paired")
+    f1 = await _file_on_sample(session, org.id, s1.id, "s1.fastq.gz")
+    await session.commit()
+
+    result = await LibraryBackfillService.commit(session, org.id, exp.id)
+    await session.commit()
+
+    libs = (await session.execute(select(Library).where(Library.sample_id == s1.id))).scalars().all()
+    assert len(libs) == 1
+    lib = libs[0]
+    assert lib.prep_kit == "TruSeq"
+    assert lib.read_layout == "paired"
+
+    file_row = await session.get(File, f1.id)
+    assert file_row.library_id == lib.id
+    assert result.libraries_created == 1
+    assert result.files_attached == 1
+
+
+async def test_commit_is_idempotent(session):
+    from app.models.library import Library
+    from app.services.library_backfill_service import LibraryBackfillService
+
+    org, exp = await _bootstrap(session)
+    s1 = await _sample(session, exp.id, library_prep_method="TruSeq")
+    await _file_on_sample(session, org.id, s1.id, "s1.fastq.gz")
+    await session.commit()
+
+    first = await LibraryBackfillService.commit(session, org.id, exp.id)
+    await session.commit()
+    second = await LibraryBackfillService.commit(session, org.id, exp.id)
+    await session.commit()
+
+    assert first.libraries_created == 1
+    assert first.files_attached == 1
+    assert second.libraries_created == 0
+    assert second.files_attached == 0
+
+    libs = (await session.execute(select(Library).where(Library.sample_id == s1.id))).scalars().all()
+    assert len(libs) == 1
+
+
+async def test_commit_skips_samples_with_existing_library(session):
+    from app.schemas.library import LibraryCreate
+    from app.services.library_backfill_service import LibraryBackfillService
+    from app.services.library_service import LibraryService
+
+    org, exp = await _bootstrap(session)
+    s1 = await _sample(session, exp.id)
+    await LibraryService.create_library(
+        session, org.id, LibraryCreate(sample_id=s1.id, library_id_external="PRE-EXISTING")
+    )
+    await _file_on_sample(session, org.id, s1.id, "existing.fastq.gz")
+    await session.commit()
+
+    result = await LibraryBackfillService.commit(session, org.id, exp.id)
+    await session.commit()
+    assert result.libraries_created == 0
+    assert result.samples_skipped == 1
+
+
+async def test_commit_leaves_already_linked_files_untouched(session):
+    from app.models.file import File
+    from app.services.library_backfill_service import LibraryBackfillService
+
+    org, exp = await _bootstrap(session)
+    s1 = await _sample(session, exp.id, library_prep_method="TruSeq")
+    # File already has a library_id set elsewhere; don't overwrite it.
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    s_other = await _sample(session, exp.id)
+    existing_lib = await LibraryService.create_library(
+        session, org.id, LibraryCreate(sample_id=s_other.id)
+    )
+    await session.commit()
+
+    f = await _file_on_sample(session, org.id, s1.id, "linked.fastq.gz")
+    f.library_id = existing_lib.id
+    await session.flush()
+    await session.commit()
+
+    await LibraryBackfillService.commit(session, org.id, exp.id)
+    await session.commit()
+
+    refreshed = await session.get(File, f.id)
+    assert refreshed.library_id == existing_lib.id
+
+
+async def test_preview_is_org_scoped(session):
+    from fastapi import HTTPException
+
+    from app.models.organization import Organization
+    from app.services.library_backfill_service import LibraryBackfillService
+
+    _, exp = await _bootstrap(session)
+    other_org = Organization(name="Other BF Org", setup_complete=True)
+    session.add(other_org)
+    await session.flush()
+    await session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await LibraryBackfillService.preview(session, other_org.id, exp.id)
+    assert exc.value.status_code == 404
+
+
+async def test_backfill_api_preview_and_commit(client, admin_token, session):
+    from app.models.user import User
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "BF API Exp"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = exp.json()["id"]
+
+    smp = await client.post(
+        f"/api/experiments/{exp_id}/samples",
+        json={"library_prep_method": "TruSeq", "library_layout": "paired"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    sample_id = smp.json()["id"]
+
+    # Upload a file and link it to the sample via the ORM (upload flow is
+    # out of scope here).
+    from app.models.file import File
+    from app.models.sample import sample_files
+
+    f = File(
+        organization_id=admin.organization_id,
+        gcs_uri="gs://bf/api.fq.gz",
+        filename="api.fq.gz",
+        file_type="fastq",
+    )
+    session.add(f)
+    await session.flush()
+    await session.execute(sample_files.insert().values(sample_id=sample_id, file_id=f.id))
+    await session.commit()
+
+    preview_r = await client.post(
+        f"/api/experiments/{exp_id}/backfill-libraries/preview",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert preview_r.status_code == 200, preview_r.text
+    assert preview_r.json()["libraries_to_create"] == 1
+    assert preview_r.json()["files_to_attach"] == 1
+
+    commit_r = await client.post(
+        f"/api/experiments/{exp_id}/backfill-libraries/commit",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert commit_r.status_code == 200
+    assert commit_r.json()["libraries_created"] == 1
+    assert commit_r.json()["files_attached"] == 1
+
+
+async def test_backfill_api_requires_admin_level_permission(client, admin_token, viewer_token):
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "BF RBAC Exp"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    exp_id = exp.json()["id"]
+
+    preview_r = await client.post(
+        f"/api/experiments/{exp_id}/backfill-libraries/preview",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert preview_r.status_code == 403

--- a/backend/tests/test_pre_demux_toggle.py
+++ b/backend/tests/test_pre_demux_toggle.py
@@ -1,0 +1,53 @@
+"""Tests for the ingest.pre_demux_enabled scaffolding toggle (issue #244 §3.1)."""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_default_is_false(session):
+    from app.services.library_service import LibraryService
+
+    assert await LibraryService.is_pre_demux_enabled(session) is False
+
+
+async def test_reads_true_when_set(session):
+    from app.models.component import PlatformConfig
+    from app.services.library_service import (
+        LibraryService,
+        PRE_DEMUX_ENABLED_KEY,
+    )
+
+    session.add(PlatformConfig(key=PRE_DEMUX_ENABLED_KEY, value="true"))
+    await session.flush()
+    await session.commit()
+
+    assert await LibraryService.is_pre_demux_enabled(session) is True
+
+
+async def test_other_truthy_values_are_accepted(session):
+    from app.models.component import PlatformConfig
+    from app.services.library_service import (
+        LibraryService,
+        PRE_DEMUX_ENABLED_KEY,
+    )
+
+    session.add(PlatformConfig(key=PRE_DEMUX_ENABLED_KEY, value="1"))
+    await session.flush()
+    await session.commit()
+
+    assert await LibraryService.is_pre_demux_enabled(session) is True
+
+
+async def test_false_value_returns_false(session):
+    from app.models.component import PlatformConfig
+    from app.services.library_service import (
+        LibraryService,
+        PRE_DEMUX_ENABLED_KEY,
+    )
+
+    session.add(PlatformConfig(key=PRE_DEMUX_ENABLED_KEY, value="false"))
+    await session.flush()
+    await session.commit()
+
+    assert await LibraryService.is_pre_demux_enabled(session) is False

--- a/backend/tests/test_sample_prep_metadata.py
+++ b/backend/tests/test_sample_prep_metadata.py
@@ -1,0 +1,143 @@
+"""Tests for SampleService.get_prep_metadata (issue #244 §3.3)."""
+
+import logging
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup(session):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+
+    org = Organization(name="Prep Meta Org", setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Prep Meta Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    return org, exp
+
+
+async def test_prep_metadata_falls_back_to_sample_columns_when_no_library(session):
+    from app.models.sample import Sample
+    from app.services.sample_service import SampleService
+
+    org, exp = await _setup(session)
+    s = Sample(
+        experiment_id=exp.id,
+        library_prep_method="TruSeq",
+        library_layout="paired",
+    )
+    session.add(s)
+    await session.flush()
+    await session.commit()
+
+    meta = await SampleService.get_prep_metadata(session, org.id, s.id)
+    assert meta["source"] == "sample"
+    assert meta["prep_kit"] == "TruSeq"
+    assert meta["read_layout"] == "paired"
+
+
+async def test_prep_metadata_returns_library_when_present(session):
+    from app.models.sample import Sample
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+    from app.services.sample_service import SampleService
+
+    org, exp = await _setup(session)
+    s = Sample(
+        experiment_id=exp.id,
+        library_prep_method="legacy-TruSeq",
+        library_layout="single",
+    )
+    session.add(s)
+    await session.flush()
+    await session.commit()
+
+    await LibraryService.create_library(
+        session,
+        org.id,
+        LibraryCreate(
+            sample_id=s.id,
+            prep_kit="TruSeq-v2",
+            read_layout="paired",
+        ),
+    )
+    await session.commit()
+
+    meta = await SampleService.get_prep_metadata(session, org.id, s.id)
+    assert meta["source"] == "library"
+    assert meta["prep_kit"] == "TruSeq-v2"
+    assert meta["read_layout"] == "paired"
+
+
+async def test_prep_metadata_missing_sample_raises(session):
+    from fastapi import HTTPException
+
+    from app.services.sample_service import SampleService
+
+    org, _ = await _setup(session)
+    with pytest.raises(HTTPException) as exc:
+        await SampleService.get_prep_metadata(session, org.id, 999_999)
+    assert exc.value.status_code == 404
+
+
+async def test_writing_sample_prep_columns_emits_deprecation_warning(
+    session, caplog
+):
+    from app.models.sample import Sample
+    from app.schemas.sample import SampleUpdate
+    from app.services.sample_service import SampleService
+
+    _, exp = await _setup(session)
+    s = Sample(experiment_id=exp.id)
+    session.add(s)
+    await session.flush()
+    await session.commit()
+
+    with caplog.at_level(logging.WARNING, logger="bioaf.sample_deprecation"):
+        await SampleService.update_sample(
+            session,
+            s.id,
+            user_id=None,
+            data=SampleUpdate(library_prep_method="NewKit"),
+        )
+    await session.commit()
+
+    deprecation = [
+        r
+        for r in caplog.records
+        if r.name == "bioaf.sample_deprecation"
+        and "library_prep_method" in r.getMessage()
+    ]
+    assert deprecation, "expected a deprecation warning log for Sample.library_prep_method"
+
+
+async def test_writing_non_deprecated_field_does_not_emit_warning(
+    session, caplog
+):
+    from app.models.sample import Sample
+    from app.schemas.sample import SampleUpdate
+    from app.services.sample_service import SampleService
+
+    _, exp = await _setup(session)
+    s = Sample(experiment_id=exp.id)
+    session.add(s)
+    await session.flush()
+    await session.commit()
+
+    with caplog.at_level(logging.WARNING, logger="bioaf.sample_deprecation"):
+        await SampleService.update_sample(
+            session,
+            s.id,
+            user_id=None,
+            data=SampleUpdate(organism="Homo sapiens"),
+        )
+    await session.commit()
+
+    deprecation = [
+        r for r in caplog.records if r.name == "bioaf.sample_deprecation"
+    ]
+    assert deprecation == []

--- a/backend/tests/test_sample_prep_metadata.py
+++ b/backend/tests/test_sample_prep_metadata.py
@@ -84,9 +84,7 @@ async def test_prep_metadata_missing_sample_raises(session):
     assert exc.value.status_code == 404
 
 
-async def test_writing_sample_prep_columns_emits_deprecation_warning(
-    session, caplog
-):
+async def test_writing_sample_prep_columns_emits_deprecation_warning(session, caplog):
     from app.models.sample import Sample
     from app.schemas.sample import SampleUpdate
     from app.services.sample_service import SampleService
@@ -107,17 +105,12 @@ async def test_writing_sample_prep_columns_emits_deprecation_warning(
     await session.commit()
 
     deprecation = [
-        r
-        for r in caplog.records
-        if r.name == "bioaf.sample_deprecation"
-        and "library_prep_method" in r.getMessage()
+        r for r in caplog.records if r.name == "bioaf.sample_deprecation" and "library_prep_method" in r.getMessage()
     ]
     assert deprecation, "expected a deprecation warning log for Sample.library_prep_method"
 
 
-async def test_writing_non_deprecated_field_does_not_emit_warning(
-    session, caplog
-):
+async def test_writing_non_deprecated_field_does_not_emit_warning(session, caplog):
     from app.models.sample import Sample
     from app.schemas.sample import SampleUpdate
     from app.services.sample_service import SampleService
@@ -137,7 +130,5 @@ async def test_writing_non_deprecated_field_does_not_emit_warning(
         )
     await session.commit()
 
-    deprecation = [
-        r for r in caplog.records if r.name == "bioaf.sample_deprecation"
-    ]
+    deprecation = [r for r in caplog.records if r.name == "bioaf.sample_deprecation"]
     assert deprecation == []

--- a/backend/tests/test_sample_swap_checks.py
+++ b/backend/tests/test_sample_swap_checks.py
@@ -22,9 +22,7 @@ async def _setup_lib(session, org_name="Swap Org"):
     sample = Sample(experiment_id=exp.id)
     session.add(sample)
     await session.flush()
-    lib = await LibraryService.create_library(
-        session, org.id, LibraryCreate(sample_id=sample.id)
-    )
+    lib = await LibraryService.create_library(session, org.id, LibraryCreate(sample_id=sample.id))
     await session.commit()
     return org, lib
 

--- a/backend/tests/test_sample_swap_checks.py
+++ b/backend/tests/test_sample_swap_checks.py
@@ -1,0 +1,180 @@
+"""Tests for sample swap check model and API (issue #244 §4.6)."""
+
+import pytest
+from sqlalchemy import select
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup_lib(session, org_name="Swap Org"):
+    from app.models.experiment import Experiment
+    from app.models.organization import Organization
+    from app.models.sample import Sample
+    from app.schemas.library import LibraryCreate
+    from app.services.library_service import LibraryService
+
+    org = Organization(name=org_name, setup_complete=True)
+    session.add(org)
+    await session.flush()
+    exp = Experiment(name="Swap Exp", organization_id=org.id)
+    session.add(exp)
+    await session.flush()
+    sample = Sample(experiment_id=exp.id)
+    session.add(sample)
+    await session.flush()
+    lib = await LibraryService.create_library(
+        session, org.id, LibraryCreate(sample_id=sample.id)
+    )
+    await session.commit()
+    return org, lib
+
+
+async def test_swap_check_model_is_registered():
+    from app.models import SampleSwapCheck
+
+    assert SampleSwapCheck.__tablename__ == "sample_swap_checks"
+
+
+async def test_swap_check_create_and_list_via_api(client, admin_token, session):
+    from app.models.user import User
+
+    admin = (await session.execute(select(User).limit(1))).scalar_one()
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "Swap API"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    eid = exp.json()["id"]
+    smp = await client.post(
+        f"/api/experiments/{eid}/samples",
+        json={},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    sid = smp.json()["id"]
+    lib = await client.post(
+        "/api/libraries",
+        json={"sample_id": sid},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    lib_id = lib.json()["id"]
+
+    r = await client.post(
+        f"/api/libraries/{lib_id}/swap-checks",
+        json={
+            "expected_attribute": "species:Homo sapiens",
+            "observed_attribute": "species:Mus musculus",
+            "status": "mismatch",
+            "evidence_json": {"method": "kraken2", "confidence": 0.98},
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200, r.text
+    check = r.json()
+    assert check["status"] == "mismatch"
+    assert check["library_id"] == lib_id
+    assert check["organization_id"] == admin.organization_id
+    assert check["resolved_at"] is None
+
+    # List unresolved mismatches for the library.
+    list_r = await client.get(
+        f"/api/libraries/{lib_id}/swap-checks?unresolved_only=true",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert list_r.status_code == 200
+    rows = list_r.json()
+    assert len(rows) == 1
+    assert rows[0]["id"] == check["id"]
+
+
+async def test_swap_check_list_returns_empty_when_none(client, admin_token):
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "Swap Empty"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    eid = exp.json()["id"]
+    smp = await client.post(
+        f"/api/experiments/{eid}/samples",
+        json={},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    sid = smp.json()["id"]
+    lib = await client.post(
+        "/api/libraries",
+        json={"sample_id": sid},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    lib_id = lib.json()["id"]
+
+    r = await client.get(
+        f"/api/libraries/{lib_id}/swap-checks",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+async def test_swap_check_resolve(client, admin_token):
+    exp = await client.post(
+        "/api/experiments",
+        json={"name": "Swap Resolve"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    eid = exp.json()["id"]
+    smp = await client.post(
+        f"/api/experiments/{eid}/samples",
+        json={},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    sid = smp.json()["id"]
+    lib = await client.post(
+        "/api/libraries",
+        json={"sample_id": sid},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    lib_id = lib.json()["id"]
+
+    create_r = await client.post(
+        f"/api/libraries/{lib_id}/swap-checks",
+        json={
+            "expected_attribute": "sex:female",
+            "observed_attribute": "sex:male",
+            "status": "mismatch",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    check_id = create_r.json()["id"]
+
+    resolve_r = await client.patch(
+        f"/api/swap-checks/{check_id}/resolve",
+        json={"resolution_notes": "investigated, was correct"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resolve_r.status_code == 200
+    assert resolve_r.json()["resolved_at"] is not None
+
+    list_r = await client.get(
+        f"/api/libraries/{lib_id}/swap-checks?unresolved_only=true",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert list_r.json() == []
+
+    # Without unresolved_only, the resolved row is visible.
+    all_r = await client.get(
+        f"/api/libraries/{lib_id}/swap-checks",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert len(all_r.json()) == 1
+
+
+async def test_swap_check_is_org_scoped(session):
+    from fastapi import HTTPException
+
+    from app.services.sample_swap_service import SampleSwapService
+
+    _, lib_a = await _setup_lib(session, "Swap A")
+    org_b, _ = await _setup_lib(session, "Swap B")
+
+    with pytest.raises(HTTPException) as exc:
+        await SampleSwapService.list_checks(session, org_b.id, lib_a.id)
+    assert exc.value.status_code == 404

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Second backend-only update for the Library / Barcode feature. Builds on v0.8.0 with the services, permissions, and edge-case handling needed before UI work ships
- Covers all 9 items from the spec sequencing: demux reconciliation, backfill wizard (backend), Sample-column deprecation path, fuzzy lookup, i5 orientation inference, index-hopping tracking, UMI/pattern-only clarity, barcode permission split, sample swap detection (model + API), and pre-demux ingest scaffolding
- **No user-visible changes in this release.** UI surface continues to be tracked separately

Implements GitHub issue #244 per ``documentation/spec-library-barcode-operational-gaps.md``.

## Test plan

- [x] Backend tests: 1895 passed (``pytest -x -q``)
- [x] Frontend tests: 412 passed (``npm test``)
- [x] ruff format + ruff check: clean
- [x] mypy: clean across 626 files
- [x] frontend tsc: clean
- [x] markdownlint on ``decisions/``, ``docs/``, ``docs/guides/``, ``RELEASE_NOTES.md``: clean
- [x] Migrations 068, 069, 070 -- upgrade + downgrade verified against a fresh DB
- [ ] Manual API smoke via ``/docs`` if desired: try ``POST /api/sequencing-batches/{id}/reconcile``, ``GET /api/barcodes/fuzzy-lookup``, ``POST /api/experiments/{id}/backfill-libraries/preview``, and the swap-check resolution flow

## Deferred (tracked separately)

- Full frontend UI for Library, Barcode, backfill, reconciliation, swap-check screens
- Sequencing Run / Lane model, lineage query API, manifest-ingest integration
- ``file_libraries`` junction table (pre-demux multi-library attribution) -- waiting on a concrete workflow
- Barcode whitelist storage (``barcode_whitelists`` tables) -- skipped for v1
- Sample prep-column 410-Gone freeze date -- future release decision
- Pipeline step that writes ``sample_swap_checks`` rows -- pipelines team