### PR TITLE
Add serviceusage.services.enable to required SA permissions

### DIFF
--- a/backend/app/services/gcp_config.py
+++ b/backend/app/services/gcp_config.py
@@ -46,15 +46,14 @@ _PERMISSION_ROLE_MAP: dict[str, str] = {
     "artifactregistry.repositories.create": "roles/artifactregistry.admin",
     "cloudbuild.builds.create": "roles/cloudbuild.builds.editor",
     "logging.logEntries.create": "roles/logging.logWriter",
+    "serviceusage.services.enable": "roles/serviceusage.serviceUsageAdmin",
 }
 
 # Deduplicated, stable-order list of recommended roles.
 # Start with roles derived from the permission map, then append roles that
 # are needed for validation probes (project access, API listing) but are not
 # tied to a specific testIamPermissions entry.
-RECOMMENDED_ROLES: list[str] = list(
-    dict.fromkeys([*_PERMISSION_ROLE_MAP.values(), "roles/serviceusage.serviceUsageViewer", "roles/viewer"])
-)
+RECOMMENDED_ROLES: list[str] = list(dict.fromkeys([*_PERMISSION_ROLE_MAP.values(), "roles/viewer"]))
 
 _SKIP_CREDS = "Skipped: credentials failed to load"
 _SKIP_PROJECT = "Skipped: project not accessible"

--- a/backend/tests/test_gcp_config_service.py
+++ b/backend/tests/test_gcp_config_service.py
@@ -72,6 +72,7 @@ ALL_REQUIRED_PERMISSIONS = [
     "artifactregistry.repositories.create",
     "cloudbuild.builds.create",
     "logging.logEntries.create",
+    "serviceusage.services.enable",
 ]
 
 

--- a/backend/tests/test_gcp_config_service.py
+++ b/backend/tests/test_gcp_config_service.py
@@ -562,7 +562,7 @@ def test_result_includes_recommended_roles(mock_sa, mock_rm, mock_storage, mock_
     assert "roles/bigquery.dataEditor" in result.recommended_roles
     assert "roles/storage.admin" in result.recommended_roles
     assert "roles/viewer" in result.recommended_roles
-    assert "roles/serviceusage.serviceUsageViewer" in result.recommended_roles
+    assert "roles/serviceusage.serviceUsageAdmin" in result.recommended_roles
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/auth/SetupWizard.tsx
+++ b/frontend/src/components/auth/SetupWizard.tsx
@@ -46,7 +46,7 @@ const SETUP_RECOMMENDED_ROLES = [
   { role: "roles/bigquery.dataEditor", description: "BigQuery Data Editor" },
   { role: "roles/artifactregistry.admin", description: "Artifact Registry Admin" },
   { role: "roles/cloudbuild.builds.editor", description: "Cloud Build Editor" },
-  { role: "roles/serviceusage.serviceUsageViewer", description: "Service Usage Viewer" },
+  { role: "roles/serviceusage.serviceUsageAdmin", description: "Service Usage Admin" },
   { role: "roles/viewer", description: "Viewer" },
 ];
 

--- a/frontend/src/components/settings/GcpSettingsContent.tsx
+++ b/frontend/src/components/settings/GcpSettingsContent.tsx
@@ -75,7 +75,7 @@ const RECOMMENDED_ROLES = [
   { role: "roles/bigquery.dataEditor", description: "BigQuery Data Editor" },
   { role: "roles/artifactregistry.admin", description: "Artifact Registry Admin" },
   { role: "roles/cloudbuild.builds.editor", description: "Cloud Build Editor" },
-  { role: "roles/serviceusage.serviceUsageViewer", description: "Service Usage Viewer" },
+  { role: "roles/serviceusage.serviceUsageAdmin", description: "Service Usage Admin" },
   { role: "roles/viewer", description: "Viewer" },
 ];
 

--- a/install-gcp.sh
+++ b/install-gcp.sh
@@ -108,7 +108,7 @@ SA_ROLES=(
     "roles/artifactregistry.admin"
     "roles/cloudbuild.builds.editor"
     "roles/logging.logWriter"
-    "roles/serviceusage.serviceUsageViewer"
+    "roles/serviceusage.serviceUsageAdmin"
     "roles/viewer"
 )
 


### PR DESCRIPTION
## Summary

- Add `serviceusage.services.enable` permission mapped to `roles/serviceusage.serviceUsageAdmin` in the GCP validation checks
- Replace `roles/serviceusage.serviceUsageViewer` with `roles/serviceusage.serviceUsageAdmin` in the install script, settings UI, and setup wizard (admin is a superset of viewer)
- The primary SA needs this to auto-enable the Sheets API when creating the reader account

## Test plan

- [x] Ruff format, ruff check, mypy: all clean
- [x] Frontend tsc: clean
- [ ] Verify Settings > Integrations > GCP validation now checks for `serviceusage.services.enable` and recommends `roles/serviceusage.serviceUsageAdmin`
- [ ] Verify setup wizard shows Service Usage Admin in recommended roles
- [ ] Verify `install-gcp.sh` grants Service Usage Admin