### PR TITLE
Fix update step ordering to minimize downtime

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.8.2
+
+Update flow improvements for faster updates with less downtime.
+
+### Bug fixes
+
+- Pull pre-built images before restarting containers so the app stays online during the download, reducing downtime to just the restart + migrate window
+- Move Cloud Logging agent setup to after restart so it does not block the update while the app is down
+- Show restart countdown message in the CLI so users know why the update pauses before restarting
+
 ## v0.8.1
 
 Pre-built Docker images published to GitHub Container Registry on each release. This is the first version to ship remote artifacts -- setup and updates now pull pre-built images instead of building on the VM, reducing install and update time from 15+ minutes to seconds. Users who encounter issues can install from source using v0.8.0 and below as they have to this point.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.8.1"
+version = "0.8.2"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/bioaf
+++ b/bioaf
@@ -524,10 +524,8 @@ STATUSEOF
     fi
     git -C "$SCRIPT_DIR" checkout "v${target_version}"
 
-    # Cloud Logging (GCE only, idempotent)
-    ensure_cloud_logging
-
-    # Pull pre-built images
+    # Pull pre-built images while old containers are still running,
+    # so the only downtime is the restart + migrate window.
     cat > "$status_dir/current.json" <<STATUSEOF
 {"status": "in_progress", "from_version": "$current_version", "to_version": "$target_version", "step": "pull", "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
 STATUSEOF
@@ -548,13 +546,17 @@ STATUSEOF
         sleep "$warn_seconds"
     fi
 
-    # Restart services
+    # Restart services with new images
     cat > "$status_dir/current.json" <<STATUSEOF
 {"status": "in_progress", "from_version": "$current_version", "to_version": "$target_version", "step": "restart", "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
 STATUSEOF
 
     $DC up -d
     wait_for_db
+
+    # Cloud Logging (GCE only, idempotent) -- run after restart so it
+    # does not block the update while containers are down.
+    ensure_cloud_logging
 
     # Run migrations
     cat > "$status_dir/current.json" <<STATUSEOF

--- a/bioaf
+++ b/bioaf
@@ -543,6 +543,8 @@ STATUSEOF
         cat > "$status_dir/current.json" <<STATUSEOF
 {"status": "in_progress", "from_version": "$current_version", "to_version": "$target_version", "step": "warn", "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
 STATUSEOF
+        echo ""
+        yellow "Restarting in ${warn_seconds}s (notifying active users)..."
         sleep "$warn_seconds"
     fi
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Pull pre-built images before restarting containers so the app stays online during the download, reducing downtime to just the restart + migrate window
- Move Cloud Logging agent setup to after restart so it does not block the update while the app is down
- Show restart countdown message in the CLI so users know why the update pauses before restarting

## Test plan

- [ ] On a GCP VM, run `./bioaf update` and confirm images pull while old containers are still serving traffic
- [ ] Verify the CLI shows `Restarting in 60s (notifying active users)...` during the countdown
- [ ] Verify Cloud Logging continues to work after the update completes
- [ ] Verify `./bioaf restart` still works without the Cloud Logging delay