### PR TITLE
Auto-add user to docker group on fresh GCE VM setup

### DIFF
--- a/bioaf
+++ b/bioaf
@@ -194,17 +194,24 @@ cmd_setup() {
             ;;
     esac
 
-    # If Docker is installed but the socket is inaccessible, the user was likely
-    # added to the docker group by the VM startup script but hasn't re-logged in.
-    # Re-exec this script under `sg docker` to activate the group inline.
+    # If Docker is installed but the socket is inaccessible, try to auto-recover.
+    # Two cases:
+    #   1. User is in the docker group but the current shell session predates
+    #      that change -- re-exec under `sg docker` to activate it inline.
+    #   2. User is not in the docker group at all (e.g. fresh GCE VM where the
+    #      startup script could not add them because /home was empty at boot) --
+    #      add them via sudo, then re-exec under `sg docker`.
     if command -v docker &>/dev/null && ! docker info &>/dev/null; then
+        local reexec_cmd="'$0' setup"
+        [ -n "$setup_version" ] && reexec_cmd="'$0' setup --version $setup_version"
+
         if id -nG 2>/dev/null | grep -qw docker || grep -q "docker.*$(whoami)\|$(whoami).*docker" /etc/group 2>/dev/null; then
             yellow "Activating docker group for this session..."
-            if [ -n "$setup_version" ]; then
-                exec sg docker -c "'$0' setup --version $setup_version"
-            else
-                exec sg docker -c "'$0' setup"
-            fi
+            exec sg docker -c "$reexec_cmd"
+        elif getent group docker &>/dev/null && sudo -n true 2>/dev/null; then
+            yellow "Adding $(whoami) to the docker group..."
+            sudo usermod -aG docker "$(whoami)"
+            exec sg docker -c "$reexec_cmd"
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Fresh `./bioaf setup` on a new GCE VM fails the prereq check with "Docker
  is installed but your user cannot connect to it," forcing the user to run
  `sudo usermod -aG docker $USER && newgrp docker` manually before retrying.
- Root cause: install-gcp.sh:427 runs `usermod -aG docker $(ls /home/ | head -1)`
  in the VM startup script, but on Ubuntu 22.04 GCE images `/home/` is empty
  at boot. User accounts are provisioned by google-guest-agent when an SSH
  key first appears in instance metadata (at `gcloud compute ssh` time),
  which is after the startup script runs. The usermod silently executes
  against an empty string and has no effect.
- Fix: extend the existing `sg docker` re-exec in cmd_setup to also handle
  the "not in docker group yet" case. When the docker group exists and
  passwordless sudo is available (true on GCE by default), add the user and
  re-exec under `sg docker`. Also rescues bare-metal installs where the
  user hasn't added themselves yet.

## Test plan

- [x] Provision a fresh GCE VM via install-gcp.sh, clone, run `./bioaf setup`
      — should proceed without the "cannot connect" error.
- [x] Run `./bioaf setup` where user is already in docker group but session
      predates it — existing `sg docker` re-exec path still fires.
- [x] Run `./bioaf setup` where docker already works — auto-recovery block
      is skipped.
- [x] Run `./bioaf setup` without passwordless sudo and no docker group —
      falls through to install.sh error with manual instructions.
- [x] Verify `./bioaf setup --version X.Y.Z` preserves the version flag
      through the re-exec.
