### PR TITLE
v0.8.0: Google Sheets integration for field setup and sample import

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+## v0.8.0
+
+Google Sheets integration for experiment field setup and sample import.
+
+### New features
+
+- Import column headers from a Google Sheet during experiment creation to populate sample field defaults and custom fields, with a column mapping UI that lets users map sheet columns to existing fields or create new custom fields
+- Import sample data directly from a Google Sheet using the same preview, column mapping, and confirm flow as CSV import
+- Dedicated reader service account provisioned automatically via the IAM API, managed from Settings > Integrations > GCP
+- Auto-match unknown columns to existing custom fields when names match, so repeat imports pre-select the right mapping
+- All 19 user-facing sample fields are now recognized during import (not just the 10 defaultable ones), with visual indicators distinguishing fields that support defaults from per-sample fields
+
+### Platform updates
+
+- Add `iam.serviceAccountKeys.create` permission and `roles/iam.serviceAccountKeyAdmin` role to the GCP setup checklist, install script, settings UI, and setup wizard
+- Add `google-api-python-client` dependency for Sheets API v4 and IAM Admin API access
+
+### Bug fixes
+
+- Fix IAM propagation race condition when creating the reader service account key immediately after SA creation
+- Fix dropdown collision where "Add as new custom field" and "Map to existing custom field" had identical select values when the column name matched an existing field name
+- Distinguish "Sheets API not enabled" from "sheet not shared" errors so users get actionable guidance
+
 ## v0.7.5
 
 Plot Archive thumbnail bug fix.

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -63,6 +63,7 @@ from app.api.sequencing_batches import router as sequencing_batches_router
 from app.api.slack_oauth import router as slack_oauth_router
 from app.api.experiment_auto_runs import router as experiment_auto_runs_router
 from app.api.content_tokens import router as content_tokens_router
+from app.api.sheets_import import router as sheets_import_router
 
 api_router = APIRouter()
 
@@ -129,3 +130,4 @@ api_router.include_router(sequencing_batches_router)
 api_router.include_router(slack_oauth_router)
 api_router.include_router(experiment_auto_runs_router)
 api_router.include_router(content_tokens_router)
+api_router.include_router(sheets_import_router)

