### PR TITLE
Publish pre-built Docker images to ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,12 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
-      - "Dockerfile*"
-      - "docker-compose*"
+      - "docker/Dockerfile*"
+      - "docker/docker-compose*"
 
 jobs:
-  build-control-plane:
-    name: Build Control Plane Image
+  build-backend:
+    name: Build Backend Image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -25,6 +25,26 @@ jobs:
           context: ./backend
           file: docker/Dockerfile.backend
           push: false
-          tags: bioaf/bioaf:pr-${{ github.event.pull_request.number }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: bioaf/bioaf-backend:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+  build-frontend:
+    name: Build Frontend Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: docker/Dockerfile.frontend
+          push: false
+          build-args: NEXT_PUBLIC_API_URL=
+          tags: bioaf/bioaf-frontend:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   release:
     name: Tag & Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.version.outputs.TAG }}
+      new_release: ${{ steps.check_tag.outputs.new_release }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -29,14 +31,14 @@ jobs:
         id: check_tag
         run: |
           if git rev-parse "v${{ steps.version.outputs.VERSION }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "new_release=false" >> "$GITHUB_OUTPUT"
             echo "Tag v${{ steps.version.outputs.VERSION }} already exists, skipping release"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "new_release=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract release notes
-        if: steps.check_tag.outputs.exists == 'false'
+        if: steps.check_tag.outputs.new_release == 'true'
         id: notes
         run: |
           TAG="${{ steps.version.outputs.TAG }}"
@@ -50,7 +52,7 @@ jobs:
           echo "Found release notes for $TAG"
 
       - name: Create tag and release
-        if: steps.check_tag.outputs.exists == 'false'
+        if: steps.check_tag.outputs.new_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -60,3 +62,61 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file /tmp/release_notes.txt
+
+  publish-images:
+    name: Publish Docker Images
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: docker/Dockerfile.backend
+          push: true
+          tags: |
+            ghcr.io/not-that-guy-again/bioaf-backend:${{ needs.release.outputs.tag }}
+            ghcr.io/not-that-guy-again/bioaf-backend:latest
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: docker/Dockerfile.frontend
+          push: true
+          build-args: NEXT_PUBLIC_API_URL=
+          tags: |
+            ghcr.io/not-that-guy-again/bioaf-frontend:${{ needs.release.outputs.tag }}
+            ghcr.io/not-that-guy-again/bioaf-frontend:latest
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+
+      - name: Build and push cellxgene
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.cellxgene
+          push: true
+          tags: |
+            ghcr.io/not-that-guy-again/bioaf-cellxgene:${{ needs.release.outputs.tag }}
+            ghcr.io/not-that-guy-again/bioaf-cellxgene:latest
+          cache-from: type=gha,scope=cellxgene
+          cache-to: type=gha,mode=max,scope=cellxgene

--- a/README.md
+++ b/README.md
@@ -76,21 +76,21 @@ cd bioAF
 ```
 
 The `setup` command handles everything: checks prerequisites, generates
-secrets and TLS certs, builds containers, runs migrations, and prints a
-one-time setup code. Open the URL it shows in your browser and enter the
+secrets and TLS certs, pulls pre-built images, runs migrations, and prints
+a one-time setup code. Open the URL it shows in your browser and enter the
 code to create your admin account and configure the platform.
 
 ### Management Commands
 
 | Command | Description |
 | ------- | ----------- |
-| `./bioaf setup` | First-run setup (installs, builds, prints setup code) |
+| `./bioaf setup` | First-run setup (pulls images, generates secrets, prints setup code) |
 | `./bioaf start` | Start all services in dependency order |
 | `./bioaf stop` | Stop all services |
 | `./bioaf restart` | Restart all services |
 | `./bioaf status` | Show service status |
 | `./bioaf logs [service]` | Tail logs (all or one service) |
-| `./bioaf build [service]` | Build (or rebuild) container images |
+| `./bioaf build [service]` | Build container images locally (development only) |
 | `./bioaf migrate` | Run database migrations |
 | `./bioaf migrate-down <rev>` | Downgrade database to a specific revision |
 | `./bioaf seed <script.py>` | Run a seed/data script in the backend container |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v0.8.1
+
+Pre-built Docker images published to GitHub Container Registry on each release. This is the first version to ship remote artifacts -- setup and updates now pull pre-built images instead of building on the VM, reducing install and update time from 15+ minutes to seconds. Users who encounter issues can install from source using v0.8.0 and below as they have to this point.
+
+### New features
+
+- Publish backend, frontend, and cellxgene Docker images to ghcr.io on each release, with GHA build cache for fast CI builds
+- Setup and update commands pull pre-built images from ghcr.io instead of building locally on the VM
+- Frontend image build validation added to PR CI pipeline
+
+### Platform updates
+
+- Add OCI source labels to Dockerfiles for automatic ghcr.io repository linking
+- Add `image:` directives to docker-compose.yml alongside `build:` directives, supporting both pull (production) and build (development) flows
+- Move Cloud Logging agent setup from start to setup/update only, eliminating a 5+ minute apt-get delay on every restart
+
 ## v0.8.0
 
 Google Sheets integration for experiment field setup and sample import.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.8.0"
+version = "0.8.1"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/bioaf
+++ b/bioaf
@@ -294,9 +294,6 @@ cmd_start() {
     bold "=== Starting Services ==="
     set_image_tag
 
-    # Cloud Logging (GCE only, idempotent)
-    ensure_cloud_logging
-
     for svc in db backend frontend nginx; do
         echo "Starting $svc..."
         $DC up -d "$svc"

--- a/bioaf
+++ b/bioaf
@@ -17,6 +17,7 @@ DC="docker compose -f $COMPOSE_FILE --env-file $ENV_FILE"
 # Use the fancy TTY display when stdout is a real terminal, plain text otherwise.
 [ -t 1 ] && _progress="auto" || _progress="plain"
 DC_BUILD="docker compose --progress=$_progress -f $COMPOSE_FILE --env-file $ENV_FILE build"
+DC_PULL="docker compose -f $COMPOSE_FILE --env-file $ENV_FILE pull"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -221,9 +222,10 @@ for v in cfg.get('volumes', {}).values():
     # Update agent (idempotent)
     ensure_update_agent
 
-    # Build and start
-    bold "Building and starting containers..."
-    $DC_BUILD
+    # Pull pre-built images and start
+    bold "Pulling pre-built images..."
+    set_image_tag
+    $DC_PULL backend frontend
     $DC up -d
 
     # Wait for DB
@@ -290,6 +292,7 @@ print(json.dumps(result))
 
 cmd_start() {
     bold "=== Starting Services ==="
+    set_image_tag
 
     # Cloud Logging (GCE only, idempotent)
     ensure_cloud_logging
@@ -412,6 +415,11 @@ print(data['project']['version'])
 " 2>/dev/null || echo "unknown"
 }
 
+set_image_tag() {
+    # Export the image tag so docker-compose.yml resolves ghcr.io image references.
+    export BIOAF_IMAGE_TAG="v$(get_current_version)"
+}
+
 get_latest_github_version() {
     # Query GitHub Releases API for the latest release tag
     local response
@@ -522,14 +530,15 @@ STATUSEOF
     # Cloud Logging (GCE only, idempotent)
     ensure_cloud_logging
 
-    # Rebuild containers
+    # Pull pre-built images
     cat > "$status_dir/current.json" <<STATUSEOF
-{"status": "in_progress", "from_version": "$current_version", "to_version": "$target_version", "step": "build", "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+{"status": "in_progress", "from_version": "$current_version", "to_version": "$target_version", "step": "pull", "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
 STATUSEOF
 
     echo ""
-    bold "Rebuilding containers..."
-    $DC_BUILD
+    export BIOAF_IMAGE_TAG="v${target_version}"
+    bold "Pulling pre-built images..."
+    $DC_PULL backend frontend
 
     # Warning window before restart: give the UI time to show a countdown
     # so users know the app is about to go offline briefly. Skipped when
@@ -573,6 +582,7 @@ STATUSEOF
 }
 
 cmd_build() {
+    set_image_tag
     local service="${1:-}"
     if [ -n "$service" ]; then
         bold "=== Building $service ==="
@@ -690,7 +700,7 @@ cmd_help() {
     echo "  restart             Restart all services"
     echo "  status              Show status of all services"
     echo "  logs [service] [-n N]  Tail logs (default 100 lines, use -n to change)"
-    echo "  build [service]     Build (or rebuild) container images"
+    echo "  build [service]     Build container images locally (development only)"
     echo ""
     bold "Database:"
     echo "  migrate             Run alembic database migrations"

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+LABEL org.opencontainers.image.source=https://github.com/not-that-guy-again/bioAF
+
 # Install system dependencies (Terraform + weasyprint rendering libs)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl unzip postgresql-client \

--- a/docker/Dockerfile.cellxgene
+++ b/docker/Dockerfile.cellxgene
@@ -9,6 +9,8 @@
 
 FROM python:3.11-slim
 
+LABEL org.opencontainers.image.source=https://github.com/not-that-guy-again/bioAF
+
 RUN pip install --no-cache-dir cellxgene gcsfs
 
 EXPOSE 5005

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -10,6 +10,8 @@ RUN npm run build
 
 # Production stage
 FROM node:20-alpine AS runner
+
+LABEL org.opencontainers.image.source=https://github.com/not-that-guy-again/bioAF
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     restart: unless-stopped
 
   backend:
+    image: ghcr.io/not-that-guy-again/bioaf-backend:${BIOAF_IMAGE_TAG:-latest}
     build:
       context: ../backend
       dockerfile: ../docker/Dockerfile.backend
@@ -45,6 +46,7 @@ services:
     restart: unless-stopped
 
   frontend:
+    image: ghcr.io/not-that-guy-again/bioaf-frontend:${BIOAF_IMAGE_TAG:-latest}
     build:
       context: ../frontend
       dockerfile: ../docker/Dockerfile.frontend

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -56,7 +56,7 @@ cd bioAF
 2. Generates `docker/.env` with secure random credentials
 3. Generates self-signed TLS certificates
 4. Removes any stale database volumes from a previous install
-5. Builds all container images
+5. Pulls pre-built images from GitHub Container Registry
 6. Starts services in dependency order (db, backend, frontend, nginx)
 7. Runs database migrations
 8. Prints a one-time setup code and the access URL
@@ -139,7 +139,7 @@ From the CLI:
 ```
 
 This backs up the database, fetches the target version tag from GitHub,
-rebuilds container images, restarts services, and runs any new migrations.
+pulls pre-built images, restarts services, and runs any new migrations.
 
 From the UI, admins can click the **Install Update** button on the
 **Settings > Information** page when a new version is available. This

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Publish backend, frontend, and cellxgene Docker images to GitHub Container Registry on each release, eliminating the need to build on the user's VM
- Setup and update commands now pull pre-built images instead of building locally, reducing install/update time from 15+ minutes to seconds
- Move Cloud Logging agent setup out of the start command, removing a 5+ minute apt-get delay on every restart

This is the first version to ship a remote artifact. Users who encounter issues can install from source using v0.8.0 and below as they have to this point.

**One-time manual step after first merge:** set each package's visibility to public on the repo's Packages page in GitHub so anonymous pulls work.

## Test plan

- [ ] Verify build.yml CI passes (both backend and frontend image builds)
- [ ] On a test GCP VM, clone the branch and run `./bioaf build` to confirm images get tagged with ghcr.io names
- [ ] Run `./bioaf restart` and confirm no apt-get output (Cloud Logging setup removed from start)
- [ ] After merge: verify release workflow publishes images to ghcr.io
- [ ] After merge: set package visibility to public, then verify anonymous `docker pull` works
- [ ] After merge: on a fresh VM, run `./bioaf setup` and confirm it pulls pre-built images