--- a/backend/app/api/sheets_import.py
+++ b/backend/app/api/sheets_import.py
@@ -1,0 +1,144 @@
+"""Google Sheets column import API endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import require_permission
+from app.database import get_session
+from app.models.experiment_field_default import DEFAULTABLE_SAMPLE_FIELDS
+from app.schemas.sheets_import import (
+    ReaderSACreateResponse,
+    ReaderSAStatusResponse,
+    RecognizedColumn,
+    SheetPreviewRequest,
+    SheetPreviewResponse,
+)
+from app.services import sheets_reader_sa_service
+from app.services.csv_service import COLUMN_MAP, _normalize_header
+from app.services.google_sheets_service import parse_sheet_url, read_header_row
+
+router = APIRouter(prefix="/api/v1/sheets", tags=["sheets_import"])
+
+# Sample fields that can be mapped as experiment-level field defaults.
+# We only surface DEFAULTABLE_SAMPLE_FIELDS as mapping targets since those
+# are the fields that cascade to every sample in an experiment.
+_MAPPABLE_FIELDS = set(DEFAULTABLE_SAMPLE_FIELDS)
+
+
+@router.get("/reader-sa", response_model=ReaderSAStatusResponse)
+async def get_reader_sa_status(
+    current_user: dict = require_permission("infrastructure", "view"),
+    session: AsyncSession = Depends(get_session),
+) -> ReaderSAStatusResponse:
+    """Check whether the reader SA exists."""
+    status = await sheets_reader_sa_service.get_reader_sa_status(session)
+    return ReaderSAStatusResponse(
+        exists=bool(status["exists"]),
+        email=str(status["email"]) if status["email"] else None,
+    )
+
+
+@router.post("/reader-sa", response_model=ReaderSACreateResponse)
+async def create_reader_sa(
+    current_user: dict = require_permission("infrastructure", "configure"),
+    session: AsyncSession = Depends(get_session),
+) -> ReaderSACreateResponse:
+    """Create the dedicated reader SA for Google Sheets access."""
+    try:
+        result = await sheets_reader_sa_service.create_reader_sa(session)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to create reader service account: {exc}",
+        ) from exc
+    return ReaderSACreateResponse(
+        email=result["email"],
+        message="Reader service account created successfully",
+    )
+
+
+@router.delete("/reader-sa")
+async def delete_reader_sa(
+    current_user: dict = require_permission("infrastructure", "configure"),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    """Delete the reader SA and its stored credentials."""
+    try:
+        await sheets_reader_sa_service.delete_reader_sa(session)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to delete reader service account: {exc}",
+        ) from exc
+    return {"message": "Reader service account deleted"}
+
+
+@router.post("/preview", response_model=SheetPreviewResponse)
+async def preview_sheet_headers(
+    body: SheetPreviewRequest,
+    current_user: dict = require_permission("experiments", "create"),
+    session: AsyncSession = Depends(get_session),
+) -> SheetPreviewResponse:
+    """Read column headers from a Google Sheet and classify them.
+
+    Columns that match known sample fields (via the CSV column map) and
+    are part of the defaultable sample fields list are returned as
+    ``recognized_columns``.  Everything else lands in ``unknown_columns``.
+    """
+    # Load reader SA credentials
+    try:
+        creds = await sheets_reader_sa_service.get_reader_credentials(session)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Parse the sheet URL
+    try:
+        spreadsheet_id, gid = parse_sheet_url(body.sheet_url)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Read headers from the sheet
+    try:
+        headers, sheet_name = read_header_row(creds, spreadsheet_id, gid)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        msg = str(exc)
+        if "403" in msg or "PERMISSION_DENIED" in msg:
+            status = await sheets_reader_sa_service.get_reader_sa_status(session)
+            sa_email = status.get("email", "the reader service account")
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    f"Cannot access this spreadsheet. "
+                    f"Share it with {sa_email} and try again."
+                ),
+            ) from exc
+        if "404" in msg or "not found" in msg.lower():
+            raise HTTPException(
+                status_code=404,
+                detail="Spreadsheet not found. Check the URL and try again.",
+            ) from exc
+        raise HTTPException(status_code=500, detail=f"Error reading spreadsheet: {msg}") from exc
+
+    # Classify columns using the existing CSV column map
+    recognized: list[RecognizedColumn] = []
+    unknown: list[str] = []
+
+    for header in headers:
+        normalized = _normalize_header(header)
+        mapped_field = COLUMN_MAP.get(normalized)
+        if mapped_field and mapped_field in _MAPPABLE_FIELDS:
+            recognized.append(RecognizedColumn(header=header, mapped_to=mapped_field))
+        else:
+            unknown.append(header)
+
+    return SheetPreviewResponse(
+        spreadsheet_id=spreadsheet_id,
+        sheet_name=sheet_name,
+        columns=headers,
+        recognized_columns=recognized,
+        unknown_columns=unknown,
+    )

--- a/backend/app/api/sheets_import.py
+++ b/backend/app/api/sheets_import.py
@@ -14,15 +14,15 @@ from app.schemas.sheets_import import (
     SheetPreviewResponse,
 )
 from app.services import sheets_reader_sa_service
-from app.services.csv_service import COLUMN_MAP, _normalize_header
+from app.services.csv_service import COLUMN_MAP, SAMPLE_FIELDS, _normalize_header
 from app.services.google_sheets_service import parse_sheet_url, read_header_row
 
 router = APIRouter(prefix="/api/v1/sheets", tags=["sheets_import"])
 
-# Sample fields that can be mapped as experiment-level field defaults.
-# We only surface DEFAULTABLE_SAMPLE_FIELDS as mapping targets since those
-# are the fields that cascade to every sample in an experiment.
-_MAPPABLE_FIELDS = set(DEFAULTABLE_SAMPLE_FIELDS)
+# All user-facing sample fields that column headers can be recognized against.
+_ALL_SAMPLE_FIELDS = set(SAMPLE_FIELDS)
+# The subset that can be configured as experiment-level field defaults.
+_DEFAULTABLE_FIELDS = set(DEFAULTABLE_SAMPLE_FIELDS)
 
 
 @router.get("/reader-sa", response_model=ReaderSAStatusResponse)
@@ -137,8 +137,14 @@ async def preview_sheet_headers(
     for header in headers:
         normalized = _normalize_header(header)
         mapped_field = COLUMN_MAP.get(normalized)
-        if mapped_field and mapped_field in _MAPPABLE_FIELDS:
-            recognized.append(RecognizedColumn(header=header, mapped_to=mapped_field))
+        if mapped_field and mapped_field in _ALL_SAMPLE_FIELDS:
+            recognized.append(
+                RecognizedColumn(
+                    header=header,
+                    mapped_to=mapped_field,
+                    defaultable=mapped_field in _DEFAULTABLE_FIELDS,
+                )
+            )
         else:
             unknown.append(header)
 

--- a/backend/app/api/sheets_import.py
+++ b/backend/app/api/sheets_import.py
@@ -54,8 +54,9 @@ async def create_reader_sa(
             detail=f"Failed to create reader service account: {exc}",
         ) from exc
     return ReaderSACreateResponse(
-        email=result["email"],
+        email=str(result["email"]),
         message="Reader service account created successfully",
+        warning=str(result["warning"]) if result.get("warning") else None,
     )
 
 
@@ -109,12 +110,18 @@ async def preview_sheet_headers(
         if "403" in msg or "PERMISSION_DENIED" in msg:
             status = await sheets_reader_sa_service.get_reader_sa_status(session)
             sa_email = status.get("email", "the reader service account")
+            # Distinguish "API not enabled" from "sheet not shared"
+            if "has not been used" in msg or "it is disabled" in msg or "FORBIDDEN" in msg:
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "The Google Sheets API is not enabled in your GCP project. "
+                        "Enable it at: https://console.cloud.google.com/apis/library/sheets.googleapis.com"
+                    ),
+                ) from exc
             raise HTTPException(
                 status_code=403,
-                detail=(
-                    f"Cannot access this spreadsheet. "
-                    f"Share it with {sa_email} and try again."
-                ),
+                detail=(f"Cannot access this spreadsheet. Share it with {sa_email} and try again."),
             ) from exc
         if "404" in msg or "not found" in msg.lower():
             raise HTTPException(

--- a/backend/app/api/sheets_import.py
+++ b/backend/app/api/sheets_import.py
@@ -1,4 +1,9 @@
-"""Google Sheets column import API endpoints."""
+"""Google Sheets import API endpoints.
+
+Covers both experiment-level field import (column headers only) and
+sample-level data import (full sheet contents piped through the
+existing CSV parsing pipeline).
+"""
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,10 +17,11 @@ from app.schemas.sheets_import import (
     RecognizedColumn,
     SheetPreviewRequest,
     SheetPreviewResponse,
+    SheetSampleConfirmRequest,
 )
 from app.services import sheets_reader_sa_service
-from app.services.csv_service import COLUMN_MAP, SAMPLE_FIELDS, _normalize_header
-from app.services.google_sheets_service import parse_sheet_url, read_header_row
+from app.services.csv_service import COLUMN_MAP, SAMPLE_FIELDS, _normalize_header, parse_sample_csv, preview_sample_csv
+from app.services.google_sheets_service import parse_sheet_url, read_all_rows_as_csv, read_header_row
 
 router = APIRouter(prefix="/api/v1/sheets", tags=["sheets_import"])
 
@@ -155,3 +161,126 @@ async def preview_sheet_headers(
         recognized_columns=recognized,
         unknown_columns=unknown,
     )
+
+
+# ---------------------------------------------------------------------------
+# Sample-level import (full sheet data -> CSV pipeline)
+# ---------------------------------------------------------------------------
+
+
+async def _read_sheet_as_csv(
+    body: SheetPreviewRequest,
+    session: AsyncSession,
+) -> tuple[bytes, str]:
+    """Shared helper: load reader SA creds, read entire sheet as CSV bytes."""
+    try:
+        creds = await sheets_reader_sa_service.get_reader_credentials(session)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        spreadsheet_id, gid = parse_sheet_url(body.sheet_url)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        csv_bytes, sheet_name = read_all_rows_as_csv(creds, spreadsheet_id, gid)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        msg = str(exc)
+        if "403" in msg or "PERMISSION_DENIED" in msg:
+            status = await sheets_reader_sa_service.get_reader_sa_status(session)
+            sa_email = status.get("email", "the reader service account")
+            if "has not been used" in msg or "it is disabled" in msg or "FORBIDDEN" in msg:
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "The Google Sheets API is not enabled in your GCP project. "
+                        "Enable it at: https://console.cloud.google.com/apis/library/sheets.googleapis.com"
+                    ),
+                ) from exc
+            raise HTTPException(
+                status_code=403,
+                detail=f"Cannot access this spreadsheet. Share it with {sa_email} and try again.",
+            ) from exc
+        if "404" in msg or "not found" in msg.lower():
+            raise HTTPException(
+                status_code=404,
+                detail="Spreadsheet not found. Check the URL and try again.",
+            ) from exc
+        raise HTTPException(status_code=500, detail=f"Error reading spreadsheet: {msg}") from exc
+
+    return csv_bytes, sheet_name
+
+
+@router.post("/{experiment_id}/samples/preview")
+async def preview_sheet_samples(
+    experiment_id: int,
+    body: SheetPreviewRequest,
+    current_user: dict = require_permission("experiments", "upload"),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Read a Google Sheet and preview its contents as sample data.
+
+    Returns the same format as the CSV preview endpoint so the frontend
+    can reuse the same mapping UI.
+    """
+    csv_bytes, _ = await _read_sheet_as_csv(body, session)
+    return preview_sample_csv(csv_bytes)
+
+
+@router.post("/{experiment_id}/samples/confirm")
+async def confirm_sheet_samples(
+    experiment_id: int,
+    body: SheetSampleConfirmRequest,
+    current_user: dict = require_permission("experiments", "upload"),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Read a Google Sheet, parse it into samples, and create them.
+
+    Uses the same parsing and creation logic as the CSV confirm endpoint.
+    """
+    from app.models.sample_custom_field import SampleCustomField
+    from app.services.sample_service import SampleService
+
+    user_id = int(current_user["sub"])
+    csv_bytes, _ = await _read_sheet_as_csv(SheetPreviewRequest(sheet_url=body.sheet_url), session)
+
+    parsed_samples, parse_errors, custom_field_rows = parse_sample_csv(
+        csv_bytes, experiment_id, column_mappings=body.column_mappings or None
+    )
+
+    if not parsed_samples and parse_errors:
+        raise HTTPException(400, detail={"errors": parse_errors})
+
+    custom_field_names: list[str] = sorted({name for row in custom_field_rows for name in row})
+
+    created = []
+    create_errors = []
+    for i, sample_data in enumerate(parsed_samples):
+        try:
+            sample = await SampleService.create_sample(session, experiment_id, user_id, sample_data)
+            created.append(sample)
+
+            if i < len(custom_field_rows) and custom_field_rows[i]:
+                for field_name, field_value in custom_field_rows[i].items():
+                    session.add(
+                        SampleCustomField(
+                            sample_id=sample.id,
+                            field_name=field_name,
+                            field_value=str(field_value),
+                        )
+                    )
+        except HTTPException as e:
+            create_errors.append(f"Sample {i + 1}: {e.detail}")
+
+    if created:
+        await session.commit()
+
+    return {
+        "created_count": len(created),
+        "error_count": len(parse_errors) + len(create_errors),
+        "errors": parse_errors + create_errors,
+        "custom_fields_created": custom_field_names,
+    }

--- a/backend/app/schemas/sheets_import.py
+++ b/backend/app/schemas/sheets_import.py
@@ -35,3 +35,4 @@ class ReaderSAStatusResponse(BaseModel):
 class ReaderSACreateResponse(BaseModel):
     email: str
     message: str
+    warning: str | None = None

--- a/backend/app/schemas/sheets_import.py
+++ b/backend/app/schemas/sheets_import.py
@@ -37,3 +37,15 @@ class ReaderSACreateResponse(BaseModel):
     email: str
     message: str
     warning: str | None = None
+
+
+class SheetSampleConfirmRequest(BaseModel):
+    sheet_url: str
+    column_mappings: dict[str, str] = {}
+
+    @field_validator("sheet_url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        if "docs.google.com/spreadsheets" not in v:
+            raise ValueError("Must be a Google Sheets URL")
+        return v

--- a/backend/app/schemas/sheets_import.py
+++ b/backend/app/schemas/sheets_import.py
@@ -1,0 +1,37 @@
+"""Schemas for Google Sheets column import."""
+
+from pydantic import BaseModel, field_validator
+
+
+class SheetPreviewRequest(BaseModel):
+    sheet_url: str
+
+    @field_validator("sheet_url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        if "docs.google.com/spreadsheets" not in v:
+            raise ValueError("Must be a Google Sheets URL")
+        return v
+
+
+class RecognizedColumn(BaseModel):
+    header: str
+    mapped_to: str
+
+
+class SheetPreviewResponse(BaseModel):
+    spreadsheet_id: str
+    sheet_name: str
+    columns: list[str]
+    recognized_columns: list[RecognizedColumn]
+    unknown_columns: list[str]
+
+
+class ReaderSAStatusResponse(BaseModel):
+    exists: bool
+    email: str | None = None
+
+
+class ReaderSACreateResponse(BaseModel):
+    email: str
+    message: str

--- a/backend/app/schemas/sheets_import.py
+++ b/backend/app/schemas/sheets_import.py
@@ -17,6 +17,7 @@ class SheetPreviewRequest(BaseModel):
 class RecognizedColumn(BaseModel):
     header: str
     mapped_to: str
+    defaultable: bool
 
 
 class SheetPreviewResponse(BaseModel):

--- a/backend/app/services/gcp_config.py
+++ b/backend/app/services/gcp_config.py
@@ -37,6 +37,7 @@ _PERMISSION_ROLE_MAP: dict[str, str] = {
     "iam.serviceAccounts.actAs": "roles/iam.serviceAccountUser",
     "iam.serviceAccounts.create": "roles/iam.serviceAccountAdmin",
     "iam.serviceAccounts.setIamPolicy": "roles/iam.serviceAccountAdmin",
+    "iam.serviceAccountKeys.create": "roles/iam.serviceAccountKeyAdmin",
     "compute.instances.create": "roles/compute.admin",
     "resourcemanager.projects.getIamPolicy": "roles/resourcemanager.projectIamAdmin",
     "resourcemanager.projects.setIamPolicy": "roles/resourcemanager.projectIamAdmin",

--- a/backend/app/services/google_sheets_service.py
+++ b/backend/app/services/google_sheets_service.py
@@ -1,17 +1,17 @@
-"""Google Sheets integration for reading spreadsheet headers.
+"""Google Sheets integration for reading spreadsheet data.
 
-Uses the Google Sheets API v4 to read column headers from a shared
-spreadsheet.  The caller is responsible for providing credentials
-scoped to ``spreadsheets.readonly``.
+Uses the Google Sheets API v4 to read column headers and full sheet
+contents from a shared spreadsheet.  The caller is responsible for
+providing credentials scoped to ``spreadsheets.readonly``.
 """
 
+import csv
+import io
 import re
 
 from googleapiclient import discovery as google_discovery
 
-_SHEET_URL_RE = re.compile(
-    r"https://docs\.google\.com/spreadsheets/d/([a-zA-Z0-9_-]+)"
-)
+_SHEET_URL_RE = re.compile(r"https://docs\.google\.com/spreadsheets/d/([a-zA-Z0-9_-]+)")
 _GID_RE = re.compile(r"[#&]gid=(\d+)")
 
 # Patchable alias for tests
@@ -38,12 +38,8 @@ def get_sheet_names(
     spreadsheet_id: str,
 ) -> list[str]:
     """Return the list of sheet/tab names in a spreadsheet."""
-    service = discovery_build(
-        "sheets", "v4", credentials=credentials, cache_discovery=False
-    )
-    meta = service.spreadsheets().get(
-        spreadsheetId=spreadsheet_id, fields="sheets.properties"
-    ).execute()
+    service = discovery_build("sheets", "v4", credentials=credentials, cache_discovery=False)
+    meta = service.spreadsheets().get(spreadsheetId=spreadsheet_id, fields="sheets.properties").execute()
     return [s["properties"]["title"] for s in meta.get("sheets", [])]
 
 
@@ -53,9 +49,13 @@ def _resolve_sheet_name(
     gid: int | None,
 ) -> str:
     """Resolve a gid to a sheet title, or return the first sheet's title."""
-    meta = service.spreadsheets().get(  # type: ignore[union-attr]
-        spreadsheetId=spreadsheet_id, fields="sheets.properties"
-    ).execute()
+    meta = (
+        service.spreadsheets()
+        .get(  # type: ignore[union-attr]
+            spreadsheetId=spreadsheet_id, fields="sheets.properties"
+        )
+        .execute()
+    )
     sheets = meta.get("sheets", [])
     if not sheets:
         raise ValueError("Spreadsheet has no sheets")
@@ -78,16 +78,57 @@ def read_header_row(
 
     Returns ``(headers, sheet_name)``.
     """
-    service = discovery_build(
-        "sheets", "v4", credentials=credentials, cache_discovery=False
-    )
+    service = discovery_build("sheets", "v4", credentials=credentials, cache_discovery=False)
     sheet_name = _resolve_sheet_name(service, spreadsheet_id, gid)
-    result = service.spreadsheets().values().get(  # type: ignore[union-attr]
-        spreadsheetId=spreadsheet_id,
-        range=f"'{sheet_name}'!1:1",
-    ).execute()
+    result = (
+        service.spreadsheets()
+        .values()
+        .get(  # type: ignore[union-attr]
+            spreadsheetId=spreadsheet_id,
+            range=f"'{sheet_name}'!1:1",
+        )
+        .execute()
+    )
     values = result.get("values", [])
     if not values or not values[0]:
         raise ValueError("The first row is empty -- ensure row 1 contains column headers")
     headers = [str(v).strip() for v in values[0] if str(v).strip()]
     return headers, sheet_name
+
+
+def read_all_rows_as_csv(
+    credentials: object,
+    spreadsheet_id: str,
+    gid: int | None = None,
+) -> tuple[bytes, str]:
+    """Read all rows from a sheet and return them as UTF-8 CSV bytes.
+
+    This allows the existing ``csv_service`` preview/parse functions to
+    consume Google Sheets data without any changes to their interface.
+
+    Returns ``(csv_bytes, sheet_name)``.
+    """
+    service = discovery_build("sheets", "v4", credentials=credentials, cache_discovery=False)
+    sheet_name = _resolve_sheet_name(service, spreadsheet_id, gid)
+    result = (
+        service.spreadsheets()
+        .values()
+        .get(  # type: ignore[union-attr]
+            spreadsheetId=spreadsheet_id,
+            range=f"'{sheet_name}'",
+        )
+        .execute()
+    )
+    rows = result.get("values", [])
+    if not rows:
+        raise ValueError("The sheet is empty")
+
+    # Pad all rows to the length of the header row so the CSV is rectangular
+    num_cols = len(rows[0])
+    output = io.StringIO()
+    writer = csv.writer(output)
+    for row in rows:
+        padded = row + [""] * (num_cols - len(row))
+        writer.writerow(padded[:num_cols])
+
+    return output.getvalue().encode("utf-8"), sheet_name

--- a/backend/app/services/google_sheets_service.py
+++ b/backend/app/services/google_sheets_service.py
@@ -1,0 +1,93 @@
+"""Google Sheets integration for reading spreadsheet headers.
+
+Uses the Google Sheets API v4 to read column headers from a shared
+spreadsheet.  The caller is responsible for providing credentials
+scoped to ``spreadsheets.readonly``.
+"""
+
+import re
+
+from googleapiclient import discovery as google_discovery
+
+_SHEET_URL_RE = re.compile(
+    r"https://docs\.google\.com/spreadsheets/d/([a-zA-Z0-9_-]+)"
+)
+_GID_RE = re.compile(r"[#&]gid=(\d+)")
+
+# Patchable alias for tests
+discovery_build = google_discovery.build
+
+
+def parse_sheet_url(url: str) -> tuple[str, int | None]:
+    """Extract spreadsheet ID and optional gid from a Google Sheets URL.
+
+    Returns ``(spreadsheet_id, gid_or_none)``.
+    Raises ``ValueError`` for unrecognised formats.
+    """
+    m = _SHEET_URL_RE.search(url)
+    if not m:
+        raise ValueError("Not a valid Google Sheets URL")
+    spreadsheet_id = m.group(1)
+    gid_match = _GID_RE.search(url)
+    gid = int(gid_match.group(1)) if gid_match else None
+    return spreadsheet_id, gid
+
+
+def get_sheet_names(
+    credentials: object,
+    spreadsheet_id: str,
+) -> list[str]:
+    """Return the list of sheet/tab names in a spreadsheet."""
+    service = discovery_build(
+        "sheets", "v4", credentials=credentials, cache_discovery=False
+    )
+    meta = service.spreadsheets().get(
+        spreadsheetId=spreadsheet_id, fields="sheets.properties"
+    ).execute()
+    return [s["properties"]["title"] for s in meta.get("sheets", [])]
+
+
+def _resolve_sheet_name(
+    service: object,
+    spreadsheet_id: str,
+    gid: int | None,
+) -> str:
+    """Resolve a gid to a sheet title, or return the first sheet's title."""
+    meta = service.spreadsheets().get(  # type: ignore[union-attr]
+        spreadsheetId=spreadsheet_id, fields="sheets.properties"
+    ).execute()
+    sheets = meta.get("sheets", [])
+    if not sheets:
+        raise ValueError("Spreadsheet has no sheets")
+    if gid is not None:
+        for s in sheets:
+            if s["properties"].get("sheetId") == gid:
+                return s["properties"]["title"]
+        raise ValueError(f"No sheet found with gid={gid}")
+    return sheets[0]["properties"]["title"]
+
+
+def read_header_row(
+    credentials: object,
+    spreadsheet_id: str,
+    gid: int | None = None,
+) -> tuple[list[str], str]:
+    """Read the first row of the specified sheet and return column headers.
+
+    If *gid* is ``None`` the first sheet is used.
+
+    Returns ``(headers, sheet_name)``.
+    """
+    service = discovery_build(
+        "sheets", "v4", credentials=credentials, cache_discovery=False
+    )
+    sheet_name = _resolve_sheet_name(service, spreadsheet_id, gid)
+    result = service.spreadsheets().values().get(  # type: ignore[union-attr]
+        spreadsheetId=spreadsheet_id,
+        range=f"'{sheet_name}'!1:1",
+    ).execute()
+    values = result.get("values", [])
+    if not values or not values[0]:
+        raise ValueError("The first row is empty -- ensure row 1 contains column headers")
+    headers = [str(v).strip() for v in values[0] if str(v).strip()]
+    return headers, sheet_name

--- a/backend/app/services/sheets_reader_sa_service.py
+++ b/backend/app/services/sheets_reader_sa_service.py
@@ -1,0 +1,219 @@
+"""Manage a dedicated Google Sheets reader service account.
+
+The reader SA is a single-purpose service account with only Sheets API
+read access.  Users share their spreadsheets with this SA's email to
+allow bioAF to read column headers during experiment creation.
+
+Credentials for the reader SA are stored in the ``platform_config``
+table alongside other GCP configuration.
+"""
+
+import base64
+import json
+import secrets
+
+from google.oauth2 import service_account
+from googleapiclient import discovery as google_discovery
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Patchable aliases for tests
+discovery_build = google_discovery.build
+
+_SHEETS_SCOPE = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+_READER_SA_KEYS = [
+    "sheets_reader_sa_email",
+    "sheets_reader_sa_key",
+    "sheets_reader_sa_created",
+]
+
+_GCP_KEYS = [
+    "gcp_project_id",
+    "gcp_credential_source",
+    "gcp_service_account_key",
+    "gcp_service_account_email",
+]
+
+
+async def _upsert(session: AsyncSession, key: str, value: str) -> None:
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value) VALUES (:k, :v) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, "
+            "updated_at = now()"
+        ).bindparams(k=key, v=value)
+    )
+
+
+async def _delete_key(session: AsyncSession, key: str) -> None:
+    await session.execute(
+        text("DELETE FROM platform_config WHERE key = :k").bindparams(k=key)
+    )
+
+
+async def _read_keys(session: AsyncSession, keys: list[str]) -> dict[str, str]:
+    rows = (
+        await session.execute(
+            text("SELECT key, value FROM platform_config WHERE key = ANY(:keys)").bindparams(keys=keys)
+        )
+    ).fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
+def _load_primary_credentials(config: dict[str, str]) -> tuple[object, str]:
+    """Load the primary SA credentials from platform_config values.
+
+    Returns ``(credentials, project_id)``.
+    Raises ``RuntimeError`` if GCP credentials are not configured.
+    """
+    project_id = config.get("gcp_project_id", "")
+    if not project_id:
+        raise RuntimeError("GCP project ID is not configured")
+
+    source = config.get("gcp_credential_source", "vm_default")
+    if source == "service_account_key":
+        key_json = config.get("gcp_service_account_key", "")
+        if not key_json:
+            raise RuntimeError("GCP service account key is not configured")
+        key_data = json.loads(key_json)
+        creds = service_account.Credentials.from_service_account_info(
+            key_data,
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+    else:
+        import google.auth as _google_auth
+
+        creds, _ = _google_auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+        sa_email = config.get("gcp_service_account_email")
+        if sa_email:
+            from google.auth import impersonated_credentials
+
+            creds = impersonated_credentials.Credentials(
+                source_credentials=creds,
+                target_principal=sa_email,
+                target_scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+
+    return creds, project_id
+
+
+async def get_reader_sa_status(session: AsyncSession) -> dict[str, object]:
+    """Return ``{exists: bool, email: str | None}``."""
+    config = await _read_keys(session, _READER_SA_KEYS)
+    exists = config.get("sheets_reader_sa_created") == "true"
+    return {
+        "exists": exists,
+        "email": config.get("sheets_reader_sa_email") if exists else None,
+    }
+
+
+async def create_reader_sa(session: AsyncSession) -> dict[str, str]:
+    """Create a dedicated reader SA via the IAM Admin API.
+
+    Stores the SA email and JSON key in ``platform_config``.
+    Returns ``{email: str}``.
+    """
+    # Check if one already exists
+    status = await get_reader_sa_status(session)
+    if status["exists"]:
+        return {"email": str(status["email"])}
+
+    # Load primary credentials
+    gcp_config = await _read_keys(session, _GCP_KEYS)
+    creds, project_id = _load_primary_credentials(gcp_config)
+
+    # Create the service account
+    iam_service = discovery_build("iam", "v1", credentials=creds, cache_discovery=False)
+    account_id = f"bioaf-reader-{secrets.token_hex(4)}"
+
+    sa = iam_service.projects().serviceAccounts().create(
+        name=f"projects/{project_id}",
+        body={
+            "accountId": account_id,
+            "serviceAccount": {
+                "displayName": "bioAF Sheets Reader",
+                "description": "Read-only access to Google Sheets for bioAF field import",
+            },
+        },
+    ).execute()
+
+    sa_email = sa["email"]
+
+    # Create a JSON key for the new SA
+    key_response = iam_service.projects().serviceAccounts().keys().create(
+        name=f"projects/{project_id}/serviceAccounts/{sa_email}",
+        body={"keyAlgorithm": "KEY_ALG_RSA_2048"},
+    ).execute()
+
+    key_json = base64.b64decode(key_response["privateKeyData"]).decode("utf-8")
+
+    # Enable the Sheets API in the project
+    try:
+        service_usage = discovery_build(
+            "serviceusage", "v1", credentials=creds, cache_discovery=False
+        )
+        service_usage.services().enable(
+            name=f"projects/{project_id}/services/sheets.googleapis.com"
+        ).execute()
+    except Exception:
+        # Non-fatal: the API may already be enabled, or the SA may
+        # not have serviceusage permissions. The user will see a clear
+        # error when they try to preview a sheet.
+        pass
+
+    # Persist to platform_config
+    await _upsert(session, "sheets_reader_sa_email", sa_email)
+    await _upsert(session, "sheets_reader_sa_key", key_json)
+    await _upsert(session, "sheets_reader_sa_created", "true")
+    await session.commit()
+
+    return {"email": sa_email}
+
+
+async def delete_reader_sa(session: AsyncSession) -> None:
+    """Delete the reader SA and remove stored credentials."""
+    config = await _read_keys(session, _READER_SA_KEYS + _GCP_KEYS)
+    sa_email = config.get("sheets_reader_sa_email")
+    if not sa_email:
+        return
+
+    # Delete from GCP
+    try:
+        gcp_config = {k: config[k] for k in _GCP_KEYS if k in config}
+        creds, project_id = _load_primary_credentials(gcp_config)
+        iam_service = discovery_build("iam", "v1", credentials=creds, cache_discovery=False)
+        iam_service.projects().serviceAccounts().delete(
+            name=f"projects/{project_id}/serviceAccounts/{sa_email}"
+        ).execute()
+    except Exception:
+        # Best effort -- SA may already have been deleted externally
+        pass
+
+    # Remove from platform_config
+    for key in _READER_SA_KEYS:
+        await _delete_key(session, key)
+    await session.commit()
+
+
+async def get_reader_credentials(session: AsyncSession) -> service_account.Credentials:
+    """Load the reader SA's credentials scoped to Sheets readonly.
+
+    Raises ``RuntimeError`` if the reader SA is not configured.
+    """
+    config = await _read_keys(session, _READER_SA_KEYS)
+    if config.get("sheets_reader_sa_created") != "true":
+        raise RuntimeError(
+            "Google Sheets reader service account is not configured. "
+            "Set it up in Settings > Integrations > GCP."
+        )
+    key_json = config.get("sheets_reader_sa_key", "")
+    if not key_json:
+        raise RuntimeError("Reader SA key is missing from configuration")
+
+    key_data = json.loads(key_json)
+    return service_account.Credentials.from_service_account_info(
+        key_data, scopes=_SHEETS_SCOPE
+    )

--- a/backend/app/services/sheets_reader_sa_service.py
+++ b/backend/app/services/sheets_reader_sa_service.py
@@ -173,14 +173,18 @@ async def create_reader_sa(session: AsyncSession) -> dict[str, str]:
     key_json = base64.b64decode(key_response["privateKeyData"]).decode("utf-8")
 
     # Enable the Sheets API in the project
+    sheets_api_enabled = False
     try:
         service_usage = discovery_build("serviceusage", "v1", credentials=creds, cache_discovery=False)
         service_usage.services().enable(name=f"projects/{project_id}/services/sheets.googleapis.com").execute()
+        sheets_api_enabled = True
     except Exception:
-        # Non-fatal: the API may already be enabled, or the SA may
-        # not have serviceusage permissions. The user will see a clear
-        # error when they try to preview a sheet.
-        pass
+        # The API may already be enabled -- check before warning
+        try:
+            svc = service_usage.services().get(name=f"projects/{project_id}/services/sheets.googleapis.com").execute()
+            sheets_api_enabled = svc.get("state") == "ENABLED"
+        except Exception:
+            pass
 
     # Persist to platform_config
     await _upsert(session, "sheets_reader_sa_email", sa_email)
@@ -188,7 +192,14 @@ async def create_reader_sa(session: AsyncSession) -> dict[str, str]:
     await _upsert(session, "sheets_reader_sa_created", "true")
     await session.commit()
 
-    return {"email": sa_email}
+    result: dict[str, object] = {"email": sa_email}
+    if not sheets_api_enabled:
+        result["warning"] = (
+            "The Google Sheets API could not be enabled automatically. "
+            "Enable it manually at: "
+            "https://console.cloud.google.com/apis/library/sheets.googleapis.com"
+        )
+    return result
 
 
 async def delete_reader_sa(session: AsyncSession) -> None:

--- a/backend/app/services/sheets_reader_sa_service.py
+++ b/backend/app/services/sheets_reader_sa_service.py
@@ -11,6 +11,7 @@ table alongside other GCP configuration.
 import base64
 import json
 import secrets
+import time
 
 from google.oauth2 import service_account
 from googleapiclient import discovery as google_discovery
@@ -47,9 +48,7 @@ async def _upsert(session: AsyncSession, key: str, value: str) -> None:
 
 
 async def _delete_key(session: AsyncSession, key: str) -> None:
-    await session.execute(
-        text("DELETE FROM platform_config WHERE key = :k").bindparams(k=key)
-    )
+    await session.execute(text("DELETE FROM platform_config WHERE key = :k").bindparams(k=key))
 
 
 async def _read_keys(session: AsyncSession, keys: list[str]) -> dict[str, str]:
@@ -84,9 +83,7 @@ def _load_primary_credentials(config: dict[str, str]) -> tuple[object, str]:
     else:
         import google.auth as _google_auth
 
-        creds, _ = _google_auth.default(
-            scopes=["https://www.googleapis.com/auth/cloud-platform"]
-        )
+        creds, _ = _google_auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
         sa_email = config.get("gcp_service_account_email")
         if sa_email:
             from google.auth import impersonated_credentials
@@ -129,35 +126,56 @@ async def create_reader_sa(session: AsyncSession) -> dict[str, str]:
     iam_service = discovery_build("iam", "v1", credentials=creds, cache_discovery=False)
     account_id = f"bioaf-reader-{secrets.token_hex(4)}"
 
-    sa = iam_service.projects().serviceAccounts().create(
-        name=f"projects/{project_id}",
-        body={
-            "accountId": account_id,
-            "serviceAccount": {
-                "displayName": "bioAF Sheets Reader",
-                "description": "Read-only access to Google Sheets for bioAF field import",
+    sa = (
+        iam_service.projects()
+        .serviceAccounts()
+        .create(
+            name=f"projects/{project_id}",
+            body={
+                "accountId": account_id,
+                "serviceAccount": {
+                    "displayName": "bioAF Sheets Reader",
+                    "description": "Read-only access to Google Sheets for bioAF field import",
+                },
             },
-        },
-    ).execute()
+        )
+        .execute()
+    )
 
     sa_email = sa["email"]
 
-    # Create a JSON key for the new SA
-    key_response = iam_service.projects().serviceAccounts().keys().create(
-        name=f"projects/{project_id}/serviceAccounts/{sa_email}",
-        body={"keyAlgorithm": "KEY_ALG_RSA_2048"},
-    ).execute()
+    # Create a JSON key for the new SA.
+    # IAM has a propagation delay after SA creation -- retry up to 5
+    # times with backoff before giving up on key creation.
+    key_response = None
+    for attempt in range(5):
+        try:
+            key_response = (
+                iam_service.projects()
+                .serviceAccounts()
+                .keys()
+                .create(
+                    name=f"projects/{project_id}/serviceAccounts/{sa_email}",
+                    body={"keyAlgorithm": "KEY_ALG_RSA_2048"},
+                )
+                .execute()
+            )
+            break
+        except Exception as exc:
+            if attempt < 4 and ("404" in str(exc) or "does not exist" in str(exc).lower()):
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+
+    if key_response is None:
+        raise RuntimeError(f"Failed to create key for {sa_email} after retries")
 
     key_json = base64.b64decode(key_response["privateKeyData"]).decode("utf-8")
 
     # Enable the Sheets API in the project
     try:
-        service_usage = discovery_build(
-            "serviceusage", "v1", credentials=creds, cache_discovery=False
-        )
-        service_usage.services().enable(
-            name=f"projects/{project_id}/services/sheets.googleapis.com"
-        ).execute()
+        service_usage = discovery_build("serviceusage", "v1", credentials=creds, cache_discovery=False)
+        service_usage.services().enable(name=f"projects/{project_id}/services/sheets.googleapis.com").execute()
     except Exception:
         # Non-fatal: the API may already be enabled, or the SA may
         # not have serviceusage permissions. The user will see a clear
@@ -206,14 +224,11 @@ async def get_reader_credentials(session: AsyncSession) -> service_account.Crede
     config = await _read_keys(session, _READER_SA_KEYS)
     if config.get("sheets_reader_sa_created") != "true":
         raise RuntimeError(
-            "Google Sheets reader service account is not configured. "
-            "Set it up in Settings > Integrations > GCP."
+            "Google Sheets reader service account is not configured. Set it up in Settings > Integrations > GCP."
         )
     key_json = config.get("sheets_reader_sa_key", "")
     if not key_json:
         raise RuntimeError("Reader SA key is missing from configuration")
 
     key_data = json.loads(key_json)
-    return service_account.Credentials.from_service_account_info(
-        key_data, scopes=_SHEETS_SCOPE
-    )
+    return service_account.Credentials.from_service_account_info(key_data, scopes=_SHEETS_SCOPE)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.7.5"
+version = "0.8.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,6 +34,8 @@ google-cloud-iam>=2.14
 google-cloud-pubsub>=2.21
 # BigQuery billing export
 google-cloud-bigquery>=3.20
+# Google Sheets import for experiment field setup
+google-api-python-client>=2.130
 # Cloud Logging fallback for pipeline log persistence
 google-cloud-logging>=3.10
 # GitHub App JWT authentication

--- a/backend/tests/test_gcp_config_service.py
+++ b/backend/tests/test_gcp_config_service.py
@@ -63,6 +63,7 @@ ALL_REQUIRED_PERMISSIONS = [
     "iam.serviceAccounts.actAs",
     "iam.serviceAccounts.create",
     "iam.serviceAccounts.setIamPolicy",
+    "iam.serviceAccountKeys.create",
     "compute.instances.create",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.projects.setIamPolicy",

--- a/backend/tests/test_google_sheets_service.py
+++ b/backend/tests/test_google_sheets_service.py
@@ -1,0 +1,183 @@
+"""Unit tests for the Google Sheets service.
+
+All Sheets API calls are mocked -- no real Google API calls are made.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.google_sheets_service import (
+    parse_sheet_url,
+    read_header_row,
+    get_sheet_names,
+    _resolve_sheet_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_sheet_url tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_basic_edit_url():
+    url = "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit"
+    sid, gid = parse_sheet_url(url)
+    assert sid == "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+    assert gid is None
+
+
+def test_parse_url_with_gid():
+    url = "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit#gid=123"
+    sid, gid = parse_sheet_url(url)
+    assert sid == "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+    assert gid == 123
+
+
+def test_parse_url_with_gid_in_query():
+    url = "https://docs.google.com/spreadsheets/d/abc123/edit?usp=sharing&gid=456"
+    sid, gid = parse_sheet_url(url)
+    assert sid == "abc123"
+    assert gid == 456
+
+
+def test_parse_url_view_mode():
+    url = "https://docs.google.com/spreadsheets/d/abc-def_123/view"
+    sid, gid = parse_sheet_url(url)
+    assert sid == "abc-def_123"
+    assert gid is None
+
+
+def test_parse_url_no_trailing_path():
+    url = "https://docs.google.com/spreadsheets/d/abc123"
+    sid, gid = parse_sheet_url(url)
+    assert sid == "abc123"
+    assert gid is None
+
+
+def test_parse_invalid_url_raises():
+    with pytest.raises(ValueError, match="Not a valid Google Sheets URL"):
+        parse_sheet_url("https://example.com/not-a-sheet")
+
+
+def test_parse_non_sheets_google_url_raises():
+    with pytest.raises(ValueError, match="Not a valid Google Sheets URL"):
+        parse_sheet_url("https://docs.google.com/document/d/abc123/edit")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_sheet_name tests
+# ---------------------------------------------------------------------------
+
+
+def _mock_spreadsheet_meta(sheets_data: list[dict]) -> MagicMock:
+    """Build a mock Sheets service with spreadsheet metadata."""
+    service = MagicMock()
+    service.spreadsheets().get().execute.return_value = {"sheets": sheets_data}
+    return service
+
+
+def test_resolve_first_sheet_when_no_gid():
+    service = _mock_spreadsheet_meta([
+        {"properties": {"sheetId": 0, "title": "Sheet1"}},
+        {"properties": {"sheetId": 123, "title": "Data"}},
+    ])
+    assert _resolve_sheet_name(service, "abc", None) == "Sheet1"
+
+
+def test_resolve_sheet_by_gid():
+    service = _mock_spreadsheet_meta([
+        {"properties": {"sheetId": 0, "title": "Sheet1"}},
+        {"properties": {"sheetId": 456, "title": "Samples"}},
+    ])
+    assert _resolve_sheet_name(service, "abc", 456) == "Samples"
+
+
+def test_resolve_sheet_unknown_gid_raises():
+    service = _mock_spreadsheet_meta([
+        {"properties": {"sheetId": 0, "title": "Sheet1"}},
+    ])
+    with pytest.raises(ValueError, match="No sheet found with gid=999"):
+        _resolve_sheet_name(service, "abc", 999)
+
+
+def test_resolve_sheet_empty_spreadsheet_raises():
+    service = _mock_spreadsheet_meta([])
+    with pytest.raises(ValueError, match="Spreadsheet has no sheets"):
+        _resolve_sheet_name(service, "abc", None)
+
+
+# ---------------------------------------------------------------------------
+# read_header_row tests
+# ---------------------------------------------------------------------------
+
+
+def _build_sheets_mock(sheet_title: str, header_values: list) -> MagicMock:
+    """Build a mock discovery service returning given headers."""
+    mock_service = MagicMock()
+
+    # Mock spreadsheets().get() for _resolve_sheet_name
+    mock_service.spreadsheets().get().execute.return_value = {
+        "sheets": [{"properties": {"sheetId": 0, "title": sheet_title}}]
+    }
+
+    # Mock spreadsheets().values().get() for header row
+    mock_service.spreadsheets().values().get().execute.return_value = {
+        "values": [header_values] if header_values else []
+    }
+
+    return mock_service
+
+
+@patch("app.services.google_sheets_service.discovery_build")
+def test_read_header_row_returns_headers(mock_build):
+    mock_build.return_value = _build_sheets_mock("Sheet1", ["Name", "Type", "Date"])
+    headers, sheet_name = read_header_row("fake_creds", "spreadsheet_id")
+    assert headers == ["Name", "Type", "Date"]
+    assert sheet_name == "Sheet1"
+
+
+@patch("app.services.google_sheets_service.discovery_build")
+def test_read_header_row_strips_whitespace(mock_build):
+    mock_build.return_value = _build_sheets_mock("Data", ["  Name  ", "Type", " Date"])
+    headers, _ = read_header_row("fake_creds", "sid")
+    assert headers == ["Name", "Type", "Date"]
+
+
+@patch("app.services.google_sheets_service.discovery_build")
+def test_read_header_row_skips_empty_cells(mock_build):
+    mock_build.return_value = _build_sheets_mock("Sheet1", ["Name", "", "Type", "  ", "Date"])
+    headers, _ = read_header_row("fake_creds", "sid")
+    assert headers == ["Name", "Type", "Date"]
+
+
+@patch("app.services.google_sheets_service.discovery_build")
+def test_read_header_row_empty_raises(mock_build):
+    mock_service = MagicMock()
+    mock_service.spreadsheets().get().execute.return_value = {
+        "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]
+    }
+    mock_service.spreadsheets().values().get().execute.return_value = {"values": []}
+    mock_build.return_value = mock_service
+
+    with pytest.raises(ValueError, match="first row is empty"):
+        read_header_row("fake_creds", "sid")
+
+
+# ---------------------------------------------------------------------------
+# get_sheet_names tests
+# ---------------------------------------------------------------------------
+
+
+@patch("app.services.google_sheets_service.discovery_build")
+def test_get_sheet_names(mock_build):
+    mock_service = MagicMock()
+    mock_service.spreadsheets().get().execute.return_value = {
+        "sheets": [
+            {"properties": {"title": "Sheet1"}},
+            {"properties": {"title": "Metadata"}},
+        ]
+    }
+    mock_build.return_value = mock_service
+    names = get_sheet_names("creds", "sid")
+    assert names == ["Sheet1", "Metadata"]

--- a/backend/tests/test_google_sheets_service.py
+++ b/backend/tests/test_google_sheets_service.py
@@ -8,10 +8,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services.google_sheets_service import (
+    _resolve_sheet_name,
+    get_sheet_names,
     parse_sheet_url,
     read_header_row,
-    get_sheet_names,
-    _resolve_sheet_name,
 )
 
 
@@ -78,25 +78,31 @@ def _mock_spreadsheet_meta(sheets_data: list[dict]) -> MagicMock:
 
 
 def test_resolve_first_sheet_when_no_gid():
-    service = _mock_spreadsheet_meta([
-        {"properties": {"sheetId": 0, "title": "Sheet1"}},
-        {"properties": {"sheetId": 123, "title": "Data"}},
-    ])
+    service = _mock_spreadsheet_meta(
+        [
+            {"properties": {"sheetId": 0, "title": "Sheet1"}},
+            {"properties": {"sheetId": 123, "title": "Data"}},
+        ]
+    )
     assert _resolve_sheet_name(service, "abc", None) == "Sheet1"
 
 
 def test_resolve_sheet_by_gid():
-    service = _mock_spreadsheet_meta([
-        {"properties": {"sheetId": 0, "title": "Sheet1"}},
-        {"properties": {"sheetId": 456, "title": "Samples"}},
-    ])
+    service = _mock_spreadsheet_meta(
+        [
+            {"properties": {"sheetId": 0, "title": "Sheet1"}},
+            {"properties": {"sheetId": 456, "title": "Samples"}},
+        ]
+    )
     assert _resolve_sheet_name(service, "abc", 456) == "Samples"
 
 
 def test_resolve_sheet_unknown_gid_raises():
-    service = _mock_spreadsheet_meta([
-        {"properties": {"sheetId": 0, "title": "Sheet1"}},
-    ])
+    service = _mock_spreadsheet_meta(
+        [
+            {"properties": {"sheetId": 0, "title": "Sheet1"}},
+        ]
+    )
     with pytest.raises(ValueError, match="No sheet found with gid=999"):
         _resolve_sheet_name(service, "abc", 999)
 

--- a/backend/tests/test_sheets_import_api.py
+++ b/backend/tests/test_sheets_import_api.py
@@ -5,7 +5,7 @@ All GCP / Sheets API calls are mocked.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy import text
@@ -18,16 +18,18 @@ from sqlalchemy import text
 
 async def _seed_reader_sa(session, email: str = "bioaf-reader-abc1@proj.iam.gserviceaccount.com"):
     """Insert reader SA config into platform_config."""
-    sa_key = json.dumps({
-        "type": "service_account",
-        "project_id": "my-project",
-        "private_key_id": "key123",
-        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
-        "client_email": email,
-        "client_id": "123456789",
-        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-        "token_uri": "https://oauth2.googleapis.com/token",
-    })
+    sa_key = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "my-project",
+            "private_key_id": "key123",
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+            "client_email": email,
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    )
     await session.execute(
         text("""
         INSERT INTO platform_config (key, value) VALUES
@@ -42,16 +44,18 @@ async def _seed_reader_sa(session, email: str = "bioaf-reader-abc1@proj.iam.gser
 
 async def _seed_gcp_config(session):
     """Insert minimal GCP config for SA creation tests."""
-    sa_key = json.dumps({
-        "type": "service_account",
-        "project_id": "my-project",
-        "private_key_id": "key123",
-        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
-        "client_email": "bioaf@my-project.iam.gserviceaccount.com",
-        "client_id": "123456789",
-        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-        "token_uri": "https://oauth2.googleapis.com/token",
-    })
+    sa_key = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "my-project",
+            "private_key_id": "key123",
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+            "client_email": "bioaf@my-project.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    )
     await session.execute(
         text("""
         INSERT INTO platform_config (key, value) VALUES
@@ -135,7 +139,10 @@ async def test_create_reader_sa_success(client, admin_token, session):
 
     with (
         patch("app.services.sheets_reader_sa_service.discovery_build", side_effect=fake_build),
-        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+        patch(
+            "app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info",
+            return_value=MagicMock(),
+        ),
     ):
         response = await client.post(
             "/api/v1/sheets/reader-sa",
@@ -235,7 +242,10 @@ async def test_preview_sheet_headers(client, admin_token, session):
 
     with (
         patch("app.services.google_sheets_service.discovery_build") as mock_build,
-        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+        patch(
+            "app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info",
+            return_value=MagicMock(),
+        ),
     ):
         mock_service = MagicMock()
         mock_service.spreadsheets().get().execute.return_value = {
@@ -258,10 +268,12 @@ async def test_preview_sheet_headers(client, admin_token, session):
     assert data["sheet_name"] == "Sheet1"
     assert len(data["columns"]) == 4
 
-    # organism and tissue_type should be recognized
-    recognized_fields = {c["mapped_to"] for c in data["recognized_columns"]}
-    assert "organism" in recognized_fields
-    assert "tissue_type" in recognized_fields
+    # organism and tissue_type should be recognized and defaultable
+    recognized = {c["mapped_to"]: c for c in data["recognized_columns"]}
+    assert "organism" in recognized
+    assert recognized["organism"]["defaultable"] is True
+    assert "tissue_type" in recognized
+    assert recognized["tissue_type"]["defaultable"] is True
 
     # centrifuge_rpm and barcode should be unknown
     assert "centrifuge_rpm" in data["unknown_columns"]
@@ -275,7 +287,10 @@ async def test_preview_sheet_with_aliases(client, admin_token, session):
 
     with (
         patch("app.services.google_sheets_service.discovery_build") as mock_build,
-        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+        patch(
+            "app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info",
+            return_value=MagicMock(),
+        ),
     ):
         mock_service = MagicMock()
         mock_service.spreadsheets().get().execute.return_value = {
@@ -331,7 +346,10 @@ async def test_preview_sheet_not_shared(client, admin_token, session):
 
     with (
         patch("app.services.google_sheets_service.discovery_build") as mock_build,
-        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+        patch(
+            "app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info",
+            return_value=MagicMock(),
+        ),
     ):
         mock_service = MagicMock()
         mock_service.spreadsheets().get().execute.side_effect = Exception(
@@ -350,22 +368,23 @@ async def test_preview_sheet_not_shared(client, admin_token, session):
 
 
 @pytest.mark.asyncio
-async def test_preview_non_defaultable_fields_are_unknown(client, admin_token, session):
-    """Fields that match COLUMN_MAP but are not in DEFAULTABLE_SAMPLE_FIELDS go to unknown."""
+async def test_preview_non_defaultable_fields_recognized_with_flag(client, admin_token, session):
+    """Fields that match COLUMN_MAP but are not defaultable are recognized with defaultable=false."""
     await _seed_reader_sa(session)
 
     with (
         patch("app.services.google_sheets_service.discovery_build") as mock_build,
-        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+        patch(
+            "app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info",
+            return_value=MagicMock(),
+        ),
     ):
         mock_service = MagicMock()
         mock_service.spreadsheets().get().execute.return_value = {
             "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]
         }
         # qc_status maps via COLUMN_MAP but is NOT in DEFAULTABLE_SAMPLE_FIELDS
-        mock_service.spreadsheets().values().get().execute.return_value = {
-            "values": [["organism", "qc_status"]]
-        }
+        mock_service.spreadsheets().values().get().execute.return_value = {"values": [["organism", "qc_status"]]}
         mock_build.return_value = mock_service
 
         response = await client.post(
@@ -376,7 +395,10 @@ async def test_preview_non_defaultable_fields_are_unknown(client, admin_token, s
 
     assert response.status_code == 200
     data = response.json()
-    recognized_fields = {c["mapped_to"] for c in data["recognized_columns"]}
-    assert "organism" in recognized_fields
-    # qc_status should be in unknown since it's not defaultable
-    assert "qc_status" in data["unknown_columns"]
+    recognized = {c["mapped_to"]: c for c in data["recognized_columns"]}
+    assert "organism" in recognized
+    assert recognized["organism"]["defaultable"] is True
+    # qc_status is recognized but not defaultable
+    assert "qc_status" in recognized
+    assert recognized["qc_status"]["defaultable"] is False
+    assert "qc_status" not in data["unknown_columns"]

--- a/backend/tests/test_sheets_import_api.py
+++ b/backend/tests/test_sheets_import_api.py
@@ -402,3 +402,70 @@ async def test_preview_non_defaultable_fields_recognized_with_flag(client, admin
     assert "qc_status" in recognized
     assert recognized["qc_status"]["defaultable"] is False
     assert "qc_status" not in data["unknown_columns"]
+
+
+# ---------------------------------------------------------------------------
+# POST /{experiment_id}/samples/preview (Google Sheet -> sample preview)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sheet_sample_preview(client, admin_token, session):
+    """POST /api/v1/sheets/{id}/samples/preview returns CSV-style preview from a sheet."""
+    await _seed_reader_sa(session)
+
+    # Create an experiment first
+    exp_resp = await client.post(
+        "/api/experiments",
+        json={"name": "Sheet Sample Test"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert exp_resp.status_code == 200
+    exp_id = exp_resp.json()["id"]
+
+    with (
+        patch("app.services.google_sheets_service.discovery_build") as mock_build,
+        patch(
+            "app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info",
+            return_value=MagicMock(),
+        ),
+    ):
+        mock_service = MagicMock()
+        mock_service.spreadsheets().get().execute.return_value = {
+            "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]
+        }
+        # Full sheet with header + 2 data rows
+        mock_service.spreadsheets().values().get().execute.return_value = {
+            "values": [
+                ["organism", "tissue_type", "custom_col"],
+                ["human", "PBMC", "val1"],
+                ["mouse", "brain", "val2"],
+            ]
+        }
+        mock_build.return_value = mock_service
+
+        response = await client.post(
+            f"/api/v1/sheets/{exp_id}/samples/preview",
+            json={"sheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_rows"] == 2
+    assert len(data["recognized_columns"]) >= 2
+    recognized_fields = {c["mapped_to"] for c in data["recognized_columns"]}
+    assert "organism" in recognized_fields
+    assert "tissue_type" in recognized_fields
+
+
+@pytest.mark.asyncio
+async def test_sheet_sample_preview_no_reader_sa(client, admin_token, session):
+    """Sheet sample preview returns 400 when reader SA not configured."""
+    response = await client.post(
+        "/api/v1/sheets/1/samples/preview",
+        json={"sheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400
+    assert "not configured" in response.json()["detail"]

--- a/backend/tests/test_sheets_import_api.py
+++ b/backend/tests/test_sheets_import_api.py
@@ -1,0 +1,382 @@
+"""Tests for Google Sheets import API endpoints.
+
+Reader SA management and sheet preview endpoints.
+All GCP / Sheets API calls are mocked.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import text
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_reader_sa(session, email: str = "bioaf-reader-abc1@proj.iam.gserviceaccount.com"):
+    """Insert reader SA config into platform_config."""
+    sa_key = json.dumps({
+        "type": "service_account",
+        "project_id": "my-project",
+        "private_key_id": "key123",
+        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+        "client_email": email,
+        "client_id": "123456789",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    })
+    await session.execute(
+        text("""
+        INSERT INTO platform_config (key, value) VALUES
+            ('sheets_reader_sa_email', :email),
+            ('sheets_reader_sa_key', :key),
+            ('sheets_reader_sa_created', 'true')
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+        """).bindparams(email=email, key=sa_key)
+    )
+    await session.commit()
+
+
+async def _seed_gcp_config(session):
+    """Insert minimal GCP config for SA creation tests."""
+    sa_key = json.dumps({
+        "type": "service_account",
+        "project_id": "my-project",
+        "private_key_id": "key123",
+        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n",
+        "client_email": "bioaf@my-project.iam.gserviceaccount.com",
+        "client_id": "123456789",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    })
+    await session.execute(
+        text("""
+        INSERT INTO platform_config (key, value) VALUES
+            ('gcp_project_id', 'my-project'),
+            ('gcp_credential_source', 'service_account_key'),
+            ('gcp_service_account_key', :key),
+            ('gcp_service_account_email', '')
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+        """).bindparams(key=sa_key)
+    )
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /reader-sa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_reader_sa_not_configured(client, admin_token, session):
+    """GET /api/v1/sheets/reader-sa returns exists=false when not configured."""
+    response = await client.get(
+        "/api/v1/sheets/reader-sa",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["exists"] is False
+    assert data["email"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_reader_sa_configured(client, admin_token, session):
+    """GET /api/v1/sheets/reader-sa returns the SA email when configured."""
+    await _seed_reader_sa(session)
+
+    response = await client.get(
+        "/api/v1/sheets/reader-sa",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["exists"] is True
+    assert "bioaf-reader" in data["email"]
+
+
+@pytest.mark.asyncio
+async def test_get_reader_sa_requires_auth(client, session):
+    """GET /api/v1/sheets/reader-sa requires authentication."""
+    response = await client.get("/api/v1/sheets/reader-sa")
+    assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# POST /reader-sa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_reader_sa_success(client, admin_token, session):
+    """POST /api/v1/sheets/reader-sa creates the SA and returns email."""
+    await _seed_gcp_config(session)
+
+    mock_iam = MagicMock()
+    mock_iam.projects().serviceAccounts().create().execute.return_value = {
+        "email": "bioaf-reader-1234@my-project.iam.gserviceaccount.com"
+    }
+    mock_iam.projects().serviceAccounts().keys().create().execute.return_value = {
+        "privateKeyData": "eyJ0eXBlIjoic2VydmljZV9hY2NvdW50In0="  # base64 of {"type":"service_account"}
+    }
+
+    mock_usage = MagicMock()
+    mock_usage.services().enable().execute.return_value = {}
+
+    def fake_build(api, version, **kwargs):
+        if api == "iam":
+            return mock_iam
+        if api == "serviceusage":
+            return mock_usage
+        return MagicMock()
+
+    with (
+        patch("app.services.sheets_reader_sa_service.discovery_build", side_effect=fake_build),
+        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+    ):
+        response = await client.post(
+            "/api/v1/sheets/reader-sa",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "bioaf-reader" in data["email"]
+    assert data["message"] == "Reader service account created successfully"
+
+
+@pytest.mark.asyncio
+async def test_create_reader_sa_idempotent(client, admin_token, session):
+    """POST /api/v1/sheets/reader-sa returns existing SA when already created."""
+    await _seed_reader_sa(session, "bioaf-reader-existing@proj.iam.gserviceaccount.com")
+
+    response = await client.post(
+        "/api/v1/sheets/reader-sa",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "bioaf-reader-existing@proj.iam.gserviceaccount.com"
+
+
+@pytest.mark.asyncio
+async def test_create_reader_sa_no_gcp_config(client, admin_token, session):
+    """POST /api/v1/sheets/reader-sa returns 400 when GCP is not configured."""
+    response = await client.post(
+        "/api/v1/sheets/reader-sa",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_reader_sa_viewer_forbidden(client, viewer_token, session):
+    """Viewers cannot create the reader SA."""
+    response = await client.post(
+        "/api/v1/sheets/reader-sa",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /reader-sa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_reader_sa_success(client, admin_token, session):
+    """DELETE /api/v1/sheets/reader-sa removes the SA config."""
+    await _seed_reader_sa(session)
+    await _seed_gcp_config(session)
+
+    with patch("app.services.sheets_reader_sa_service.discovery_build") as mock_build:
+        mock_iam = MagicMock()
+        mock_iam.projects().serviceAccounts().delete().execute.return_value = {}
+        mock_build.return_value = mock_iam
+
+        response = await client.delete(
+            "/api/v1/sheets/reader-sa",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+
+    # Verify SA config was removed
+    get_response = await client.get(
+        "/api/v1/sheets/reader-sa",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert get_response.json()["exists"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_reader_sa_noop_when_not_configured(client, admin_token, session):
+    """DELETE /api/v1/sheets/reader-sa succeeds even when no SA exists."""
+    response = await client.delete(
+        "/api/v1/sheets/reader-sa",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /preview
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_sheet_headers(client, admin_token, session):
+    """POST /api/v1/sheets/preview returns classified columns."""
+    await _seed_reader_sa(session)
+
+    with (
+        patch("app.services.google_sheets_service.discovery_build") as mock_build,
+        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+    ):
+        mock_service = MagicMock()
+        mock_service.spreadsheets().get().execute.return_value = {
+            "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]
+        }
+        mock_service.spreadsheets().values().get().execute.return_value = {
+            "values": [["organism", "tissue_type", "centrifuge_rpm", "barcode"]]
+        }
+        mock_build.return_value = mock_service
+
+        response = await client.post(
+            "/api/v1/sheets/preview",
+            json={"sheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["spreadsheet_id"] == "abc123"
+    assert data["sheet_name"] == "Sheet1"
+    assert len(data["columns"]) == 4
+
+    # organism and tissue_type should be recognized
+    recognized_fields = {c["mapped_to"] for c in data["recognized_columns"]}
+    assert "organism" in recognized_fields
+    assert "tissue_type" in recognized_fields
+
+    # centrifuge_rpm and barcode should be unknown
+    assert "centrifuge_rpm" in data["unknown_columns"]
+    assert "barcode" in data["unknown_columns"]
+
+
+@pytest.mark.asyncio
+async def test_preview_sheet_with_aliases(client, admin_token, session):
+    """Column aliases from COLUMN_MAP are resolved correctly."""
+    await _seed_reader_sa(session)
+
+    with (
+        patch("app.services.google_sheets_service.discovery_build") as mock_build,
+        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+    ):
+        mock_service = MagicMock()
+        mock_service.spreadsheets().get().execute.return_value = {
+            "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]
+        }
+        # "tissue" is an alias for "tissue_type", "treatment" for "treatment_condition"
+        mock_service.spreadsheets().values().get().execute.return_value = {
+            "values": [["tissue", "treatment", "custom_field_1"]]
+        }
+        mock_build.return_value = mock_service
+
+        response = await client.post(
+            "/api/v1/sheets/preview",
+            json={"sheet_url": "https://docs.google.com/spreadsheets/d/xyz789/edit"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    recognized_map = {c["header"]: c["mapped_to"] for c in data["recognized_columns"]}
+    assert recognized_map["tissue"] == "tissue_type"
+    assert recognized_map["treatment"] == "treatment_condition"
+    assert "custom_field_1" in data["unknown_columns"]
+
+
+@pytest.mark.asyncio
+async def test_preview_sheet_no_reader_sa(client, admin_token, session):
+    """POST /api/v1/sheets/preview returns 400 when reader SA not configured."""
+    response = await client.post(
+        "/api/v1/sheets/preview",
+        json={"sheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400
+    assert "not configured" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_preview_sheet_invalid_url(client, admin_token, session):
+    """POST /api/v1/sheets/preview returns 422 for non-Sheets URL."""
+    response = await client.post(
+        "/api/v1/sheets/preview",
+        json={"sheet_url": "https://example.com/not-a-sheet"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_preview_sheet_not_shared(client, admin_token, session):
+    """POST /api/v1/sheets/preview returns 403 when sheet not shared with SA."""
+    await _seed_reader_sa(session)
+
+    with (
+        patch("app.services.google_sheets_service.discovery_build") as mock_build,
+        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+    ):
+        mock_service = MagicMock()
+        mock_service.spreadsheets().get().execute.side_effect = Exception(
+            "HttpError 403: The caller does not have permission"
+        )
+        mock_build.return_value = mock_service
+
+        response = await client.post(
+            "/api/v1/sheets/preview",
+            json={"sheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 403
+    assert "Share it with" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_preview_non_defaultable_fields_are_unknown(client, admin_token, session):
+    """Fields that match COLUMN_MAP but are not in DEFAULTABLE_SAMPLE_FIELDS go to unknown."""
+    await _seed_reader_sa(session)
+
+    with (
+        patch("app.services.google_sheets_service.discovery_build") as mock_build,
+        patch("app.services.sheets_reader_sa_service.service_account.Credentials.from_service_account_info", return_value=MagicMock()),
+    ):
+        mock_service = MagicMock()
+        mock_service.spreadsheets().get().execute.return_value = {
+            "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]
+        }
+        # qc_status maps via COLUMN_MAP but is NOT in DEFAULTABLE_SAMPLE_FIELDS
+        mock_service.spreadsheets().values().get().execute.return_value = {
+            "values": [["organism", "qc_status"]]
+        }
+        mock_build.return_value = mock_service
+
+        response = await client.post(
+            "/api/v1/sheets/preview",
+            json={"sheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    recognized_fields = {c["mapped_to"] for c in data["recognized_columns"]}
+    assert "organism" in recognized_fields
+    # qc_status should be in unknown since it's not defaultable
+    assert "qc_status" in data["unknown_columns"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/experiments/[id]/page.tsx
+++ b/frontend/src/app/experiments/[id]/page.tsx
@@ -732,7 +732,7 @@ export default function ExperimentDetailPage() {
                   onClick={() => setShowCsvUpload(true)}
                   className="bg-white border border-gray-300 px-4 py-2 rounded-md text-sm hover:bg-gray-50"
                 >
-                  Upload CSV
+                  Import Samples
                 </button>
                 {selectedSampleIds.size > 0 && (
                   <>

--- a/frontend/src/app/experiments/new/page.tsx
+++ b/frontend/src/app/experiments/new/page.tsx
@@ -8,6 +8,7 @@ import { isAuthenticated } from "@/lib/auth";
 import { api } from "@/lib/api";
 import { VocabularySelect } from "@/components/shared/VocabularySelect";
 import { ExtensibleVocabularySelect } from "@/components/shared/ExtensibleVocabularySelect";
+import { SheetImportModal } from "@/components/experiments/SheetImportModal";
 import type {
   Experiment,
   ExperimentCreateRequest,
@@ -40,6 +41,7 @@ export default function NewExperimentPage() {
   const [showFieldDefaults, setShowFieldDefaults] = useState(false);
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, string>>({});
   const [extraCustomFields, setExtraCustomFields] = useState<{ name: string; value: string; required: boolean }[]>([]);
+  const [showSheetImport, setShowSheetImport] = useState(false);
 
   const DEFAULTABLE_FIELDS = [
     { name: "organism", label: "Organism", type: "text" as const },
@@ -68,6 +70,28 @@ export default function NewExperimentPage() {
       }
       return prev;
     });
+  }
+
+  function handleSheetImportApply(result: {
+    fieldDefaults: FieldDefaultValue[];
+    customFields: { name: string; value: string; required: boolean }[];
+  }) {
+    // Merge imported field defaults (only add fields not already configured)
+    setFieldDefaults((prev) => {
+      const existing = new Set(prev.map((d) => d.field_name));
+      const newDefaults = result.fieldDefaults.filter((d) => !existing.has(d.field_name));
+      return [...prev, ...newDefaults];
+    });
+
+    // Append imported custom fields (only add fields not already present)
+    setExtraCustomFields((prev) => {
+      const existing = new Set(prev.map((f) => f.name));
+      const newFields = result.customFields.filter((f) => !existing.has(f.name));
+      return [...prev, ...newFields];
+    });
+
+    // Auto-expand the field defaults section
+    setShowFieldDefaults(true);
   }
 
   useEffect(() => {
@@ -250,13 +274,22 @@ export default function NewExperimentPage() {
                     Set default values applied to all samples in this experiment. Per-sample values still override these.
                   </p>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setShowFieldDefaults(!showFieldDefaults)}
-                  className="text-sm text-bioaf-600 hover:underline"
-                >
-                  {showFieldDefaults ? "Hide" : "Configure"}
-                </button>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setShowSheetImport(true)}
+                    className="text-sm text-bioaf-600 hover:underline"
+                  >
+                    Import from Google Sheet
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowFieldDefaults(!showFieldDefaults)}
+                    className="text-sm text-bioaf-600 hover:underline"
+                  >
+                    {showFieldDefaults ? "Hide" : "Configure"}
+                  </button>
+                </div>
               </div>
 
               {showFieldDefaults && (
@@ -401,6 +434,15 @@ export default function NewExperimentPage() {
               </button>
             </div>
           </form>
+
+          {showSheetImport && (
+            <SheetImportModal
+              onClose={() => setShowSheetImport(false)}
+              onApply={handleSheetImportApply}
+              existingFieldDefaults={fieldDefaults}
+              existingCustomFields={extraCustomFields}
+            />
+          )}
         </main>
       </div>
     </div>

--- a/frontend/src/components/auth/SetupWizard.tsx
+++ b/frontend/src/components/auth/SetupWizard.tsx
@@ -40,6 +40,7 @@ const SETUP_RECOMMENDED_ROLES = [
   { role: "roles/pubsub.admin", description: "Pub/Sub Admin" },
   { role: "roles/container.admin", description: "Kubernetes Engine Admin" },
   { role: "roles/iam.serviceAccountUser", description: "Service Account User" },
+  { role: "roles/iam.serviceAccountKeyAdmin", description: "Service Account Key Admin" },
   { role: "roles/compute.admin", description: "Compute Admin" },
   { role: "roles/resourcemanager.projectIamAdmin", description: "Project IAM Admin" },
   { role: "roles/bigquery.dataEditor", description: "BigQuery Data Editor" },

--- a/frontend/src/components/experiments/CsvUploadModal.tsx
+++ b/frontend/src/components/experiments/CsvUploadModal.tsx
@@ -99,7 +99,7 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
       const match = existingCustomFieldsLower.get(normalized);
       if (match) {
         // Auto-map to the existing custom field
-        initial[col] = `custom:${match}`;
+        initial[col] = `existing:${match}`;
       } else {
         // Default to creating as a new custom field
         initial[col] = `custom:${col}`;
@@ -167,12 +167,7 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
     setLoading(true);
     setError("");
 
-    const activeMappings: Record<string, string> = {};
-    for (const [col, target] of Object.entries(mappings)) {
-      if (target !== "skip") {
-        activeMappings[col] = target;
-      }
-    }
+    const activeMappings = resolveActiveMappings(mappings);
 
     try {
       const data = await api.post<ConfirmResponse>(
@@ -191,17 +186,21 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
     }
   }
 
+  function resolveActiveMappings(mappings: Record<string, string>): Record<string, string> {
+    const active: Record<string, string> = {};
+    for (const [col, target] of Object.entries(mappings)) {
+      if (target === "skip") continue;
+      // Normalize "existing:X" to "custom:X" -- the backend treats both the same
+      active[col] = target.startsWith("existing:") ? `custom:${target.slice("existing:".length)}` : target;
+    }
+    return active;
+  }
+
   async function submitConfirm(confirmFile: File, mappings: Record<string, string>) {
     setLoading(true);
     setError("");
 
-    // Filter out "skip" mappings
-    const activeMappings: Record<string, string> = {};
-    for (const [col, target] of Object.entries(mappings)) {
-      if (target !== "skip") {
-        activeMappings[col] = target;
-      }
-    }
+    const activeMappings = resolveActiveMappings(mappings);
 
     try {
       const data = await api.upload<ConfirmResponse>(
@@ -228,7 +227,7 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
   // Fields already claimed by recognized columns or other mappings
   const usedFields = new Set<string>([
     ...(preview?.recognized_columns.map((c) => c.mapped_to) ?? []),
-    ...Object.values(columnMappings).filter((v) => v !== "skip" && !v.startsWith("custom:")),
+    ...Object.values(columnMappings).filter((v) => v !== "skip" && !v.startsWith("custom:") && !v.startsWith("existing:")),
   ]);
 
   return (
@@ -447,7 +446,7 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
                         {existingCustomFields.length > 0 && (
                           <optgroup label="Map to existing custom field">
                             {existingCustomFields.map((cf) => (
-                              <option key={`cf:${cf}`} value={`custom:${cf}`}>
+                              <option key={`cf:${cf}`} value={`existing:${cf}`}>
                                 {cf}
                               </option>
                             ))}

--- a/frontend/src/components/experiments/CsvUploadModal.tsx
+++ b/frontend/src/components/experiments/CsvUploadModal.tsx
@@ -87,6 +87,27 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
+  // Build a lookup of existing custom field names (lowercased) for auto-matching
+  const existingCustomFieldsLower = new Map(
+    existingCustomFields.map((name) => [name.toLowerCase().replace(/\s+/g, "_"), name])
+  );
+
+  function buildInitialMappings(unknownColumns: string[]): Record<string, string> {
+    const initial: Record<string, string> = {};
+    for (const col of unknownColumns) {
+      const normalized = col.toLowerCase().replace(/\s+/g, "_");
+      const match = existingCustomFieldsLower.get(normalized);
+      if (match) {
+        // Auto-map to the existing custom field
+        initial[col] = `custom:${match}`;
+      } else {
+        // Default to creating as a new custom field
+        initial[col] = `custom:${col}`;
+      }
+    }
+    return initial;
+  }
+
   async function handleFileSelect(selectedFile: File) {
     setFile(selectedFile);
     setError("");
@@ -100,12 +121,7 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
       setPreview(data);
 
       if (data.unknown_columns.length > 0) {
-        // Initialize mappings: default to "skip" for unknown columns
-        const initial: Record<string, string> = {};
-        for (const col of data.unknown_columns) {
-          initial[col] = "skip";
-        }
-        setColumnMappings(initial);
+        setColumnMappings(buildInitialMappings(data.unknown_columns));
         setStep("preview");
       } else if (data.errors.length > 0 && data.total_rows === 0) {
         setError(data.errors.join("; "));
@@ -133,11 +149,7 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
       setPreview(data);
 
       if (data.unknown_columns.length > 0) {
-        const initial: Record<string, string> = {};
-        for (const col of data.unknown_columns) {
-          initial[col] = "skip";
-        }
-        setColumnMappings(initial);
+        setColumnMappings(buildInitialMappings(data.unknown_columns));
         setStep("preview");
       } else if (data.errors.length > 0 && data.total_rows === 0) {
         setError(data.errors.join("; "));

--- a/frontend/src/components/experiments/CsvUploadModal.tsx
+++ b/frontend/src/components/experiments/CsvUploadModal.tsx
@@ -74,9 +74,13 @@ interface Props {
 
 type Step = "select" | "preview" | "confirm" | "done";
 
+type Source = "csv" | "gsheet";
+
 export function CsvUploadModal({ experimentId, existingCustomFields = [], onClose, onSuccess }: Props) {
   const [step, setStep] = useState<Step>("select");
+  const [source, setSource] = useState<Source>("csv");
   const [file, setFile] = useState<File | null>(null);
+  const [sheetUrl, setSheetUrl] = useState("");
   const [preview, setPreview] = useState<PreviewResponse | null>(null);
   const [columnMappings, setColumnMappings] = useState<Record<string, string>>({});
   const [result, setResult] = useState<ConfirmResponse | null>(null);
@@ -111,6 +115,65 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to parse CSV");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSheetPreview() {
+    if (!sheetUrl.trim()) return;
+    setError("");
+    setLoading(true);
+
+    try {
+      const data = await api.post<PreviewResponse>(
+        `/api/v1/sheets/${experimentId}/samples/preview`,
+        { sheet_url: sheetUrl.trim() },
+      );
+      setPreview(data);
+
+      if (data.unknown_columns.length > 0) {
+        const initial: Record<string, string> = {};
+        for (const col of data.unknown_columns) {
+          initial[col] = "skip";
+        }
+        setColumnMappings(initial);
+        setStep("preview");
+      } else if (data.errors.length > 0 && data.total_rows === 0) {
+        setError(data.errors.join("; "));
+      } else {
+        await submitSheetConfirm({});
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to read spreadsheet");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitSheetConfirm(mappings: Record<string, string>) {
+    setLoading(true);
+    setError("");
+
+    const activeMappings: Record<string, string> = {};
+    for (const [col, target] of Object.entries(mappings)) {
+      if (target !== "skip") {
+        activeMappings[col] = target;
+      }
+    }
+
+    try {
+      const data = await api.post<ConfirmResponse>(
+        `/api/v1/sheets/${experimentId}/samples/confirm`,
+        { sheet_url: sheetUrl.trim(), column_mappings: activeMappings },
+      );
+      setResult(data);
+      setStep("done");
+      if (data.created_count > 0) {
+        onSuccess();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create samples");
     } finally {
       setLoading(false);
     }
@@ -161,9 +224,9 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
       <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[80vh] overflow-hidden flex flex-col">
         <div className="px-6 py-4 border-b flex justify-between items-center">
           <h2 className="text-lg font-semibold">
-            {step === "select" && "Upload Sample CSV"}
+            {step === "select" && "Import Samples"}
             {step === "preview" && "Map Unknown Columns"}
-            {step === "done" && "Upload Complete"}
+            {step === "done" && "Import Complete"}
           </h2>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl">
             &times;
@@ -171,76 +234,148 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
         </div>
 
         <div className="flex-1 overflow-y-auto p-6">
-          {/* Step 1: File selection */}
+          {/* Step 1: Source selection */}
           {step === "select" && (
             <div className="space-y-4">
-              <p className="text-sm text-gray-600">
-                Upload a CSV or TSV file to bulk-create samples. Your CSV should include a
-                header row with column names matching the fields below.
-              </p>
-
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="text-sm font-medium text-gray-700">Expected CSV Format</h3>
-                  <button
-                    onClick={() => api.download(`/api/experiments/${experimentId}/samples/csv-template`)}
-                    className="text-xs text-bioaf-600 hover:underline"
-                  >
-                    Download template CSV
-                  </button>
-                </div>
-                <div className="overflow-x-auto border rounded-md">
-                  <table className="min-w-full text-xs">
-                    <thead className="bg-gray-50">
-                      <tr>
-                        {SAMPLE_FIELDS.map((f) => (
-                          <th key={f.value} className="px-2 py-1.5 text-left font-medium text-gray-600 whitespace-nowrap">
-                            {f.value}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr className="text-gray-400 italic">
-                        {SAMPLE_FIELDS.map((f) => (
-                          <td key={f.value} className="px-2 py-1 whitespace-nowrap">
-                            {EXAMPLE_VALUES[f.value] ?? ""}
-                          </td>
-                        ))}
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-                <p className="text-xs text-gray-500 mt-1">
-                  All columns are optional. Unrecognized columns will prompt you to map or skip them.
-                </p>
+              {/* Source toggle */}
+              <div className="flex border-b">
+                <button
+                  type="button"
+                  onClick={() => { setSource("csv"); setError(""); }}
+                  className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+                    source === "csv"
+                      ? "border-bioaf-600 text-bioaf-600"
+                      : "border-transparent text-gray-500 hover:text-gray-700"
+                  }`}
+                >
+                  CSV File
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setSource("gsheet"); setError(""); }}
+                  className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+                    source === "gsheet"
+                      ? "border-bioaf-600 text-bioaf-600"
+                      : "border-transparent text-gray-500 hover:text-gray-700"
+                  }`}
+                >
+                  Google Sheet
+                </button>
               </div>
 
-              <label className="flex items-center justify-center w-full h-24 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-bioaf-400 hover:bg-gray-50 transition-colors">
-                <div className="text-center">
-                  {loading ? (
-                    <p className="text-sm text-gray-500">Analyzing file...</p>
-                  ) : (
-                    <>
-                      <p className="text-sm font-medium text-gray-700">
-                        Click to select a CSV file
-                      </p>
-                      <p className="text-xs text-gray-500 mt-1">
-                        Supports .csv, .tsv, and .txt
-                      </p>
-                    </>
-                  )}
-                </div>
-                <input
-                  type="file"
-                  accept=".csv,.tsv,.txt"
-                  className="hidden"
-                  onChange={(e) => {
-                    if (e.target.files?.[0]) handleFileSelect(e.target.files[0]);
-                  }}
-                  disabled={loading}
-                />
-              </label>
+              {source === "csv" && (
+                <>
+                  <p className="text-sm text-gray-600">
+                    Upload a CSV or TSV file to bulk-create samples. Your CSV should include a
+                    header row with column names matching the fields below.
+                  </p>
+
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <h3 className="text-sm font-medium text-gray-700">Expected CSV Format</h3>
+                      <button
+                        onClick={() => api.download(`/api/experiments/${experimentId}/samples/csv-template`)}
+                        className="text-xs text-bioaf-600 hover:underline"
+                      >
+                        Download template CSV
+                      </button>
+                    </div>
+                    <div className="overflow-x-auto border rounded-md">
+                      <table className="min-w-full text-xs">
+                        <thead className="bg-gray-50">
+                          <tr>
+                            {SAMPLE_FIELDS.map((f) => (
+                              <th key={f.value} className="px-2 py-1.5 text-left font-medium text-gray-600 whitespace-nowrap">
+                                {f.value}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr className="text-gray-400 italic">
+                            {SAMPLE_FIELDS.map((f) => (
+                              <td key={f.value} className="px-2 py-1 whitespace-nowrap">
+                                {EXAMPLE_VALUES[f.value] ?? ""}
+                              </td>
+                            ))}
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <p className="text-xs text-gray-500 mt-1">
+                      All columns are optional. Unrecognized columns will prompt you to map or skip them.
+                    </p>
+                  </div>
+
+                  <label className="flex items-center justify-center w-full h-24 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-bioaf-400 hover:bg-gray-50 transition-colors">
+                    <div className="text-center">
+                      {loading ? (
+                        <p className="text-sm text-gray-500">Analyzing file...</p>
+                      ) : (
+                        <>
+                          <p className="text-sm font-medium text-gray-700">
+                            Click to select a CSV file
+                          </p>
+                          <p className="text-xs text-gray-500 mt-1">
+                            Supports .csv, .tsv, and .txt
+                          </p>
+                        </>
+                      )}
+                    </div>
+                    <input
+                      type="file"
+                      accept=".csv,.tsv,.txt"
+                      className="hidden"
+                      onChange={(e) => {
+                        if (e.target.files?.[0]) handleFileSelect(e.target.files[0]);
+                      }}
+                      disabled={loading}
+                    />
+                  </label>
+                </>
+              )}
+
+              {source === "gsheet" && (
+                <>
+                  <p className="text-sm text-gray-600">
+                    Import samples directly from a Google Sheet. The sheet must be shared with
+                    the bioAF reader account (see Settings &gt; Integrations &gt; GCP).
+                  </p>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Google Sheets URL
+                    </label>
+                    <input
+                      type="url"
+                      value={sheetUrl}
+                      onChange={(e) => setSheetUrl(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          handleSheetPreview();
+                        }
+                      }}
+                      placeholder="https://docs.google.com/spreadsheets/d/..."
+                      className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-bioaf-500 focus:border-bioaf-500"
+                      autoFocus
+                    />
+                  </div>
+
+                  <p className="text-xs text-gray-500">
+                    The first row should contain column headers. Data rows start from row 2.
+                    Unrecognized columns will prompt you to map or skip them.
+                  </p>
+
+                  <button
+                    onClick={handleSheetPreview}
+                    disabled={loading || !sheetUrl.trim()}
+                    className="px-4 py-2 text-sm bg-bioaf-600 text-white rounded-md hover:bg-bioaf-700 disabled:opacity-50"
+                  >
+                    {loading ? "Reading sheet..." : "Import from Sheet"}
+                  </button>
+                </>
+              )}
 
               {error && (
                 <div className="bg-red-50 border border-red-200 rounded-md p-3">
@@ -415,7 +550,13 @@ export function CsvUploadModal({ experimentId, existingCustomFields = [], onClos
                 Back
               </button>
               <button
-                onClick={() => file && submitConfirm(file, columnMappings)}
+                onClick={() => {
+                  if (source === "gsheet") {
+                    submitSheetConfirm(columnMappings);
+                  } else if (file) {
+                    submitConfirm(file, columnMappings);
+                  }
+                }}
                 className="px-4 py-2 text-sm text-white bg-bioaf-600 rounded-md hover:bg-bioaf-700 disabled:opacity-50"
                 disabled={loading}
               >

--- a/frontend/src/components/experiments/SheetImportModal.tsx
+++ b/frontend/src/components/experiments/SheetImportModal.tsx
@@ -4,20 +4,33 @@ import { useState } from "react";
 import { api } from "@/lib/api";
 import type { FieldDefaultValue, SheetPreviewResponse } from "@/lib/types";
 
-// Sample fields that can be set as experiment-level defaults.
-// Must match DEFAULTABLE_SAMPLE_FIELDS on the backend.
-const DEFAULTABLE_FIELDS = [
-  { value: "organism", label: "Organism" },
-  { value: "tissue_type", label: "Tissue Type" },
-  { value: "donor_source", label: "Donor ID" },
-  { value: "treatment_condition", label: "Treatment Condition" },
-  { value: "chemistry_version", label: "Chemistry Version" },
-  { value: "sample_batch_code", label: "Sample Batch" },
-  { value: "sequencing_batch_code", label: "Sequencing Batch" },
-  { value: "molecule_type", label: "Molecule Type" },
-  { value: "library_prep_method", label: "Library Prep Method" },
-  { value: "library_layout", label: "Library Layout" },
+// All user-facing sample fields. Must match SAMPLE_FIELDS + DEFAULTABLE_SAMPLE_FIELDS
+// on the backend. Fields marked defaultable can have experiment-level defaults set.
+const ALL_SAMPLE_FIELDS = [
+  { value: "sample_id_unique", label: "Sample ID", defaultable: false },
+  { value: "organism", label: "Organism", defaultable: true },
+  { value: "tissue_type", label: "Tissue Type", defaultable: true },
+  { value: "donor_source", label: "Donor ID", defaultable: true },
+  { value: "treatment_condition", label: "Treatment Condition", defaultable: true },
+  { value: "chemistry_version", label: "Chemistry Version", defaultable: true },
+  { value: "viability_pct", label: "Viability %", defaultable: false },
+  { value: "cell_count", label: "Cell Count", defaultable: false },
+  { value: "prep_notes", label: "Prep Notes", defaultable: false },
+  { value: "molecule_type", label: "Molecule Type", defaultable: true },
+  { value: "library_prep_method", label: "Library Prep Method", defaultable: true },
+  { value: "library_layout", label: "Library Layout", defaultable: true },
+  { value: "qc_status", label: "QC Status", defaultable: false },
+  { value: "qc_notes", label: "QC Notes", defaultable: false },
+  { value: "collection_timestamp", label: "Collection Timestamp", defaultable: false },
+  { value: "collection_method", label: "Collection Method", defaultable: false },
+  { value: "sample_batch_code", label: "Sample Batch", defaultable: true },
+  { value: "sequencing_batch_code", label: "Sequencing Batch", defaultable: true },
+  { value: "sequencing_batch_position", label: "Batch Position", defaultable: false },
 ];
+
+const DEFAULTABLE_VALUES = new Set(
+  ALL_SAMPLE_FIELDS.filter((f) => f.defaultable).map((f) => f.value)
+);
 
 interface SheetImportModalProps {
   onClose: () => void;
@@ -101,29 +114,30 @@ export function SheetImportModal({
     const newFieldDefaults: FieldDefaultValue[] = [];
     const newCustomFields: { name: string; value: string; required: boolean }[] = [];
 
-    // Add recognized columns as field defaults (if not already set)
+    // Add recognized defaultable columns as field defaults (if not already set)
     for (const col of preview.recognized_columns) {
-      if (!existingFieldDefaults.some((d) => d.field_name === col.mapped_to)) {
+      if (col.defaultable && !existingFieldDefaults.some((d) => d.field_name === col.mapped_to)) {
         newFieldDefaults.push({
           field_name: col.mapped_to,
           default_value: null,
           is_required: null,
         });
       }
+      // Non-defaultable recognized fields (sample_id_unique, viability_pct, etc.)
+      // don't need any action -- they'll be handled during sample CSV import
     }
 
     // Process user mappings for unknown columns
-    for (const [header, mapping] of Object.entries(columnMappings)) {
+    for (const [, mapping] of Object.entries(columnMappings)) {
       if (mapping === "skip") continue;
 
       if (mapping.startsWith("custom:")) {
         const fieldName = mapping.slice("custom:".length);
-        // Don't add if already exists
         if (!existingCustomFields.some((f) => f.name === fieldName)) {
           newCustomFields.push({ name: fieldName, value: "", required: false });
         }
-      } else {
-        // Mapped to a defaultable field
+      } else if (DEFAULTABLE_VALUES.has(mapping)) {
+        // Mapped to a defaultable sample field
         if (!existingFieldDefaults.some((d) => d.field_name === mapping)) {
           newFieldDefaults.push({
             field_name: mapping,
@@ -132,6 +146,8 @@ export function SheetImportModal({
           });
         }
       }
+      // Non-defaultable sample field mappings are informational --
+      // the user now knows the field exists and will be used on sample import
     }
 
     onApply({ fieldDefaults: newFieldDefaults, customFields: newCustomFields });
@@ -207,19 +223,35 @@ export function SheetImportModal({
               {preview.recognized_columns.length > 0 && (
                 <div>
                   <h3 className="text-sm font-medium text-gray-700 mb-2">Recognized Columns</h3>
+                  <p className="text-xs text-gray-500 mb-2">
+                    These columns match existing sample fields and will be handled automatically during sample import.
+                  </p>
                   <div className="flex flex-wrap gap-2">
                     {preview.recognized_columns.map((col) => {
-                      const label = DEFAULTABLE_FIELDS.find((f) => f.value === col.mapped_to)?.label ?? col.mapped_to;
+                      const label = ALL_SAMPLE_FIELDS.find((f) => f.value === col.mapped_to)?.label ?? col.mapped_to;
                       return (
                         <span
                           key={col.header}
-                          className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                            col.defaultable
+                              ? "bg-green-100 text-green-800"
+                              : "bg-blue-100 text-blue-800"
+                          }`}
                         >
                           {col.header} &rarr; {label}
+                          {col.defaultable && (
+                            <span className="ml-1 text-green-600" title="Can set a default value">*</span>
+                          )}
                         </span>
                       );
                     })}
                   </div>
+                  <p className="text-xs text-gray-400 mt-2">
+                    <span className="inline-block w-2 h-2 rounded-full bg-green-200 mr-1" />
+                    Default value can be set &nbsp;
+                    <span className="inline-block w-2 h-2 rounded-full bg-blue-200 mr-1" />
+                    Tracked per sample
+                  </p>
                 </div>
               )}
 
@@ -245,9 +277,18 @@ export function SheetImportModal({
                         >
                           <option value={`custom:${col}`}>Add as custom field &quot;{col}&quot;</option>
                           <option value="skip">Skip this column</option>
-                          <optgroup label="Map to sample field default">
-                            {DEFAULTABLE_FIELDS.filter(
-                              (f) => !usedFields.has(f.value) || columnMappings[col] === f.value
+                          <optgroup label="Sample fields (default value can be set)">
+                            {ALL_SAMPLE_FIELDS.filter(
+                              (f) => f.defaultable && (!usedFields.has(f.value) || columnMappings[col] === f.value)
+                            ).map((f) => (
+                              <option key={f.value} value={f.value}>
+                                {f.label}
+                              </option>
+                            ))}
+                          </optgroup>
+                          <optgroup label="Sample fields (tracked per sample)">
+                            {ALL_SAMPLE_FIELDS.filter(
+                              (f) => !f.defaultable && (!usedFields.has(f.value) || columnMappings[col] === f.value)
                             ).map((f) => (
                               <option key={f.value} value={f.value}>
                                 {f.label}

--- a/frontend/src/components/experiments/SheetImportModal.tsx
+++ b/frontend/src/components/experiments/SheetImportModal.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import type { FieldDefaultValue, SheetPreviewResponse } from "@/lib/types";
+
+// Sample fields that can be set as experiment-level defaults.
+// Must match DEFAULTABLE_SAMPLE_FIELDS on the backend.
+const DEFAULTABLE_FIELDS = [
+  { value: "organism", label: "Organism" },
+  { value: "tissue_type", label: "Tissue Type" },
+  { value: "donor_source", label: "Donor ID" },
+  { value: "treatment_condition", label: "Treatment Condition" },
+  { value: "chemistry_version", label: "Chemistry Version" },
+  { value: "sample_batch_code", label: "Sample Batch" },
+  { value: "sequencing_batch_code", label: "Sequencing Batch" },
+  { value: "molecule_type", label: "Molecule Type" },
+  { value: "library_prep_method", label: "Library Prep Method" },
+  { value: "library_layout", label: "Library Layout" },
+];
+
+interface SheetImportModalProps {
+  onClose: () => void;
+  onApply: (result: {
+    fieldDefaults: FieldDefaultValue[];
+    customFields: { name: string; value: string; required: boolean }[];
+  }) => void;
+  existingFieldDefaults: FieldDefaultValue[];
+  existingCustomFields: { name: string; value: string; required: boolean }[];
+}
+
+type Step = "url" | "mapping" | "done";
+
+export function SheetImportModal({
+  onClose,
+  onApply,
+  existingFieldDefaults,
+  existingCustomFields,
+}: SheetImportModalProps) {
+  const [step, setStep] = useState<Step>("url");
+  const [sheetUrl, setSheetUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [preview, setPreview] = useState<SheetPreviewResponse | null>(null);
+
+  // Column mapping state: header -> target field or action
+  // Values: "skip" | "custom:<name>" | a DEFAULTABLE_FIELDS value
+  const [columnMappings, setColumnMappings] = useState<Record<string, string>>({});
+
+  // -----------------------------------------------------------------------
+  // Step 1: Fetch headers from the sheet
+  // -----------------------------------------------------------------------
+
+  async function handlePreview() {
+    if (!sheetUrl.trim()) return;
+    setLoading(true);
+    setError("");
+    try {
+      const data = await api.post<SheetPreviewResponse>("/api/v1/sheets/preview", {
+        sheet_url: sheetUrl.trim(),
+      });
+      setPreview(data);
+
+      // Default unknown columns to "custom" (create as custom field)
+      const defaults: Record<string, string> = {};
+      for (const col of data.unknown_columns) {
+        defaults[col] = `custom:${col}`;
+      }
+      setColumnMappings(defaults);
+
+      setStep("mapping");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to read spreadsheet");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 2: Column mapping
+  // -----------------------------------------------------------------------
+
+  function handleMappingChange(column: string, value: string) {
+    setColumnMappings((prev) => ({ ...prev, [column]: value }));
+  }
+
+  // Fields already claimed by recognized columns, existing defaults, or other mappings
+  const usedFields = new Set<string>([
+    ...(preview?.recognized_columns.map((c) => c.mapped_to) ?? []),
+    ...existingFieldDefaults.map((d) => d.field_name),
+    ...Object.values(columnMappings).filter((v) => v !== "skip" && !v.startsWith("custom:")),
+  ]);
+
+  // -----------------------------------------------------------------------
+  // Step 3: Apply to form
+  // -----------------------------------------------------------------------
+
+  function handleApply() {
+    if (!preview) return;
+
+    const newFieldDefaults: FieldDefaultValue[] = [];
+    const newCustomFields: { name: string; value: string; required: boolean }[] = [];
+
+    // Add recognized columns as field defaults (if not already set)
+    for (const col of preview.recognized_columns) {
+      if (!existingFieldDefaults.some((d) => d.field_name === col.mapped_to)) {
+        newFieldDefaults.push({
+          field_name: col.mapped_to,
+          default_value: null,
+          is_required: null,
+        });
+      }
+    }
+
+    // Process user mappings for unknown columns
+    for (const [header, mapping] of Object.entries(columnMappings)) {
+      if (mapping === "skip") continue;
+
+      if (mapping.startsWith("custom:")) {
+        const fieldName = mapping.slice("custom:".length);
+        // Don't add if already exists
+        if (!existingCustomFields.some((f) => f.name === fieldName)) {
+          newCustomFields.push({ name: fieldName, value: "", required: false });
+        }
+      } else {
+        // Mapped to a defaultable field
+        if (!existingFieldDefaults.some((d) => d.field_name === mapping)) {
+          newFieldDefaults.push({
+            field_name: mapping,
+            default_value: null,
+            is_required: null,
+          });
+        }
+      }
+    }
+
+    onApply({ fieldDefaults: newFieldDefaults, customFields: newCustomFields });
+    onClose();
+  }
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[80vh] overflow-hidden flex flex-col">
+        <div className="px-6 py-4 border-b flex justify-between items-center">
+          <h2 className="text-lg font-semibold">
+            {step === "url" && "Import from Google Sheet"}
+            {step === "mapping" && "Map Columns"}
+          </h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl">
+            &times;
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {/* Step 1: URL input */}
+          {step === "url" && (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                Paste a Google Sheets URL to import column headers as sample field defaults
+                and custom fields. The sheet must be shared with the bioAF reader service account.
+              </p>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Google Sheets URL
+                </label>
+                <input
+                  type="url"
+                  value={sheetUrl}
+                  onChange={(e) => setSheetUrl(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      handlePreview();
+                    }
+                  }}
+                  placeholder="https://docs.google.com/spreadsheets/d/..."
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-bioaf-500 focus:border-bioaf-500"
+                  autoFocus
+                />
+              </div>
+
+              <p className="text-xs text-gray-500">
+                The sheet&apos;s first row should contain column headers. Share the sheet with the
+                reader service account email (found in Settings &gt; Integrations &gt; GCP).
+              </p>
+            </div>
+          )}
+
+          {/* Step 2: Column mapping */}
+          {step === "mapping" && preview && (
+            <div className="space-y-6">
+              <p className="text-sm text-gray-600">
+                Found {preview.columns.length} column{preview.columns.length !== 1 ? "s" : ""} in
+                sheet &quot;{preview.sheet_name}&quot;.{" "}
+                {preview.recognized_columns.length > 0 &&
+                  `${preview.recognized_columns.length} matched known fields. `}
+                {preview.unknown_columns.length > 0 &&
+                  `${preview.unknown_columns.length} need mapping.`}
+              </p>
+
+              {/* Recognized columns */}
+              {preview.recognized_columns.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">Recognized Columns</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {preview.recognized_columns.map((col) => {
+                      const label = DEFAULTABLE_FIELDS.find((f) => f.value === col.mapped_to)?.label ?? col.mapped_to;
+                      return (
+                        <span
+                          key={col.header}
+                          className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
+                        >
+                          {col.header} &rarr; {label}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Unknown columns */}
+              {preview.unknown_columns.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-700 mb-3">Unmapped Columns</h3>
+                  <p className="text-xs text-gray-500 mb-3">
+                    For each column, choose to map it to an existing sample field,
+                    add it as a custom field, or skip it.
+                  </p>
+                  <div className="space-y-3">
+                    {preview.unknown_columns.map((col) => (
+                      <div key={col} className="flex items-center gap-3 bg-gray-50 rounded-md p-3">
+                        <span className="text-sm font-mono font-medium text-gray-800 min-w-[140px]">
+                          {col}
+                        </span>
+                        <span className="text-gray-400">&rarr;</span>
+                        <select
+                          value={columnMappings[col] ?? `custom:${col}`}
+                          onChange={(e) => handleMappingChange(col, e.target.value)}
+                          className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5"
+                        >
+                          <option value={`custom:${col}`}>Add as custom field &quot;{col}&quot;</option>
+                          <option value="skip">Skip this column</option>
+                          <optgroup label="Map to sample field default">
+                            {DEFAULTABLE_FIELDS.filter(
+                              (f) => !usedFields.has(f.value) || columnMappings[col] === f.value
+                            ).map((f) => (
+                              <option key={f.value} value={f.value}>
+                                {f.label}
+                              </option>
+                            ))}
+                          </optgroup>
+                        </select>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* All recognized, no unknowns */}
+              {preview.unknown_columns.length === 0 && preview.recognized_columns.length > 0 && (
+                <div className="bg-green-50 border border-green-200 rounded-md p-3">
+                  <p className="text-sm text-green-700">
+                    All columns matched known sample fields. Click &quot;Apply to Form&quot; to populate your experiment.
+                  </p>
+                </div>
+              )}
+
+              {/* All skipped/empty */}
+              {preview.columns.length === 0 && (
+                <div className="bg-amber-50 border border-amber-200 rounded-md p-3">
+                  <p className="text-sm text-amber-700">
+                    No columns found in the first row of this sheet.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Error display */}
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-md p-3 mt-4">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        <div className="px-6 py-4 border-t flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+
+          {step === "url" && (
+            <button
+              onClick={handlePreview}
+              disabled={loading || !sheetUrl.trim()}
+              className="px-4 py-2 text-sm bg-bioaf-600 text-white rounded-md hover:bg-bioaf-700 disabled:opacity-50"
+            >
+              {loading ? "Reading sheet..." : "Import Columns"}
+            </button>
+          )}
+
+          {step === "mapping" && (
+            <button
+              onClick={handleApply}
+              className="px-4 py-2 text-sm bg-bioaf-600 text-white rounded-md hover:bg-bioaf-700"
+            >
+              Apply to Form
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/GcpSettingsContent.tsx
+++ b/frontend/src/components/settings/GcpSettingsContent.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
+import { SheetsReaderSACard } from "@/components/settings/SheetsReaderSACard";
 
 interface GCPConfig {
   gcp_project_id: string | null;
@@ -473,6 +474,8 @@ ${RECOMMENDED_ROLES.map(({ role }) => `gcloud projects add-iam-policy-binding $P
               </div>
             )}
           </div>
+
+          <SheetsReaderSACard />
     </>
   );
 }

--- a/frontend/src/components/settings/GcpSettingsContent.tsx
+++ b/frontend/src/components/settings/GcpSettingsContent.tsx
@@ -69,6 +69,7 @@ const RECOMMENDED_ROLES = [
   { role: "roles/pubsub.admin", description: "Pub/Sub Admin" },
   { role: "roles/container.admin", description: "Kubernetes Engine Admin" },
   { role: "roles/iam.serviceAccountUser", description: "Service Account User" },
+  { role: "roles/iam.serviceAccountKeyAdmin", description: "Service Account Key Admin" },
   { role: "roles/compute.admin", description: "Compute Admin" },
   { role: "roles/resourcemanager.projectIamAdmin", description: "Project IAM Admin" },
   { role: "roles/bigquery.dataEditor", description: "BigQuery Data Editor" },

--- a/frontend/src/components/settings/SheetsReaderSACard.tsx
+++ b/frontend/src/components/settings/SheetsReaderSACard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import type { ReaderSAStatus, ReaderSACreateResponse } from "@/lib/types";
+
+export function SheetsReaderSACard() {
+  const [status, setStatus] = useState<ReaderSAStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  async function loadStatus() {
+    try {
+      const data = await api.get<ReaderSAStatus>("/api/v1/sheets/reader-sa");
+      setStatus(data);
+    } catch {
+      // Non-fatal -- admin may not have infra view permission
+    }
+  }
+
+  useEffect(() => {
+    loadStatus();
+  }, []);
+
+  async function handleCreate() {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await api.post<ReaderSACreateResponse>("/api/v1/sheets/reader-sa", {});
+      setStatus({ exists: true, email: data.email });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create reader service account");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm("Delete the Google Sheets reader service account? Users will no longer be able to import columns from Google Sheets.")) {
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      await api.delete("/api/v1/sheets/reader-sa");
+      setStatus({ exists: false, email: null });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete reader service account");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function copyEmail() {
+    if (status?.email) {
+      navigator.clipboard.writeText(status.email);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  if (status === null) return null;
+
+  return (
+    <div className="border rounded-lg p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-800">Google Sheets Reader</h3>
+          <p className="text-xs text-gray-500 mt-0.5">
+            A dedicated service account for reading column headers from shared Google Sheets.
+          </p>
+        </div>
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+            status.exists
+              ? "bg-green-100 text-green-800"
+              : "bg-gray-100 text-gray-600"
+          }`}
+        >
+          {status.exists ? "Active" : "Not created"}
+        </span>
+      </div>
+
+      {status.exists && status.email && (
+        <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+          <p className="text-xs text-blue-800 mb-1.5">
+            Share your Google Sheet with this email to allow bioAF to read column headers:
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs bg-white border border-blue-200 rounded px-2 py-1 font-mono break-all">
+              {status.email}
+            </code>
+            <button
+              onClick={copyEmail}
+              className="text-xs text-blue-600 hover:text-blue-800 whitespace-nowrap"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-md p-2">
+          <p className="text-xs text-red-700">{error}</p>
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        {!status.exists ? (
+          <button
+            onClick={handleCreate}
+            disabled={loading}
+            className="text-sm px-3 py-1.5 bg-bioaf-600 text-white rounded-md hover:bg-bioaf-700 disabled:opacity-50"
+          >
+            {loading ? "Creating..." : "Create Reader SA"}
+          </button>
+        ) : (
+          <button
+            onClick={handleDelete}
+            disabled={loading}
+            className="text-sm px-3 py-1.5 border border-red-300 text-red-600 rounded-md hover:bg-red-50 disabled:opacity-50"
+          >
+            {loading ? "Deleting..." : "Delete Reader SA"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SheetsReaderSACard.tsx
+++ b/frontend/src/components/settings/SheetsReaderSACard.tsx
@@ -9,6 +9,7 @@ export function SheetsReaderSACard() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [copied, setCopied] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
 
   async function loadStatus() {
     try {
@@ -68,7 +69,7 @@ export function SheetsReaderSACard() {
         <div>
           <h3 className="text-sm font-semibold text-gray-800">Google Sheets Reader</h3>
           <p className="text-xs text-gray-500 mt-0.5">
-            A dedicated service account for reading column headers from shared Google Sheets.
+            A dedicated reader account for importing column headers from shared Google Sheets.
           </p>
         </div>
         <span
@@ -107,14 +108,14 @@ export function SheetsReaderSACard() {
         </div>
       )}
 
-      <div className="flex gap-2">
+      <div className="flex items-center gap-2">
         {!status.exists ? (
           <button
             onClick={handleCreate}
             disabled={loading}
             className="text-sm px-3 py-1.5 bg-bioaf-600 text-white rounded-md hover:bg-bioaf-700 disabled:opacity-50"
           >
-            {loading ? "Creating..." : "Create Reader SA"}
+            {loading ? "Creating..." : "Create Reader Account"}
           </button>
         ) : (
           <button
@@ -122,10 +123,27 @@ export function SheetsReaderSACard() {
             disabled={loading}
             className="text-sm px-3 py-1.5 border border-red-300 text-red-600 rounded-md hover:bg-red-50 disabled:opacity-50"
           >
-            {loading ? "Deleting..." : "Delete Reader SA"}
+            {loading ? "Deleting..." : "Delete Reader Account"}
           </button>
         )}
+        <button
+          onClick={() => setShowInfo(!showInfo)}
+          className="text-gray-400 hover:text-gray-600 w-5 h-5 flex items-center justify-center rounded-full border border-gray-300 text-xs font-medium"
+          title="What is a reader account?"
+        >
+          ?
+        </button>
       </div>
+
+      {showInfo && (
+        <div className="bg-gray-50 border border-gray-200 rounded-md p-3 text-xs text-gray-600">
+          <p>
+            A reader account lets bioAF securely access your Google Sheets without creating a
+            new Google Workspace user. You share your spreadsheet with this account the same way
+            you would share with a colleague. It can only read data, never edit or delete.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/settings/SheetsReaderSACard.tsx
+++ b/frontend/src/components/settings/SheetsReaderSACard.tsx
@@ -8,6 +8,7 @@ export function SheetsReaderSACard() {
   const [status, setStatus] = useState<ReaderSAStatus | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [warning, setWarning] = useState("");
   const [copied, setCopied] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
 
@@ -30,6 +31,7 @@ export function SheetsReaderSACard() {
     try {
       const data = await api.post<ReaderSACreateResponse>("/api/v1/sheets/reader-sa", {});
       setStatus({ exists: true, email: data.email });
+      if (data.warning) setWarning(data.warning);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create reader service account");
     } finally {
@@ -105,6 +107,12 @@ export function SheetsReaderSACard() {
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-md p-2">
           <p className="text-xs text-red-700">{error}</p>
+        </div>
+      )}
+
+      {warning && (
+        <div className="bg-amber-50 border border-amber-200 rounded-md p-2">
+          <p className="text-xs text-amber-700">{warning}</p>
         </div>
       )}
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1635,3 +1635,27 @@ export interface DataMount {
   label: string;
   description: string;
 }
+
+// Google Sheets import
+export interface SheetRecognizedColumn {
+  header: string;
+  mapped_to: string;
+}
+
+export interface SheetPreviewResponse {
+  spreadsheet_id: string;
+  sheet_name: string;
+  columns: string[];
+  recognized_columns: SheetRecognizedColumn[];
+  unknown_columns: string[];
+}
+
+export interface ReaderSAStatus {
+  exists: boolean;
+  email: string | null;
+}
+
+export interface ReaderSACreateResponse {
+  email: string;
+  message: string;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1658,4 +1658,5 @@ export interface ReaderSAStatus {
 export interface ReaderSACreateResponse {
   email: string;
   message: string;
+  warning: string | null;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1640,6 +1640,7 @@ export interface DataMount {
 export interface SheetRecognizedColumn {
   header: string;
   mapped_to: string;
+  defaultable: boolean;
 }
 
 export interface SheetPreviewResponse {

--- a/install-gcp.sh
+++ b/install-gcp.sh
@@ -101,6 +101,7 @@ SA_ROLES=(
     "roles/container.admin"
     "roles/iam.serviceAccountUser"
     "roles/iam.serviceAccountAdmin"
+    "roles/iam.serviceAccountKeyAdmin"
     "roles/compute.admin"
     "roles/resourcemanager.projectIamAdmin"
     "roles/bigquery.dataEditor"


### PR DESCRIPTION
## Summary

- Adds Google Sheets integration for both experiment field setup (column headers as field defaults / custom fields) and sample data import (full sheet contents through the existing CSV pipeline)
- Dedicated reader service account created via IAM API and managed from Settings > Integrations > GCP, keeping the primary SA isolated
- Import modal auto-matches unknown columns to existing custom fields and surfaces all 19 sample fields as recognized mapping targets
- Adds `iam.serviceAccountKeys.create` permission and `roles/iam.serviceAccountKeyAdmin` to the GCP setup checklist across install script, settings UI, and setup wizard

## Test plan

- [x] Backend unit tests: 33 sheets-related tests (URL parsing, header reading, column classification, SA lifecycle, API endpoints, permission checks)
- [x] Full backend suite: 1827 passed
- [x] Frontend tests: 412 passed
- [x] Linting: ruff format, ruff check, mypy, tsc, markdownlint all clean
- [ ] Manual: create reader account from Settings > Integrations > GCP, share a Google Sheet with it, import columns during experiment creation, import samples from the experiment detail page
- [ ] Manual: verify CSV import still works unchanged
- [ ] Manual: verify auto-matching of unknown columns to existing custom fields on repeat imports