### PR TITLE
v0.9.0: Work Nodes GCE overhaul

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,37 @@
 # Release Notes
 
+## v0.9.0
+
+Work Nodes overhaul: GCE VMs with conda environments, GitHub repo cloning, and a redesigned file picker.
+
+### New features
+
+- **Work Nodes on GCE VMs** -- work nodes now launch as full Linux VMs on Google Compute Engine instead of GKE Pods, with SSH access via session credentials (ADR-043)
+- **Packer-built VM images** -- work node environments build as GCE VM images via Cloud Build + Packer with conda environments pre-installed for fast startup
+- **Independent environment types** -- environments are now tagged as "Notebook" or "Work Node" with separate image pipelines; work node environments are conda-only
+- **GitHub repo cloning** -- users manage a list of GitHub repos on the Work Nodes page; selected repos are automatically cloned into `~/repos/` when a work node boots
+- **MOTD** -- work nodes display a message of the day on SSH login showing paths to input data, repos, outputs, and scratch space
+- **File picker for work nodes** -- the launch wizard now uses the same FileTreeSelector as notebooks, with project -> experiment -> file selection and sample grouping
+- **Default Work Node environment** -- a base conda environment (Python 3.11, numpy, pandas, scipy, matplotlib, etc.) is automatically seeded on first boot
+- **Files page search and filters** -- added filename search, project filter, experiment filter, and source type filter to the Data & Files page
+- **Work node output tracking** -- outputs from work nodes are registered as `work_node_output` source type, distinct from notebook outputs
+
+### Improvements
+
+- **Zone retry on capacity exhaustion** -- VM creation tries zones b, c, f, a in order if GCE returns ZONE_RESOURCE_POOL_EXHAUSTED
+- **E2 machine types** -- added e2-standard-4, e2-standard-8, and e2-highmem-8 with better availability than N2 in constrained regions
+- **Resource failure UX** -- failed launches due to GCP capacity show "Resource Failure" status with a "GCP Resources Unavailable" detail banner instead of generic "failed"
+- **Stop persistence** -- stopping a work node immediately commits a "stopping" status so navigating away no longer shows stale "running" state
+- **Project file filter** -- the project filter on the Files page now includes files associated via experiment, not just direct project_id
+
+### Bug fixes
+
+- Fix Packer template syntax (double braces, missing packer init, universe repo, miniconda TOS)
+- Fix SSH access (password auth via sshd drop-in config, username in SSH command)
+- Fix output sync (SSH into VM before stopping instead of unreliable shutdown hooks)
+- Fix environment rebuild for work node type (was hardcoded to Dockerfile format)
+- Add google-cloud-compute dependency for GCE adapter
+
 ## v0.8.3
 
 Fixes fresh install failure and improves the GCP installer experience.

--- a/backend/alembic/versions/067_work_node_gce_overhaul.py
+++ b/backend/alembic/versions/067_work_node_gce_overhaul.py
@@ -1,0 +1,55 @@
+"""Work node GCE overhaul (ADR-043).
+
+Revision ID: 067
+Revises: 066
+Create Date: 2026-04-19
+
+Adds environment_type to environments, GCE columns to compute_sessions,
+and creates the github_repos table.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "067"
+down_revision = "066"
+
+
+def upgrade() -> None:
+    # 1. Add environment_type to environments
+    op.add_column(
+        "environments",
+        sa.Column("environment_type", sa.String(50), nullable=False, server_default="notebook"),
+    )
+
+    # 2. Add GCE columns to compute_sessions
+    op.add_column("compute_sessions", sa.Column("gce_instance_name", sa.String(255), nullable=True))
+    op.add_column("compute_sessions", sa.Column("gce_zone", sa.String(100), nullable=True))
+    op.add_column("compute_sessions", sa.Column("gce_project_id", sa.String(255), nullable=True))
+    op.add_column("compute_sessions", sa.Column("github_repo_ids", sa.JSON(), nullable=True))
+
+    # 3. Create github_repos table
+    op.create_table(
+        "github_repos",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("git_ssh_url", sa.String(500), nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "git_ssh_url", name="uq_github_repo_user_url"),
+    )
+    op.create_index("ix_github_repos_user_id", "github_repos", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_github_repos_user_id", table_name="github_repos")
+    op.drop_table("github_repos")
+    op.drop_column("compute_sessions", "github_repo_ids")
+    op.drop_column("compute_sessions", "gce_project_id")
+    op.drop_column("compute_sessions", "gce_zone")
+    op.drop_column("compute_sessions", "gce_instance_name")
+    op.drop_column("environments", "environment_type")

--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -116,6 +116,26 @@ class NotebookProvider(ABC):
         """Get SSH/exec command for direct access to the session."""
 
 
+class WorkNodeProvider(ABC):
+    """Abstract interface for work node VM backends (GCE)."""
+
+    @abstractmethod
+    async def launch_vm(self, vm_spec: dict) -> dict:
+        """Create and start a GCE VM. Returns dict with instance_name, zone, status, external_ip."""
+
+    @abstractmethod
+    async def terminate_vm(self, instance_name: str, zone: str, **kwargs) -> dict:
+        """Sync outputs, then stop and delete a VM. Returns output_files and gcs_output_prefix."""
+
+    @abstractmethod
+    async def get_vm_status(self, instance_name: str, zone: str) -> dict:
+        """Get VM status and external IP."""
+
+    @abstractmethod
+    async def list_vms(self, filters: dict | None = None) -> list[dict]:
+        """List active work node VMs."""
+
+
 class CellxgeneProvider(ABC):
     """Abstract interface for cellxgene visualization backends."""
 

--- a/backend/app/adapters/registry.py
+++ b/backend/app/adapters/registry.py
@@ -9,7 +9,7 @@ import logging
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.adapters.base import CellxgeneProvider, ComputeProvider, NotebookProvider, StorageProvider
+from app.adapters.base import CellxgeneProvider, ComputeProvider, NotebookProvider, StorageProvider, WorkNodeProvider
 
 logger = logging.getLogger("bioaf.adapters.registry")
 
@@ -20,6 +20,7 @@ _compute_adapter: ComputeProvider | None = None
 _storage_adapter: StorageProvider | None = None
 _notebook_adapter: NotebookProvider | None = None
 _cellxgene_adapter: CellxgeneProvider | None = None
+_work_node_adapter: WorkNodeProvider | None = None
 _initialized: bool = False
 
 
@@ -59,7 +60,7 @@ def _create_adapters(
 
 async def initialize_adapters(session: AsyncSession, session_factory=None) -> None:
     """Read compute_stack from platform_config and initialize adapters."""
-    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _initialized
+    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _work_node_adapter, _initialized
 
     result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'compute_stack'"))
     row = result.first()
@@ -70,6 +71,11 @@ async def initialize_adapters(session: AsyncSession, session_factory=None) -> No
         compute_stack, session_factory=session_factory
     )
 
+    # Work nodes always use GCE regardless of compute_stack (ADR-043)
+    from app.adapters.work_nodes.gce import GCEWorkNodeProvider
+
+    _work_node_adapter = GCEWorkNodeProvider(session_factory=session_factory)
+
     # Eagerly load cluster config so adapters never need to run async DB
     # queries from a sync context (which breaks asyncpg).
     if hasattr(_compute_adapter, "load_cluster_config"):
@@ -78,15 +84,20 @@ async def initialize_adapters(session: AsyncSession, session_factory=None) -> No
         await _notebook_adapter.load_cluster_config()
     if hasattr(_cellxgene_adapter, "load_cluster_config"):
         await _cellxgene_adapter.load_cluster_config()
+    await _work_node_adapter.load_gcp_config()
 
     _initialized = True
 
 
 def initialize_adapters_sync(compute_stack: str) -> None:
     """Initialize adapters synchronously from a known value (for testing)."""
-    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _initialized
+    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _work_node_adapter, _initialized
 
     _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter = _create_adapters(compute_stack)
+
+    from app.adapters.work_nodes.gce import GCEWorkNodeProvider
+
+    _work_node_adapter = GCEWorkNodeProvider()
     _initialized = True
 
 
@@ -118,11 +129,19 @@ def get_cellxgene_adapter() -> CellxgeneProvider:
     return _cellxgene_adapter
 
 
+def get_work_node_adapter() -> WorkNodeProvider:
+    """Get the active work node adapter (GCE VMs)."""
+    if not _initialized or _work_node_adapter is None:
+        raise RuntimeError("Adapter registry not initialized. Call initialize_adapters() first.")
+    return _work_node_adapter
+
+
 def reset_registry() -> None:
     """Reset the registry (for testing)."""
-    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _initialized
+    global _compute_adapter, _storage_adapter, _notebook_adapter, _cellxgene_adapter, _work_node_adapter, _initialized
     _compute_adapter = None
     _storage_adapter = None
     _notebook_adapter = None
     _cellxgene_adapter = None
+    _work_node_adapter = None
     _initialized = False

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -33,8 +33,7 @@ def _build_startup_script(vm_spec: dict) -> str:
     ssh_public_key = vm_spec.get("ssh_public_key", "")
     heartbeat_token = vm_spec.get("heartbeat_token", "")
     github_repos = vm_spec.get("github_repos", [])
-    data_mount_paths = vm_spec.get("data_mount_paths", [])
-    working_bucket = vm_spec.get("working_bucket", "")
+    input_files = vm_spec.get("input_files", [])
     session_id = vm_spec.get("session_id", 0)
     env_name = vm_spec.get("conda_env_name", "base")
     env_label = vm_spec.get("environment_label", "")
@@ -89,20 +88,23 @@ def _build_startup_script(vm_spec: dict) -> str:
             )
         lines.append(f"chown -R {username}:{username} {home_dir}/repos")
 
-    # 4. Mount GCS data (read-only via gcsfuse)
-    if data_mount_paths and working_bucket:
+    # 4. Copy input files from GCS
+    if input_files:
         lines += [
             "",
-            "# 4. Mount GCS data (read-only)",
+            "# 4. Copy input files from GCS",
+            "mkdir -p /data",
         ]
-        for mount_path in data_mount_paths:
-            clean_path = mount_path.strip("/")
-            lines += [
-                f"mkdir -p /data/{clean_path}",
-                f"gcsfuse --implicit-dirs --read-only --only-dir '{clean_path}' "
-                f"'{working_bucket}' /data/{clean_path} || "
-                f"echo 'Warning: failed to mount /data/{clean_path}'",
-            ]
+        for input_file in input_files:
+            rel_path = input_file["relative_path"]
+            gcs_uri = input_file["gcs_uri"]
+            dest_path = f"/data/{rel_path}"
+            dest_dir = "/".join(dest_path.split("/")[:-1])
+            lines.append(
+                f"mkdir -p '{dest_dir}' && "
+                f"gsutil cp '{gcs_uri}' '{dest_path}' || "
+                f"echo 'Warning: failed to copy {rel_path}'"
+            )
 
     # 5. Create output and scratch directories
     lines += [
@@ -121,8 +123,8 @@ def _build_startup_script(vm_spec: dict) -> str:
         ]
 
     # 7. Generate MOTD
-    repo_names = ", ".join(r["display_name"] for r in github_repos) if github_repos else "(none selected)"
-    mount_list = ", ".join(f"/data/{p.strip('/')}" for p in data_mount_paths) if data_mount_paths else "(none selected)"
+    repo_names = ", ".join(r["display_name"] for r in github_repos) if github_repos else "(none)"
+    file_count = len(input_files)
     lines += [
         "",
         "# 7. Generate MOTD",
@@ -130,14 +132,14 @@ def _build_startup_script(vm_spec: dict) -> str:
         "",
         "=== bioAF Work Node ===",
         "",
-        "  Input data:     /data/                    (read-only GCS mounts)",
+        "  Input data:     /data/                    (copied from GCS at boot)",
         f"  Your repos:     {home_dir}/repos/          (cloned from GitHub)",
         "  Output files:   /outputs/                  (synced to GCS on stop)",
         "  Scratch space:  /scratch/                  (LOST on stop)",
         "",
         f"  Environment:    {env_label}",
         f"  Repos:          {repo_names}",
-        f"  Data mounts:    {mount_list}",
+        f"  Input files:    {file_count} file(s)",
         "",
         "MOTD_EOF",
     ]

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -355,7 +355,9 @@ class GCEWorkNodeProvider(WorkNodeProvider):
         logger.info("Creating GCE instance %s in %s/%s", instance_name, project, zone)
 
         # Launch background poller
-        asyncio.create_task(self._poll_vm_ready(session_id, instance_name, project, zone))
+        creds = vm_spec.get("session_credentials", {})
+        ssh_username = creds.get("username", "")
+        asyncio.create_task(self._poll_vm_ready(session_id, instance_name, project, zone, ssh_username))
 
         return {
             "instance_name": instance_name,
@@ -371,6 +373,7 @@ class GCEWorkNodeProvider(WorkNodeProvider):
         instance_name: str,
         project: str,
         zone: str,
+        ssh_username: str = "",
     ) -> None:
         """Background: poll for VM running status + external IP, then update DB."""
         try:
@@ -406,7 +409,8 @@ class GCEWorkNodeProvider(WorkNodeProvider):
                 await self._update_session_in_db(session_id, status="failed", access_url=None)
                 return
 
-            access_url = f"ssh://{external_ip}:22"
+            user_prefix = f"{ssh_username}@" if ssh_username else ""
+            access_url = f"ssh://{user_prefix}{external_ip}:22"
             logger.info("VM %s ready at %s", instance_name, external_ip)
             await self._update_session_in_db(session_id, status="running", access_url=access_url)
 

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -115,7 +115,23 @@ def _build_startup_script(vm_spec: dict) -> str:
         f"chown {username}:{username} /outputs /scratch",
     ]
 
-    # 6. Install shutdown sync service (syncs /outputs/ to GCS on stop)
+    # 6. Create bioaf-sync user for backend SSH access (output sync at stop)
+    sync_public_key = vm_spec.get("sync_public_key", "")
+    if sync_public_key:
+        lines += [
+            "",
+            "# 6. Create bioaf-sync user for output sync",
+            "useradd -r -m -s /bin/bash bioaf-sync || true",
+            "mkdir -p /home/bioaf-sync/.ssh",
+            f"echo '{sync_public_key}' > /home/bioaf-sync/.ssh/authorized_keys",
+            "chmod 700 /home/bioaf-sync/.ssh",
+            "chmod 600 /home/bioaf-sync/.ssh/authorized_keys",
+            "chown -R bioaf-sync:bioaf-sync /home/bioaf-sync/.ssh",
+            "# Allow bioaf-sync to read /outputs/ and run gsutil",
+            "usermod -aG root bioaf-sync 2>/dev/null || true",
+        ]
+
+    # 7. Install shutdown sync service (fallback for unclean stops)
     if working_bucket and session_id:
         gcs_output_prefix = f"gs://{working_bucket}/sessions/{session_id}/outputs/"
         gcs_scripts_prefix = f"gs://{working_bucket}/sessions/{session_id}/scripts/"
@@ -216,6 +232,9 @@ class GCEWorkNodeProvider(WorkNodeProvider):
         self._mode = os.environ.get("BIOAF_COMPUTE_MODE", "local")
         self._session_factory = session_factory
         self._gcp_config: dict | None = None
+        # In-memory store for sync SSH private keys, keyed by session_id.
+        # Generated at launch, used at terminate to SSH in for output sync.
+        self._sync_keys: dict[int, str] = {}
 
     @property
     def is_local(self) -> bool:
@@ -316,6 +335,16 @@ class GCEWorkNodeProvider(WorkNodeProvider):
 
         # Resolve GCE machine type for GPU types
         gce_machine_type = vm_spec.get("gce_machine_type", machine_type)
+
+        # Generate an SSH key pair for the bioaf-sync user so the backend
+        # can SSH into the VM at terminate time to sync outputs.
+        import asyncssh
+
+        sync_key = asyncssh.generate_private_key("ssh-ed25519")
+        sync_private_pem = sync_key.export_private_key().decode()
+        sync_public_key = sync_key.export_public_key().decode().strip()
+        self._sync_keys[session_id] = sync_private_pem
+        vm_spec["sync_public_key"] = sync_public_key
 
         # Build startup script
         startup_script = _build_startup_script(vm_spec)
@@ -513,18 +542,72 @@ class GCEWorkNodeProvider(WorkNodeProvider):
         output_files: list[dict] = []
         gcs_output_prefix = ""
 
-        # Stop the VM gracefully -- the systemd bioaf-shutdown-sync service
-        # (installed by the startup script) handles syncing /outputs/ to GCS.
+        # Sync outputs from the running VM before stopping it.
+        # SSH into the VM as the bioaf-sync user (key-based) and run gsutil,
+        # mirroring the K8s approach of exec'ing into the pod before deletion.
         if working_bucket and session_id:
             gcs_output_prefix = f"gs://{working_bucket}/sessions/{session_id}/outputs/"
+            gcs_scripts_prefix = f"gs://{working_bucket}/sessions/{session_id}/scripts/"
 
+            # Get the VM's external IP
+            external_ip = None
+            try:
+                credentials = self._get_gcp_credentials()
+                instances_client = compute_v1.InstancesClient(credentials=credentials)
+                instance = instances_client.get(project=project, zone=zone, instance=instance_name)
+                for iface in instance.network_interfaces:
+                    for ac in iface.access_configs:
+                        if ac.nat_i_p:
+                            external_ip = ac.nat_i_p
+                            break
+            except Exception as e:
+                logger.warning("Could not get external IP for VM %s: %s", instance_name, e)
+
+            if external_ip:
+                sync_cmd = (
+                    f'if [ -d /outputs ] && [ "$(ls -A /outputs)" ]; then '
+                    f"gsutil -m rsync -r /outputs {gcs_output_prefix}; fi; "
+                    f"find /home -maxdepth 4 "
+                    r"\( -name '*.ipynb' -o -name '*.Rmd' -o -name '*.R' -o -name '*.py' \) "
+                    f"-type f "
+                    f'| while read f; do gsutil cp "$f" '
+                    f'{gcs_scripts_prefix}"$(basename "$f")"; done'
+                )
+                try:
+                    import asyncssh
+
+                    # Read the sync private key that was embedded at launch
+                    sync_key = self._sync_keys.get(session_id)
+                    if sync_key:
+                        key = asyncssh.import_private_key(sync_key)
+                        async with asyncssh.connect(
+                            external_ip,
+                            port=22,
+                            username="bioaf-sync",
+                            client_keys=[key],
+                            known_hosts=None,
+                        ) as conn:
+                            result = await asyncio.wait_for(conn.run(sync_cmd), timeout=300)
+                            if result.exit_status == 0:
+                                logger.info("Output sync complete for VM %s", instance_name)
+                            else:
+                                logger.warning(
+                                    "Output sync returned %d for VM %s: %s",
+                                    result.exit_status,
+                                    instance_name,
+                                    result.stderr,
+                                )
+                    else:
+                        logger.warning("No sync key for session %d, skipping output sync", session_id)
+                except Exception as e:
+                    logger.warning("SSH output sync failed for VM %s: %s", instance_name, e)
+
+        # Stop and delete the VM
         try:
             credentials = self._get_gcp_credentials()
             instances_client = compute_v1.InstancesClient(credentials=credentials)
-
             instances_client.stop(project=project, zone=zone, instance=instance_name)
 
-            # Wait for the instance to stop (up to 5 minutes)
             for _ in range(60):
                 try:
                     instance = instances_client.get(project=project, zone=zone, instance=instance_name)
@@ -534,7 +617,7 @@ class GCEWorkNodeProvider(WorkNodeProvider):
                     break
                 await asyncio.sleep(5)
 
-            logger.info("VM %s stopped, outputs synced via shutdown service", instance_name)
+            logger.info("VM %s stopped", instance_name)
         except Exception as e:
             logger.warning("Failed to stop VM %s: %s", instance_name, e)
 
@@ -546,6 +629,9 @@ class GCEWorkNodeProvider(WorkNodeProvider):
             logger.info("Deleted VM %s", instance_name)
         except Exception as e:
             logger.warning("Failed to delete VM %s: %s", instance_name, e)
+
+        # Clean up sync key
+        self._sync_keys.pop(session_id, None)
 
         # List output files from GCS
         if gcs_output_prefix:

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -403,6 +403,12 @@ class GCEWorkNodeProvider(WorkNodeProvider):
                     logger.warning("Zone %s exhausted for %s, trying next zone", try_zone, machine_type)
                     continue
                 raise
+        else:
+            # All zones exhausted -- for loop completed without break
+            raise ValueError(
+                f"GCP resources unavailable: no {machine_type} capacity in any {region} zone. "
+                "Try again later or choose a different machine type."
+            )
 
         # Launch background poller
         creds = vm_spec.get("session_credentials", {})

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -1,0 +1,669 @@
+"""GCE work node adapter (ADR-043).
+
+Manages GCE VM instances for SSH-accessible work nodes.
+Supports local/mock mode for development and real GCE API for production.
+"""
+
+import asyncio
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+
+from app.adapters.base import WorkNodeProvider
+
+logger = logging.getLogger("bioaf.adapters.work_nodes.gce")
+
+# In-memory session store for local mode
+_local_vms: dict[str, dict] = {}
+
+
+def _build_startup_script(vm_spec: dict) -> str:
+    """Build the VM startup script from a work node spec.
+
+    The Packer-built image already has conda, sshd, gcsfuse, and system
+    packages installed. This script handles user-specific configuration.
+    """
+    creds = vm_spec.get("session_credentials", {})
+    username = creds.get("username", "bioaf")
+    password_hash = creds.get("password_hash", "")
+    home_dir = f"/home/{username}"
+
+    ssh_private_key = vm_spec.get("ssh_private_key", "")
+    ssh_public_key = vm_spec.get("ssh_public_key", "")
+    heartbeat_token = vm_spec.get("heartbeat_token", "")
+    github_repos = vm_spec.get("github_repos", [])
+    data_mount_paths = vm_spec.get("data_mount_paths", [])
+    working_bucket = vm_spec.get("working_bucket", "")
+    session_id = vm_spec.get("session_id", 0)
+    env_name = vm_spec.get("conda_env_name", "base")
+    env_label = vm_spec.get("environment_label", "")
+
+    lines = [
+        "#!/bin/bash",
+        "set -e",
+        "",
+        "# 1. Create PAM user with session credentials",
+        f"useradd -m -d {home_dir} -s /bin/bash {username} || true",
+    ]
+
+    if password_hash.startswith("$2"):
+        lines.append(f"echo '{username}:{password_hash}' | chpasswd -e")
+    else:
+        lines.append(f"echo '{username}:{password_hash}' | chpasswd")
+
+    # 2. SSH keys for GitHub
+    if ssh_private_key:
+        escaped_key = ssh_private_key.replace("'", "'\\''")
+        lines += [
+            "",
+            "# 2. SSH keys for GitHub",
+            f"mkdir -p {home_dir}/.ssh",
+            f"printf '%s\\n' '{escaped_key}' > {home_dir}/.ssh/id_rsa",
+            f"chmod 600 {home_dir}/.ssh/id_rsa",
+            f"ssh-keyscan github.com >> {home_dir}/.ssh/known_hosts 2>/dev/null",
+        ]
+        if ssh_public_key:
+            escaped_pub = ssh_public_key.replace("'", "'\\''")
+            lines.append(f"printf '%s\\n' '{escaped_pub}' > {home_dir}/.ssh/id_rsa.pub")
+        lines.append(f"chown -R {username}:{username} {home_dir}/.ssh")
+
+    # 3. Clone GitHub repos
+    if github_repos:
+        lines += [
+            "",
+            "# 3. Clone GitHub repos",
+            f"mkdir -p {home_dir}/repos",
+        ]
+        for repo in github_repos:
+            url = repo["git_ssh_url"]
+            name = repo["display_name"]
+            safe_name = name.replace("'", "'\\''")
+            safe_url = url.replace("'", "'\\''")
+            lines.append(
+                f'su - {username} -c "cd {home_dir}/repos && '
+                f"GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' "
+                f"git clone '{safe_url}' '{safe_name}'\" || "
+                f"echo 'Warning: failed to clone {safe_name}'"
+            )
+        lines.append(f"chown -R {username}:{username} {home_dir}/repos")
+
+    # 4. Mount GCS data (read-only via gcsfuse)
+    if data_mount_paths and working_bucket:
+        lines += [
+            "",
+            "# 4. Mount GCS data (read-only)",
+        ]
+        for mount_path in data_mount_paths:
+            clean_path = mount_path.strip("/")
+            lines += [
+                f"mkdir -p /data/{clean_path}",
+                f"gcsfuse --implicit-dirs --only-dir '{clean_path}' "
+                f"-o ro '{working_bucket}' /data/{clean_path} || "
+                f"echo 'Warning: failed to mount /data/{clean_path}'",
+            ]
+
+    # 5. Create output and scratch directories
+    lines += [
+        "",
+        "# 5. Create output and scratch directories",
+        "mkdir -p /outputs /scratch",
+        f"chown {username}:{username} /outputs /scratch",
+    ]
+
+    # 6. Activate conda env in user's shell
+    if env_name and env_name != "base":
+        lines += [
+            "",
+            "# 6. Activate conda environment",
+            f"echo 'source /opt/conda/etc/profile.d/conda.sh && conda activate {env_name}' >> {home_dir}/.bashrc",
+        ]
+
+    # 7. Generate MOTD
+    repo_names = ", ".join(r["display_name"] for r in github_repos) if github_repos else "(none selected)"
+    mount_list = ", ".join(f"/data/{p.strip('/')}" for p in data_mount_paths) if data_mount_paths else "(none selected)"
+    lines += [
+        "",
+        "# 7. Generate MOTD",
+        "cat > /etc/motd << 'MOTD_EOF'",
+        "",
+        "=== bioAF Work Node ===",
+        "",
+        "  Input data:     /data/                    (read-only GCS mounts)",
+        f"  Your repos:     {home_dir}/repos/          (cloned from GitHub)",
+        "  Output files:   /outputs/                  (synced to GCS on stop)",
+        "  Scratch space:  /scratch/                  (LOST on stop)",
+        "",
+        f"  Environment:    {env_label}",
+        f"  Repos:          {repo_names}",
+        f"  Data mounts:    {mount_list}",
+        "",
+        "MOTD_EOF",
+    ]
+
+    # 8. Heartbeat agent
+    if heartbeat_token:
+        lines += [
+            "",
+            "# 8. Heartbeat agent",
+            "mkdir -p /etc/bioaf",
+            f"echo '{heartbeat_token}' > /etc/bioaf/token",
+        ]
+        # Simple heartbeat cron: POST every 5 minutes
+        api_base = vm_spec.get("api_base_url", "")
+        if api_base:
+            lines += [
+                f"echo '*/5 * * * * curl -s -X POST {api_base}/api/v1/work-nodes/sessions/{session_id}/heartbeat "
+                f'-H "X-Heartbeat-Token: {heartbeat_token}" > /dev/null 2>&1\' | crontab -',
+            ]
+
+    # 9. Ownership
+    lines += [
+        "",
+        "# 9. Final ownership",
+        f"chown -R {username}:{username} {home_dir}",
+    ]
+
+    return "\n".join(lines)
+
+
+class GCEWorkNodeProvider(WorkNodeProvider):
+    """GCE work node backend with local mode for development."""
+
+    def __init__(self, session_factory=None):
+        self._mode = os.environ.get("BIOAF_COMPUTE_MODE", "local")
+        self._session_factory = session_factory
+        self._gcp_config: dict | None = None
+
+    @property
+    def is_local(self) -> bool:
+        return self._mode == "local"
+
+    async def load_gcp_config(self, force: bool = False) -> dict:
+        """Read GCP config from platform_config. Caches the result."""
+        if self._gcp_config is not None and not force:
+            return self._gcp_config
+
+        from sqlalchemy import text as sa_text
+
+        if not self._session_factory:
+            self._gcp_config = {}
+            return self._gcp_config
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                sa_text(
+                    "SELECT key, value FROM platform_config "
+                    "WHERE key IN ("
+                    "  'gcp_project_id', 'gcp_zone', 'gcp_region',"
+                    "  'gcp_service_account_key', 'gcp_service_account_email',"
+                    "  'notebook_runner_sa_email', 'working_bucket_name'"
+                    ")"
+                )
+            )
+            self._gcp_config = {r[0]: r[1] for r in result.fetchall()}
+
+        return self._gcp_config
+
+    def _get_gcp_credentials(self):
+        """Build GCP credentials from service account key."""
+        import json as _json
+
+        from google.oauth2 import service_account
+
+        cfg = self._gcp_config or {}
+        sa_key = cfg.get("gcp_service_account_key", "")
+        if not sa_key:
+            raise RuntimeError("No GCP service account key in platform_config")
+
+        key_data = _json.loads(sa_key)
+        return service_account.Credentials.from_service_account_info(
+            key_data,
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+
+    async def launch_vm(self, vm_spec: dict) -> dict:
+        if self.is_local:
+            return self._local_launch_vm(vm_spec)
+        return await self._gce_launch_vm(vm_spec)
+
+    async def terminate_vm(self, instance_name: str, zone: str, **kwargs) -> dict:
+        if self.is_local:
+            return self._local_terminate_vm(instance_name)
+        return await self._gce_terminate_vm(instance_name, zone, **kwargs)
+
+    async def get_vm_status(self, instance_name: str, zone: str) -> dict:
+        if self.is_local:
+            return self._local_get_vm_status(instance_name)
+        return await self._gce_get_vm_status(instance_name, zone)
+
+    async def list_vms(self, filters: dict | None = None) -> list[dict]:
+        if self.is_local:
+            return self._local_list_vms(filters)
+        return await self._gce_list_vms(filters)
+
+    # -- GCE API implementations --
+
+    async def _gce_launch_vm(self, vm_spec: dict) -> dict:
+        """Create a GCE VM instance for a work node."""
+        from google.cloud import compute_v1
+
+        await self.load_gcp_config()
+        cfg = self._gcp_config or {}
+
+        project = vm_spec.get("gcp_project_id") or cfg.get("gcp_project_id", "")
+        zone = vm_spec.get("gcp_zone") or cfg.get("gcp_zone", "")
+        if not project or not zone:
+            raise RuntimeError("GCP project or zone not configured")
+
+        session_id = vm_spec.get("session_id", 0)
+        user_id = vm_spec.get("user_id", 0)
+        machine_type = vm_spec.get("machine_type", "n2-standard-4")
+        image_uri = vm_spec.get("image_uri", "")
+
+        if not image_uri:
+            raise ValueError("No image_uri provided for work node")
+
+        instance_name = f"bioaf-worknode-{session_id}"
+
+        # Resolve GCE machine type for GPU types
+        gce_machine_type = vm_spec.get("gce_machine_type", machine_type)
+
+        # Build startup script
+        startup_script = _build_startup_script(vm_spec)
+
+        # Service account
+        sa_email = (
+            vm_spec.get("service_account_email")
+            or cfg.get("notebook_runner_sa_email", "")
+            or cfg.get("gcp_service_account_email", "")
+        )
+
+        credentials = self._get_gcp_credentials()
+        instances_client = compute_v1.InstancesClient(credentials=credentials)
+
+        # Build instance resource
+        instance = compute_v1.Instance()
+        instance.name = instance_name
+        instance.machine_type = f"zones/{zone}/machineTypes/{gce_machine_type}"
+
+        # Boot disk from Packer-built image
+        disk = compute_v1.AttachedDisk()
+        disk.auto_delete = True
+        disk.boot = True
+        init_params = compute_v1.AttachedDiskInitializeParams()
+        init_params.source_image = image_uri
+        init_params.disk_size_gb = 200
+        init_params.disk_type = f"zones/{zone}/diskTypes/pd-ssd"
+        disk.initialize_params = init_params
+        instance.disks = [disk]
+
+        # Network with ephemeral external IP
+        network_interface = compute_v1.NetworkInterface()
+        network_interface.name = "global/networks/default"
+        access_config = compute_v1.AccessConfig()
+        access_config.name = "External NAT"
+        access_config.type_ = "ONE_TO_ONE_NAT"
+        network_interface.access_configs = [access_config]
+        instance.network_interfaces = [network_interface]
+
+        # Service account
+        if sa_email:
+            sa = compute_v1.ServiceAccount()
+            sa.email = sa_email
+            sa.scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+            instance.service_accounts = [sa]
+
+        # Tags for firewall
+        tags = compute_v1.Tags()
+        tags.items = ["bioaf-work-node"]
+        instance.tags = tags
+
+        # Labels
+        instance.labels = {
+            "bioaf-session": str(session_id),
+            "bioaf-user": str(user_id),
+            "bioaf-managed": "true",
+        }
+
+        # Metadata (startup script)
+        metadata = compute_v1.Metadata()
+        metadata.items = [
+            compute_v1.Items(key="startup-script", value=startup_script),
+        ]
+        instance.metadata = metadata
+
+        # GPU accelerator
+        accelerator_type = vm_spec.get("accelerator_type")
+        accelerator_count = vm_spec.get("accelerator_count", 1)
+        if accelerator_type:
+            accel = compute_v1.AcceleratorConfig()
+            accel.accelerator_type = f"zones/{zone}/acceleratorTypes/{accelerator_type}"
+            accel.accelerator_count = accelerator_count
+            instance.guest_accelerators = [accel]
+            # GPU VMs require specific scheduling
+            scheduling = compute_v1.Scheduling()
+            scheduling.on_host_maintenance = "TERMINATE"
+            instance.scheduling = scheduling
+
+        # Create the VM
+        instances_client.insert(
+            project=project,
+            zone=zone,
+            instance_resource=instance,
+        )
+        logger.info("Creating GCE instance %s in %s/%s", instance_name, project, zone)
+
+        # Launch background poller
+        asyncio.create_task(self._poll_vm_ready(session_id, instance_name, project, zone))
+
+        return {
+            "instance_name": instance_name,
+            "zone": zone,
+            "gcp_project_id": project,
+            "status": "starting",
+            "access_url": None,
+        }
+
+    async def _poll_vm_ready(
+        self,
+        session_id: int,
+        instance_name: str,
+        project: str,
+        zone: str,
+    ) -> None:
+        """Background: poll for VM running status + external IP, then update DB."""
+        try:
+            from google.cloud import compute_v1
+
+            credentials = self._get_gcp_credentials()
+            instances_client = compute_v1.InstancesClient(credentials=credentials)
+
+            external_ip = None
+            for _ in range(60):  # up to 5 minutes
+                try:
+                    instance = instances_client.get(project=project, zone=zone, instance=instance_name)
+                    if instance.status == "RUNNING":
+                        for iface in instance.network_interfaces:
+                            for ac in iface.access_configs:
+                                if ac.nat_i_p:
+                                    external_ip = ac.nat_i_p
+                                    break
+                            if external_ip:
+                                break
+                        if external_ip:
+                            break
+                    elif instance.status in ("TERMINATED", "STOPPED", "SUSPENDED"):
+                        logger.error("VM %s entered %s status", instance_name, instance.status)
+                        await self._update_session_in_db(session_id, status="failed", access_url=None)
+                        return
+                except Exception:
+                    pass
+                await asyncio.sleep(5)
+
+            if not external_ip:
+                logger.error("VM %s not running with external IP after 5 min", instance_name)
+                await self._update_session_in_db(session_id, status="failed", access_url=None)
+                return
+
+            access_url = f"ssh://{external_ip}:22"
+            logger.info("VM %s ready at %s", instance_name, external_ip)
+            await self._update_session_in_db(session_id, status="running", access_url=access_url)
+
+        except Exception:
+            logger.exception("Background poll failed for VM session %s", session_id)
+            await self._update_session_in_db(session_id, status="failed", access_url=None)
+
+    async def _update_session_in_db(self, session_id: int, status: str, access_url: str | None) -> None:
+        """Update a work node session's status and access_url in the DB."""
+        if not self._session_factory:
+            logger.warning("No session_factory, cannot update session %s", session_id)
+            return
+
+        try:
+            async with self._session_factory() as db:
+                from sqlalchemy import text
+
+                await db.execute(
+                    text("UPDATE compute_sessions SET status = :status, access_url = :url WHERE id = :id"),
+                    {"status": status, "url": access_url, "id": session_id},
+                )
+                await db.commit()
+                logger.info("Updated session %s: status=%s access_url=%s", session_id, status, access_url)
+        except Exception:
+            logger.exception("Failed to update session %s in DB", session_id)
+
+    async def _gce_terminate_vm(
+        self,
+        instance_name: str,
+        zone: str,
+        *,
+        gcp_project_id: str = "",
+        session_id: int = 0,
+        working_bucket: str = "",
+        **kwargs,
+    ) -> dict:
+        """Sync outputs from VM, then delete it."""
+        from google.cloud import compute_v1
+
+        await self.load_gcp_config()
+        cfg = self._gcp_config or {}
+        project = gcp_project_id or cfg.get("gcp_project_id", "")
+
+        output_files: list[dict] = []
+        gcs_output_prefix = ""
+
+        # Sync outputs via shutdown script metadata update
+        # The VM runs gsutil on its own -- we set a shutdown-script and then stop gracefully
+        if working_bucket and session_id:
+            gcs_output_prefix = f"gs://{working_bucket}/sessions/{session_id}/outputs/"
+            try:
+                credentials = self._get_gcp_credentials()
+                instances_client = compute_v1.InstancesClient(credentials=credentials)
+
+                # Add shutdown script to sync outputs before deletion
+                shutdown_script = (
+                    "#!/bin/bash\n"
+                    f'if [ -d /outputs ] && [ "$(ls -A /outputs)" ]; then\n'
+                    f"  gsutil -m rsync -r /outputs {gcs_output_prefix}\n"
+                    f"fi\n"
+                    f"# Capture scripts\n"
+                    f"find /home -maxdepth 4 "
+                    r"\( -name '*.ipynb' -o -name '*.Rmd' -o -name '*.R' -o -name '*.py' \) "
+                    f"-type f "
+                    f'| while read f; do gsutil cp "$f" '
+                    f'gs://{working_bucket}/sessions/{session_id}/scripts/"$(basename "$f")"; done\n'
+                )
+
+                # Set shutdown script and stop the instance to trigger it
+                metadata = compute_v1.Metadata()
+                metadata.items = [
+                    compute_v1.Items(key="shutdown-script", value=shutdown_script),
+                ]
+
+                instances_client.set_metadata(
+                    project=project,
+                    zone=zone,
+                    instance=instance_name,
+                    metadata_resource=metadata,
+                )
+
+                # Stop the instance (triggers shutdown script)
+                instances_client.stop(project=project, zone=zone, instance=instance_name)
+
+                # Wait for the instance to stop (up to 5 minutes)
+                for _ in range(60):
+                    try:
+                        instance = instances_client.get(project=project, zone=zone, instance=instance_name)
+                        if instance.status in ("TERMINATED", "STOPPED"):
+                            break
+                    except Exception:
+                        break
+                    await asyncio.sleep(5)
+
+                logger.info("VM %s stopped, outputs synced", instance_name)
+            except Exception as e:
+                logger.warning("Output sync failed for VM %s: %s", instance_name, e)
+
+        # Delete the VM
+        try:
+            credentials = self._get_gcp_credentials()
+            instances_client = compute_v1.InstancesClient(credentials=credentials)
+            instances_client.delete(project=project, zone=zone, instance=instance_name)
+            logger.info("Deleted VM %s", instance_name)
+        except Exception as e:
+            logger.warning("Failed to delete VM %s: %s", instance_name, e)
+
+        # List output files from GCS
+        if gcs_output_prefix:
+            try:
+                from google.cloud import storage
+
+                credentials = self._get_gcp_credentials()
+                storage_client = storage.Client(project=project, credentials=credentials)
+                bucket = storage_client.bucket(working_bucket)
+                prefix = f"sessions/{session_id}/"
+                blobs = bucket.list_blobs(prefix=prefix)
+                for blob in blobs:
+                    output_files.append(
+                        {
+                            "gcs_uri": f"gs://{working_bucket}/{blob.name}",
+                            "size_bytes": blob.size or 0,
+                            "filename": blob.name.split("/")[-1],
+                        }
+                    )
+            except Exception as e:
+                logger.warning("Failed to list output files for session %s: %s", session_id, e)
+
+        return {
+            "instance_name": instance_name,
+            "status": "stopped",
+            "stopped_at": datetime.now(timezone.utc).isoformat(),
+            "output_files": output_files,
+            "gcs_output_prefix": gcs_output_prefix,
+        }
+
+    async def _gce_get_vm_status(self, instance_name: str, zone: str) -> dict:
+        """Query GCE API for VM status."""
+        from google.cloud import compute_v1
+
+        await self.load_gcp_config()
+        cfg = self._gcp_config or {}
+        project = cfg.get("gcp_project_id", "")
+
+        try:
+            credentials = self._get_gcp_credentials()
+            instances_client = compute_v1.InstancesClient(credentials=credentials)
+            instance = instances_client.get(project=project, zone=zone, instance=instance_name)
+
+            external_ip = None
+            for iface in instance.network_interfaces:
+                for ac in iface.access_configs:
+                    if ac.nat_i_p:
+                        external_ip = ac.nat_i_p
+                        break
+
+            status_map = {
+                "RUNNING": "running",
+                "STAGING": "starting",
+                "PROVISIONING": "starting",
+                "STOPPING": "stopping",
+                "TERMINATED": "stopped",
+                "STOPPED": "stopped",
+                "SUSPENDED": "stopped",
+            }
+
+            return {
+                "instance_name": instance_name,
+                "status": status_map.get(instance.status, "unknown"),
+                "external_ip": external_ip,
+                "zone": zone,
+            }
+        except Exception:
+            return {
+                "instance_name": instance_name,
+                "status": "unknown",
+                "zone": zone,
+            }
+
+    async def _gce_list_vms(self, filters: dict | None = None) -> list[dict]:
+        """List work node VMs by label."""
+        from google.cloud import compute_v1
+
+        await self.load_gcp_config()
+        cfg = self._gcp_config or {}
+        project = cfg.get("gcp_project_id", "")
+        zone = cfg.get("gcp_zone", "")
+
+        try:
+            credentials = self._get_gcp_credentials()
+            instances_client = compute_v1.InstancesClient(credentials=credentials)
+
+            request = compute_v1.ListInstancesRequest(
+                project=project,
+                zone=zone,
+                filter='labels.bioaf-managed="true"',
+            )
+            instances = instances_client.list(request=request)
+
+            vms = []
+            for instance in instances:
+                labels = dict(instance.labels) if instance.labels else {}
+                external_ip = None
+                for iface in instance.network_interfaces:
+                    for ac in iface.access_configs:
+                        if ac.nat_i_p:
+                            external_ip = ac.nat_i_p
+                            break
+
+                vms.append(
+                    {
+                        "instance_name": instance.name,
+                        "status": instance.status.lower(),
+                        "external_ip": external_ip,
+                        "zone": zone,
+                        "session_id": labels.get("bioaf-session", ""),
+                        "user_id": labels.get("bioaf-user", ""),
+                    }
+                )
+            return vms
+        except Exception:
+            logger.exception("Failed to list GCE VMs")
+            return []
+
+    # -- Local mode implementations --
+
+    def _local_launch_vm(self, vm_spec: dict) -> dict:
+        instance_name = f"bioaf-worknode-local-{uuid.uuid4().hex[:8]}"
+        vm_data = {
+            "instance_name": instance_name,
+            "status": "running",
+            "access_url": "ssh://127.0.0.1:22",
+            "zone": "us-central1-a",
+            "gcp_project_id": "local-project",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _local_vms[instance_name] = vm_data
+        logger.info("Local mode: launched VM %s", instance_name)
+        return vm_data
+
+    def _local_terminate_vm(self, instance_name: str) -> dict:
+        if instance_name in _local_vms:
+            _local_vms[instance_name]["status"] = "stopped"
+            _local_vms[instance_name]["stopped_at"] = datetime.now(timezone.utc).isoformat()
+        logger.info("Local mode: terminated VM %s", instance_name)
+        return {
+            "instance_name": instance_name,
+            "status": "stopped",
+            "stopped_at": datetime.now(timezone.utc).isoformat(),
+            "output_files": [],
+            "gcs_output_prefix": "",
+        }
+
+    def _local_get_vm_status(self, instance_name: str) -> dict:
+        if instance_name in _local_vms:
+            return _local_vms[instance_name]
+        return {"instance_name": instance_name, "status": "unknown"}
+
+    def _local_list_vms(self, filters: dict | None = None) -> list[dict]:
+        return list(_local_vms.values())

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -34,6 +34,7 @@ def _build_startup_script(vm_spec: dict) -> str:
     heartbeat_token = vm_spec.get("heartbeat_token", "")
     github_repos = vm_spec.get("github_repos", [])
     input_files = vm_spec.get("input_files", [])
+    working_bucket = vm_spec.get("working_bucket", "")
     session_id = vm_spec.get("session_id", 0)
     env_name = vm_spec.get("conda_env_name", "base")
     env_label = vm_spec.get("environment_label", "")
@@ -114,7 +115,45 @@ def _build_startup_script(vm_spec: dict) -> str:
         f"chown {username}:{username} /outputs /scratch",
     ]
 
-    # 6. Activate conda env in user's shell
+    # 6. Install shutdown sync service (syncs /outputs/ to GCS on stop)
+    if working_bucket and session_id:
+        gcs_output_prefix = f"gs://{working_bucket}/sessions/{session_id}/outputs/"
+        gcs_scripts_prefix = f"gs://{working_bucket}/sessions/{session_id}/scripts/"
+        lines += [
+            "",
+            "# 6. Install shutdown sync service",
+            "cat > /usr/local/bin/bioaf-shutdown-sync.sh << 'SYNCEOF'",
+            "#!/bin/bash",
+            'if [ -d /outputs ] && [ "$(ls -A /outputs)" ]; then',
+            f"  gsutil -m rsync -r /outputs {gcs_output_prefix}",
+            "fi",
+            f"find /home -maxdepth 4 "
+            r"\( -name '*.ipynb' -o -name '*.Rmd' -o -name '*.R' -o -name '*.py' \) "
+            f"-type f "
+            f'| while read f; do gsutil cp "$f" '
+            f'{gcs_scripts_prefix}"$(basename "$f")"; done',
+            "SYNCEOF",
+            "chmod +x /usr/local/bin/bioaf-shutdown-sync.sh",
+            "",
+            "cat > /etc/systemd/system/bioaf-shutdown-sync.service << 'SVCEOF'",
+            "[Unit]",
+            "Description=bioAF output sync on shutdown",
+            "DefaultDependencies=no",
+            "Before=shutdown.target reboot.target halt.target",
+            "",
+            "[Service]",
+            "Type=oneshot",
+            "ExecStart=/usr/local/bin/bioaf-shutdown-sync.sh",
+            "TimeoutStartSec=300",
+            "",
+            "[Install]",
+            "WantedBy=halt.target reboot.target shutdown.target",
+            "SVCEOF",
+            "systemctl daemon-reload",
+            "systemctl enable bioaf-shutdown-sync.service",
+        ]
+
+    # 7. Activate conda env in user's shell
     if env_name and env_name != "base":
         lines += [
             "",
@@ -460,57 +499,30 @@ class GCEWorkNodeProvider(WorkNodeProvider):
         output_files: list[dict] = []
         gcs_output_prefix = ""
 
-        # Sync outputs via shutdown script metadata update
-        # The VM runs gsutil on its own -- we set a shutdown-script and then stop gracefully
+        # Stop the VM gracefully -- the systemd bioaf-shutdown-sync service
+        # (installed by the startup script) handles syncing /outputs/ to GCS.
         if working_bucket and session_id:
             gcs_output_prefix = f"gs://{working_bucket}/sessions/{session_id}/outputs/"
-            try:
-                credentials = self._get_gcp_credentials()
-                instances_client = compute_v1.InstancesClient(credentials=credentials)
 
-                # Add shutdown script to sync outputs before deletion
-                shutdown_script = (
-                    "#!/bin/bash\n"
-                    f'if [ -d /outputs ] && [ "$(ls -A /outputs)" ]; then\n'
-                    f"  gsutil -m rsync -r /outputs {gcs_output_prefix}\n"
-                    f"fi\n"
-                    f"# Capture scripts\n"
-                    f"find /home -maxdepth 4 "
-                    r"\( -name '*.ipynb' -o -name '*.Rmd' -o -name '*.R' -o -name '*.py' \) "
-                    f"-type f "
-                    f'| while read f; do gsutil cp "$f" '
-                    f'gs://{working_bucket}/sessions/{session_id}/scripts/"$(basename "$f")"; done\n'
-                )
+        try:
+            credentials = self._get_gcp_credentials()
+            instances_client = compute_v1.InstancesClient(credentials=credentials)
 
-                # Set shutdown script and stop the instance to trigger it
-                metadata = compute_v1.Metadata()
-                metadata.items = [
-                    compute_v1.Items(key="shutdown-script", value=shutdown_script),
-                ]
+            instances_client.stop(project=project, zone=zone, instance=instance_name)
 
-                instances_client.set_metadata(
-                    project=project,
-                    zone=zone,
-                    instance=instance_name,
-                    metadata_resource=metadata,
-                )
-
-                # Stop the instance (triggers shutdown script)
-                instances_client.stop(project=project, zone=zone, instance=instance_name)
-
-                # Wait for the instance to stop (up to 5 minutes)
-                for _ in range(60):
-                    try:
-                        instance = instances_client.get(project=project, zone=zone, instance=instance_name)
-                        if instance.status in ("TERMINATED", "STOPPED"):
-                            break
-                    except Exception:
+            # Wait for the instance to stop (up to 5 minutes)
+            for _ in range(60):
+                try:
+                    instance = instances_client.get(project=project, zone=zone, instance=instance_name)
+                    if instance.status in ("TERMINATED", "STOPPED"):
                         break
-                    await asyncio.sleep(5)
+                except Exception:
+                    break
+                await asyncio.sleep(5)
 
-                logger.info("VM %s stopped, outputs synced", instance_name)
-            except Exception as e:
-                logger.warning("Output sync failed for VM %s: %s", instance_name, e)
+            logger.info("VM %s stopped, outputs synced via shutdown service", instance_name)
+        except Exception as e:
+            logger.warning("Failed to stop VM %s: %s", instance_name, e)
 
         # Delete the VM
         try:

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -294,9 +294,15 @@ class GCEWorkNodeProvider(WorkNodeProvider):
         cfg = self._gcp_config or {}
 
         project = vm_spec.get("gcp_project_id") or cfg.get("gcp_project_id", "")
-        zone = vm_spec.get("gcp_zone") or cfg.get("gcp_zone", "")
-        if not project or not zone:
+        configured_zone = vm_spec.get("gcp_zone") or cfg.get("gcp_zone", "")
+        if not project or not configured_zone:
             raise RuntimeError("GCP project or zone not configured")
+
+        # Derive region and build a list of zones to try, avoiding repeated
+        # capacity failures in a single zone.
+        region = configured_zone.rsplit("-", 1)[0]
+        zone_suffixes = ["b", "c", "f", "a"]
+        zones_to_try = [f"{region}-{s}" for s in zone_suffixes]
 
         session_id = vm_spec.get("session_id", 0)
         user_id = vm_spec.get("user_id", 0)
@@ -324,77 +330,79 @@ class GCEWorkNodeProvider(WorkNodeProvider):
         credentials = self._get_gcp_credentials()
         instances_client = compute_v1.InstancesClient(credentials=credentials)
 
-        # Build instance resource
-        instance = compute_v1.Instance()
-        instance.name = instance_name
-        instance.machine_type = f"zones/{zone}/machineTypes/{gce_machine_type}"
-
-        # Boot disk from Packer-built image
-        disk = compute_v1.AttachedDisk()
-        disk.auto_delete = True
-        disk.boot = True
-        init_params = compute_v1.AttachedDiskInitializeParams()
-        init_params.source_image = image_uri
-        init_params.disk_size_gb = 200
-        init_params.disk_type = f"zones/{zone}/diskTypes/pd-ssd"
-        disk.initialize_params = init_params
-        instance.disks = [disk]
-
-        # Network with ephemeral external IP
-        network_interface = compute_v1.NetworkInterface()
-        network_interface.name = "global/networks/default"
-        access_config = compute_v1.AccessConfig()
-        access_config.name = "External NAT"
-        access_config.type_ = "ONE_TO_ONE_NAT"
-        network_interface.access_configs = [access_config]
-        instance.network_interfaces = [network_interface]
-
-        # Service account
-        if sa_email:
-            sa = compute_v1.ServiceAccount()
-            sa.email = sa_email
-            sa.scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-            instance.service_accounts = [sa]
-
-        # Tags for firewall
-        tags = compute_v1.Tags()
-        tags.items = ["bioaf-work-node"]
-        instance.tags = tags
-
-        # Labels
-        instance.labels = {
-            "bioaf-session": str(session_id),
-            "bioaf-user": str(user_id),
-            "bioaf-managed": "true",
-        }
-
-        # Metadata (startup script)
-        metadata = compute_v1.Metadata()
-        metadata.items = [
-            compute_v1.Items(key="startup-script", value=startup_script),
-        ]
-        instance.metadata = metadata
-
-        # GPU accelerator
+        # Try creating the VM across zones until one succeeds
         accelerator_type = vm_spec.get("accelerator_type")
         accelerator_count = vm_spec.get("accelerator_count", 1)
-        if accelerator_type:
-            accel = compute_v1.AcceleratorConfig()
-            accel.accelerator_type = f"zones/{zone}/acceleratorTypes/{accelerator_type}"
-            accel.accelerator_count = accelerator_count
-            instance.guest_accelerators = [accel]
-            # GPU VMs require specific scheduling
-            scheduling = compute_v1.Scheduling()
-            scheduling.on_host_maintenance = "TERMINATE"
-            instance.scheduling = scheduling
+        zone = zones_to_try[0]  # default for error reporting
 
-        # Create the VM
-        instances_client.insert(
-            project=project,
-            zone=zone,
-            instance_resource=instance,
-        )
-        logger.info("Creating GCE instance %s in %s/%s", instance_name, project, zone)
+        for try_zone in zones_to_try:
+            try:
+                instance = compute_v1.Instance()
+                instance.name = instance_name
+                instance.machine_type = f"zones/{try_zone}/machineTypes/{gce_machine_type}"
+
+                disk = compute_v1.AttachedDisk()
+                disk.auto_delete = True
+                disk.boot = True
+                init_params = compute_v1.AttachedDiskInitializeParams()
+                init_params.source_image = image_uri
+                init_params.disk_size_gb = 200
+                init_params.disk_type = f"zones/{try_zone}/diskTypes/pd-ssd"
+                disk.initialize_params = init_params
+                instance.disks = [disk]
+
+                network_interface = compute_v1.NetworkInterface()
+                network_interface.name = "global/networks/default"
+                access_config = compute_v1.AccessConfig()
+                access_config.name = "External NAT"
+                access_config.type_ = "ONE_TO_ONE_NAT"
+                network_interface.access_configs = [access_config]
+                instance.network_interfaces = [network_interface]
+
+                if sa_email:
+                    sa = compute_v1.ServiceAccount()
+                    sa.email = sa_email
+                    sa.scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+                    instance.service_accounts = [sa]
+
+                tags = compute_v1.Tags()
+                tags.items = ["bioaf-work-node"]
+                instance.tags = tags
+
+                instance.labels = {
+                    "bioaf-session": str(session_id),
+                    "bioaf-user": str(user_id),
+                    "bioaf-managed": "true",
+                }
+
+                metadata = compute_v1.Metadata()
+                metadata.items = [
+                    compute_v1.Items(key="startup-script", value=startup_script),
+                ]
+                instance.metadata = metadata
+
+                if accelerator_type:
+                    accel = compute_v1.AcceleratorConfig()
+                    accel.accelerator_type = f"zones/{try_zone}/acceleratorTypes/{accelerator_type}"
+                    accel.accelerator_count = accelerator_count
+                    instance.guest_accelerators = [accel]
+                    scheduling = compute_v1.Scheduling()
+                    scheduling.on_host_maintenance = "TERMINATE"
+                    instance.scheduling = scheduling
+
+                instances_client.insert(
+                    project=project,
+                    zone=try_zone,
+                    instance_resource=instance,
+                )
+                zone = try_zone
+                logger.info("Creating GCE instance %s in %s/%s", instance_name, project, zone)
+                break
+            except Exception as e:
+                if "ZONE_RESOURCE_POOL_EXHAUSTED" in str(e) or "does not have enough resources" in str(e):
+                    logger.warning("Zone %s exhausted for %s, trying next zone", try_zone, machine_type)
+                    continue
+                raise
 
         # Launch background poller
         creds = vm_spec.get("session_credentials", {})

--- a/backend/app/adapters/work_nodes/gce.py
+++ b/backend/app/adapters/work_nodes/gce.py
@@ -41,7 +41,8 @@ def _build_startup_script(vm_spec: dict) -> str:
 
     lines = [
         "#!/bin/bash",
-        "set -e",
+        "# Log all output for debugging",
+        "exec > >(tee -a /var/log/bioaf-startup.log) 2>&1",
         "",
         "# 1. Create PAM user with session credentials",
         f"useradd -m -d {home_dir} -s /bin/bash {username} || true",
@@ -81,9 +82,9 @@ def _build_startup_script(vm_spec: dict) -> str:
             safe_name = name.replace("'", "'\\''")
             safe_url = url.replace("'", "'\\''")
             lines.append(
-                f'su - {username} -c "cd {home_dir}/repos && '
-                f"GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' "
-                f"git clone '{safe_url}' '{safe_name}'\" || "
+                f"cd {home_dir}/repos && "
+                f"GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -i {home_dir}/.ssh/id_rsa' "
+                f"git clone '{safe_url}' '{safe_name}' || "
                 f"echo 'Warning: failed to clone {safe_name}'"
             )
         lines.append(f"chown -R {username}:{username} {home_dir}/repos")
@@ -98,8 +99,8 @@ def _build_startup_script(vm_spec: dict) -> str:
             clean_path = mount_path.strip("/")
             lines += [
                 f"mkdir -p /data/{clean_path}",
-                f"gcsfuse --implicit-dirs --only-dir '{clean_path}' "
-                f"-o ro '{working_bucket}' /data/{clean_path} || "
+                f"gcsfuse --implicit-dirs --read-only --only-dir '{clean_path}' "
+                f"'{working_bucket}' /data/{clean_path} || "
                 f"echo 'Warning: failed to mount /data/{clean_path}'",
             ]
 

--- a/backend/app/api/environments.py
+++ b/backend/app/api/environments.py
@@ -63,6 +63,7 @@ def _env_response(env) -> EnvironmentResponse:
         name=env.name,
         description=env.description,
         visibility=env.visibility,
+        environment_type=env.environment_type,
         version_count=len(versions),
         latest_version=latest,
         created_by=UserSummary(
@@ -79,11 +80,12 @@ def _env_response(env) -> EnvironmentResponse:
 
 @router.get("", response_model=EnvironmentListResponse)
 async def list_environments(
+    type: str | None = None,
     current_user: dict = require_permission("environments", "view"),
     session: AsyncSession = Depends(get_session),
 ):
     org_id = int(current_user["org_id"])
-    envs = await EnvironmentService.list_environments(session, org_id)
+    envs = await EnvironmentService.list_environments(session, org_id, environment_type=type)
     return EnvironmentListResponse(
         environments=[_env_response(e) for e in envs],
         total=len(envs),
@@ -107,6 +109,7 @@ async def create_environment(
             name=data.name,
             description=data.description,
             visibility=data.visibility,
+            environment_type=data.environment_type,
         )
         await session.commit()
         # Re-fetch to load relationships
@@ -135,6 +138,7 @@ async def get_environment(
         name=env.name,
         description=env.description,
         visibility=env.visibility,
+        environment_type=env.environment_type,
         versions=[
             EnvironmentVersionSummary(
                 id=v.id,

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -254,6 +254,7 @@ async def list_files(
     project_id: int | None = None,
     source_type: str | None = None,
     sample_id: int | None = None,
+    search: str | None = None,
     page: int = 1,
     page_size: int = 25,
     session: AsyncSession = Depends(get_session),
@@ -262,7 +263,7 @@ async def list_files(
     org_id = int(current_user["org_id"])
 
     files, total = await FileService.list_files(
-        session, org_id, file_type, experiment_id, project_id, source_type, sample_id, page, page_size
+        session, org_id, file_type, experiment_id, project_id, source_type, sample_id, search, page, page_size
     )
     file_ids = [f.id for f in files]
     sample_ids_map = await FileService.get_sample_ids_for_files(session, file_ids)

--- a/backend/app/api/github_repos.py
+++ b/backend/app/api/github_repos.py
@@ -1,0 +1,63 @@
+"""GitHub repo API endpoints (ADR-043).
+
+CRUD for user-scoped GitHub repos used by work nodes.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.api.dependencies import require_permission
+from app.schemas.github_repo import (
+    GitHubRepoCreateRequest,
+    GitHubRepoListResponse,
+    GitHubRepoResponse,
+)
+from app.services.github_repo_service import GitHubRepoService
+
+router = APIRouter(prefix="/api/v1/github-repos", tags=["github-repos"])
+
+
+@router.get("", response_model=GitHubRepoListResponse)
+async def list_github_repos(
+    current_user: dict = require_permission("work_nodes", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = int(current_user["sub"])
+    org_id = int(current_user["org_id"])
+    repos = await GitHubRepoService.list_repos(session, user_id, org_id)
+    return GitHubRepoListResponse(
+        repos=[GitHubRepoResponse.model_validate(r) for r in repos],
+        total=len(repos),
+    )
+
+
+@router.post("", response_model=GitHubRepoResponse)
+async def create_github_repo(
+    body: GitHubRepoCreateRequest,
+    current_user: dict = require_permission("work_nodes", "launch"),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = int(current_user["sub"])
+    org_id = int(current_user["org_id"])
+    try:
+        repo = await GitHubRepoService.create_repo(session, user_id, org_id, body.git_ssh_url, body.display_name)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    await session.commit()
+    return GitHubRepoResponse.model_validate(repo)
+
+
+@router.delete("/{repo_id}")
+async def delete_github_repo(
+    repo_id: int,
+    current_user: dict = require_permission("work_nodes", "launch"),
+    session: AsyncSession = Depends(get_session),
+):
+    user_id = int(current_user["sub"])
+    try:
+        await GitHubRepoService.delete_repo(session, repo_id, user_id)
+    except ValueError as e:
+        raise HTTPException(404, str(e))
+    await session.commit()
+    return {"status": "ok"}

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -64,6 +64,7 @@ from app.api.slack_oauth import router as slack_oauth_router
 from app.api.experiment_auto_runs import router as experiment_auto_runs_router
 from app.api.content_tokens import router as content_tokens_router
 from app.api.sheets_import import router as sheets_import_router
+from app.api.github_repos import router as github_repos_router
 
 api_router = APIRouter()
 
@@ -131,3 +132,4 @@ api_router.include_router(slack_oauth_router)
 api_router.include_router(experiment_auto_runs_router)
 api_router.include_router(content_tokens_router)
 api_router.include_router(sheets_import_router)
+api_router.include_router(github_repos_router)

--- a/backend/app/api/work_nodes.py
+++ b/backend/app/api/work_nodes.py
@@ -43,7 +43,7 @@ def _work_node_response(cs) -> WorkNodeResponse:
         project_id=cs.project_id,
         environment_version_id=cs.environment_version_id,
         machine_type=cs.machine_type,
-        data_mount_paths=cs.data_mount_paths,
+        input_file_ids=cs.data_mount_paths,
         resource_profile=cs.resource_profile,
         cpu_cores=cs.cpu_cores,
         memory_gb=cs.memory_gb,

--- a/backend/app/api/work_nodes.py
+++ b/backend/app/api/work_nodes.py
@@ -135,7 +135,7 @@ async def launch_work_node(
             project_id=body.project_id,
             environment_version_id=body.environment_version_id,
             machine_type=body.machine_type,
-            data_mount_paths=body.data_mount_paths,
+            input_file_ids=body.input_file_ids,
             github_repo_ids=body.github_repo_ids,
         )
     except ValueError as e:

--- a/backend/app/api/work_nodes.py
+++ b/backend/app/api/work_nodes.py
@@ -43,7 +43,7 @@ def _work_node_response(cs) -> WorkNodeResponse:
         project_id=cs.project_id,
         environment_version_id=cs.environment_version_id,
         machine_type=cs.machine_type,
-        input_file_ids=cs.data_mount_paths,
+        input_file_ids=[v for v in (cs.data_mount_paths or []) if isinstance(v, int)],
         resource_profile=cs.resource_profile,
         cpu_cores=cs.cpu_cores,
         memory_gb=cs.memory_gb,

--- a/backend/app/api/work_nodes.py
+++ b/backend/app/api/work_nodes.py
@@ -49,6 +49,9 @@ def _work_node_response(cs) -> WorkNodeResponse:
         memory_gb=cs.memory_gb,
         status=cs.status,
         access_url=cs.access_url,
+        gce_instance_name=cs.gce_instance_name,
+        gce_zone=cs.gce_zone,
+        github_repo_ids=cs.github_repo_ids,
         heartbeat_at=cs.heartbeat_at,
         started_at=cs.started_at,
         stopped_at=cs.stopped_at,
@@ -133,6 +136,7 @@ async def launch_work_node(
             environment_version_id=body.environment_version_id,
             machine_type=body.machine_type,
             data_mount_paths=body.data_mount_paths,
+            github_repo_ids=body.github_repo_ids,
         )
     except ValueError as e:
         raise HTTPException(400, str(e))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -146,6 +146,16 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning("Built-in role permission sync failed: %s", e)
 
+    # Seed default work node environment if none exists (ADR-043)
+    from app.services.environment_service import ensure_default_work_node_environment
+
+    try:
+        async with notif_session_factory() as env_seed_session:
+            await ensure_default_work_node_environment(env_seed_session)
+            await env_seed_session.commit()
+    except Exception as e:
+        logger.warning("Default work node environment seed failed: %s", e)
+
     # Resolve any pending upgrades from before the restart
     from app.services.upgrade_service import UpgradeService
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -61,6 +61,7 @@ from app.models.role import Role, RolePermission
 from app.models.sample_custom_field import SampleCustomField
 from app.models.experiment_auto_run import ExperimentAutoRun
 from app.models.pending_auto_run import PendingAutoRun
+from app.models.github_repo import GitHubRepo
 
 __all__ = [
     "User",
@@ -132,4 +133,5 @@ __all__ = [
     "SampleCustomField",
     "ExperimentAutoRun",
     "PendingAutoRun",
+    "GitHubRepo",
 ]

--- a/backend/app/models/environment.py
+++ b/backend/app/models/environment.py
@@ -15,6 +15,7 @@ class Environment(Base):
     organization_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
     created_by_user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False)
     visibility: Mapped[str] = mapped_column(String(50), nullable=False, server_default="team")
+    environment_type: Mapped[str] = mapped_column(String(50), nullable=False, server_default="notebook")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/app/models/github_repo.py
+++ b/backend/app/models/github_repo.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class GitHubRepo(Base):
+    __tablename__ = "github_repos"
+    __table_args__ = (UniqueConstraint("user_id", "git_ssh_url", name="uq_github_repo_user_url"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    organization_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
+    git_ssh_url: Mapped[str] = mapped_column(String(500), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/notebook_session.py
+++ b/backend/app/models/notebook_session.py
@@ -43,6 +43,12 @@ class ComputeSession(Base):
     git_commit_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     gcs_output_prefix: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
+    # GCE VM columns (ADR-043)
+    gce_instance_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    gce_zone: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    gce_project_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    github_repo_ids: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
     user = relationship("User")
     organization = relationship("Organization")
     experiment = relationship("Experiment")

--- a/backend/app/schemas/environment.py
+++ b/backend/app/schemas/environment.py
@@ -16,6 +16,7 @@ class EnvironmentCreateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     description: str | None = None
     visibility: str = "team"
+    environment_type: str = "notebook"
 
 
 class EnvironmentUpdateRequest(BaseModel):
@@ -41,6 +42,7 @@ class EnvironmentResponse(BaseModel):
     name: str
     description: str | None = None
     visibility: str
+    environment_type: str = "notebook"
     version_count: int = 0
     latest_version: EnvironmentVersionSummary | None = None
     created_by: UserSummary | None = None
@@ -60,6 +62,7 @@ class EnvironmentDetailResponse(BaseModel):
     name: str
     description: str | None = None
     visibility: str
+    environment_type: str = "notebook"
     versions: list[EnvironmentVersionSummary]
     created_by: UserSummary | None = None
     created_at: datetime

--- a/backend/app/schemas/github_repo.py
+++ b/backend/app/schemas/github_repo.py
@@ -1,0 +1,24 @@
+"""Pydantic schemas for GitHub repo management (ADR-043)."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class GitHubRepoCreateRequest(BaseModel):
+    git_ssh_url: str = Field(..., min_length=1, max_length=500)
+    display_name: str | None = Field(default=None, max_length=255)
+
+
+class GitHubRepoResponse(BaseModel):
+    id: int
+    git_ssh_url: str
+    display_name: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class GitHubRepoListResponse(BaseModel):
+    repos: list[GitHubRepoResponse]
+    total: int

--- a/backend/app/schemas/work_node.py
+++ b/backend/app/schemas/work_node.py
@@ -18,6 +18,7 @@ class WorkNodeLaunchRequest(BaseModel):
     environment_version_id: int
     machine_type: str
     data_mount_paths: list[str] | None = None
+    github_repo_ids: list[int] | None = None
 
 
 class WorkNodeResponse(BaseModel):
@@ -33,6 +34,9 @@ class WorkNodeResponse(BaseModel):
     memory_gb: int
     status: str
     access_url: str | None = None
+    gce_instance_name: str | None = None
+    gce_zone: str | None = None
+    github_repo_ids: list[int] | None = None
     heartbeat_at: datetime | None = None
     started_at: datetime | None = None
     stopped_at: datetime | None = None

--- a/backend/app/schemas/work_node.py
+++ b/backend/app/schemas/work_node.py
@@ -17,7 +17,7 @@ class WorkNodeLaunchRequest(BaseModel):
     project_id: int
     environment_version_id: int
     machine_type: str
-    data_mount_paths: list[str] | None = None
+    input_file_ids: list[int] | None = None
     github_repo_ids: list[int] | None = None
 
 

--- a/backend/app/schemas/work_node.py
+++ b/backend/app/schemas/work_node.py
@@ -28,7 +28,7 @@ class WorkNodeResponse(BaseModel):
     project_id: int | None = None
     environment_version_id: int | None = None
     machine_type: str | None = None
-    data_mount_paths: list[str] | None = None
+    input_file_ids: list[int] | None = None
     resource_profile: str
     cpu_cores: int
     memory_gb: int

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -121,6 +121,8 @@ build {
   provisioner "shell" {
     inline = [
       "export PATH=/opt/conda/bin:$PATH",
+      "conda config --remove channels defaults 2>/dev/null || true",
+      "conda config --add channels conda-forge",
       "gsutil cp ${var.environment_yml_gcs} /tmp/environment.yml",
       "conda env create -f /tmp/environment.yml",
       "conda clean -afy",

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -44,7 +44,7 @@ variable "project_id" {
   type = string
 }
 
-variable "region" {
+variable "zone" {
   type = string
 }
 
@@ -63,7 +63,7 @@ variable "conda_env_name" {
 
 source "googlecompute" "work_node" {
   project_id   = var.project_id
-  region       = var.region
+  zone         = var.zone
   machine_type = "n2-standard-4"
 
   source_image_family = "ubuntu-2204-lts"
@@ -400,6 +400,13 @@ class EnvironmentBuildService:
         if not working_bucket or working_bucket == "null":
             raise ValueError("Working bucket not configured")
 
+        # Pick a zone for the Packer build VM, avoiding -a which is
+        # often capacity-constrained.  The image itself is regional.
+        import random
+
+        zone_suffix = random.choice(["b", "c", "f"])
+        build_zone = f"{region}-{zone_suffix}"
+
         # Extract conda env name from the YAML
         data = yaml.safe_load(version.definition_content)
         conda_env_name = data.get("name", "bioaf") if data else "bioaf"
@@ -447,7 +454,7 @@ class EnvironmentBuildService:
                     "args": [
                         "build",
                         f"-var=project_id={project_id}",
-                        f"-var=region={region}",
+                        f"-var=zone={build_zone}",
                         f"-var=image_name={image_name}",
                         f"-var=environment_yml_gcs={env_yml_gcs}",
                         f"-var=conda_env_name={conda_env_name}",

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -88,6 +88,7 @@ build {
   # System packages
   provisioner "shell" {
     inline = [
+      "sudo add-apt-repository -y universe",
       "sudo apt-get update",
       "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server git tmux htop curl fail2ban",
       "sudo systemctl enable ssh",

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -28,6 +28,136 @@ from app.services.notebook_image_service import (
 
 logger = logging.getLogger("bioaf.environment_build")
 
+# Packer template for building GCE VM images with conda environments (ADR-043).
+# Stored as a string constant; written to the build context at build time.
+PACKER_VM_TEMPLATE = """\
+packer {{
+  required_plugins {{
+    googlecompute = {{
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/googlecompute"
+    }}
+  }}
+}}
+
+variable "project_id" {{
+  type = string
+}}
+
+variable "zone" {{
+  type = string
+}}
+
+variable "image_name" {{
+  type = string
+}}
+
+variable "environment_yml_gcs" {{
+  type = string
+}}
+
+variable "conda_env_name" {{
+  type    = string
+  default = "bioaf"
+}}
+
+source "googlecompute" "work_node" {{
+  project_id   = var.project_id
+  zone         = var.zone
+  machine_type = "n2-standard-4"
+
+  source_image_family = "ubuntu-2204-lts"
+  source_image_project_id = ["ubuntu-os-cloud"]
+
+  image_name        = var.image_name
+  image_description = "bioAF work node environment"
+  image_family      = "bioaf-worknode"
+  image_labels = {{
+    bioaf-managed = "true"
+  }}
+
+  disk_size = 50
+  disk_type = "pd-ssd"
+
+  ssh_username = "packer"
+}}
+
+build {{
+  sources = ["source.googlecompute.work_node"]
+
+  # System packages
+  provisioner "shell" {{
+    inline = [
+      "sudo apt-get update",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server git tmux htop curl fail2ban",
+      "sudo systemctl enable ssh",
+      "sudo sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config",
+    ]
+  }}
+
+  # Install gcsfuse
+  provisioner "shell" {{
+    inline = [
+      "export GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s)",
+      "echo \"deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main\" | sudo tee /etc/apt/sources.list.d/gcsfuse.list",
+      "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
+      "sudo apt-get update && sudo apt-get install -y gcsfuse",
+    ]
+  }}
+
+  # Install miniconda
+  provisioner "shell" {{
+    inline = [
+      "wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh",
+      "sudo bash /tmp/miniconda.sh -b -p /opt/conda",
+      "sudo chmod -R a+rx /opt/conda",
+      "rm /tmp/miniconda.sh",
+      "echo 'export PATH=/opt/conda/bin:$PATH' | sudo tee /etc/profile.d/conda.sh",
+    ]
+  }}
+
+  # Download environment.yml from GCS and create conda env
+  provisioner "shell" {{
+    inline = [
+      "export PATH=/opt/conda/bin:$PATH",
+      "gsutil cp ${{var.environment_yml_gcs}} /tmp/environment.yml",
+      "conda env create -f /tmp/environment.yml",
+      "conda clean -afy",
+      "rm /tmp/environment.yml",
+    ]
+  }}
+
+  # Install bioaf heartbeat agent
+  provisioner "shell" {{
+    inline = [
+      "sudo mkdir -p /etc/bioaf",
+      "sudo mkdir -p /outputs /scratch",
+    ]
+  }}
+
+  # Cleanup
+  provisioner "shell" {{
+    inline = [
+      "sudo apt-get clean",
+      "sudo rm -rf /var/lib/apt/lists/*",
+    ]
+  }}
+}}
+"""
+
+
+def _get_vm_image_name(env_name: str, version_number: int, build_number: int) -> str:
+    """Construct GCE image name for a work node environment."""
+    safe_name = env_name.lower().replace(" ", "-").replace("_", "-")
+    return f"bioaf-worknode-{safe_name}-v{version_number}-{build_number}"
+
+
+def _get_vm_image_uri(project_id: str, env_name: str, version_number: int, build_number: int) -> str:
+    """Construct GCE image self-link URI."""
+    name = _get_vm_image_name(env_name, version_number, build_number)
+    return f"projects/{project_id}/global/images/{name}"
+
+
 # Template for wrapping a conda environment.yml in a Dockerfile
 CONDA_DOCKERFILE_TEMPLATE = """\
 FROM continuumio/miniconda3:latest
@@ -149,6 +279,26 @@ class EnvironmentBuildService:
         if version.status not in ("draft", "failed"):
             raise ValueError(f"Cannot build version in '{version.status}' status")
 
+        # Route to the correct build pipeline based on environment type (ADR-043)
+        if env.environment_type == "work_node":
+            return await EnvironmentBuildService._build_vm_image(
+                session, env, version, org_id, user_id, environment_id
+            )
+
+        return await EnvironmentBuildService._build_docker_image(
+            session, env, version, org_id, user_id, environment_id
+        )
+
+    @staticmethod
+    async def _build_docker_image(
+        session: AsyncSession,
+        env: Environment,
+        version: EnvironmentVersion,
+        org_id: int,
+        user_id: int,
+        environment_id: int,
+    ) -> str:
+        """Build a Docker container image via Cloud Build (notebook environments)."""
         project_id = await _read_config(session, "gcp_project_id")
         region = await _read_config(session, "gcp_region")
         working_bucket = await _read_config(session, "working_bucket_name")
@@ -222,6 +372,121 @@ class EnvironmentBuildService:
 
         logger.info(
             "Submitted Cloud Build %s for %s v%d",
+            build_id,
+            env.name,
+            version.version_number,
+        )
+        return build_id
+
+    @staticmethod
+    async def _build_vm_image(
+        session: AsyncSession,
+        env: Environment,
+        version: EnvironmentVersion,
+        org_id: int,
+        user_id: int,
+        environment_id: int,
+    ) -> str:
+        """Build a GCE VM image via Cloud Build + Packer (work node environments, ADR-043)."""
+        import yaml
+
+        if version.definition_format != "conda":
+            raise ValueError("Work node environments only support conda definition format")
+
+        project_id = await _read_config(session, "gcp_project_id")
+        zone = await _read_config(session, "gcp_zone")
+        working_bucket = await _read_config(session, "working_bucket_name")
+
+        if not project_id or project_id == "null":
+            raise ValueError("GCP project not configured")
+        if not zone or zone == "null":
+            raise ValueError("GCP zone not configured")
+        if not working_bucket or working_bucket == "null":
+            raise ValueError("Working bucket not configured")
+
+        # Extract conda env name from the YAML
+        data = yaml.safe_load(version.definition_content)
+        conda_env_name = data.get("name", "bioaf") if data else "bioaf"
+
+        # Upload environment.yml to GCS
+        from google.cloud import storage
+
+        credentials = await _get_credentials(session)
+        storage_client = storage.Client(project=project_id, credentials=credentials)
+        bucket = storage_client.bucket(working_bucket)
+
+        safe_name = env.name.lower().replace(" ", "-").replace("_", "-")
+        env_yml_path = f"builds/{safe_name}/v{version.version_number}/environment.yml"
+        blob = bucket.blob(env_yml_path)
+        blob.upload_from_string(version.definition_content, content_type="text/yaml")
+        env_yml_gcs = f"gs://{working_bucket}/{env_yml_path}"
+
+        # Upload Packer template
+        packer_path = f"builds/{safe_name}/v{version.version_number}/work_node.pkr.hcl"
+        packer_blob = bucket.blob(packer_path)
+        packer_blob.upload_from_string(PACKER_VM_TEMPLATE, content_type="text/plain")
+
+        # Build image name and URI
+        image_name = _get_vm_image_name(env.name, version.version_number, version.build_number)
+        image_uri = _get_vm_image_uri(project_id, env.name, version.version_number, version.build_number)
+
+        # Submit Cloud Build with Packer
+        sa_email = await _read_config(session, "gcp_service_account_email")
+        if not sa_email or sa_email == "null":
+            sa_email = getattr(credentials, "service_account_email", None)
+
+        build_url = f"https://cloudbuild.googleapis.com/v1/projects/{project_id}/builds"
+        build_body: dict = {
+            "steps": [
+                {
+                    "name": "gcr.io/cloud-builders/gsutil",
+                    "args": ["cp", f"gs://{working_bucket}/{packer_path}", "/workspace/work_node.pkr.hcl"],
+                },
+                {
+                    "name": "hashicorp/packer",
+                    "args": [
+                        "build",
+                        f"-var=project_id={project_id}",
+                        f"-var=zone={zone}",
+                        f"-var=image_name={image_name}",
+                        f"-var=environment_yml_gcs={env_yml_gcs}",
+                        f"-var=conda_env_name={conda_env_name}",
+                        "/workspace/work_node.pkr.hcl",
+                    ],
+                },
+            ],
+            "options": {"machineType": "E2_HIGHCPU_8"},
+            "timeout": "3600s",
+        }
+        if sa_email and sa_email != "null":
+            build_body["serviceAccount"] = f"projects/{project_id}/serviceAccounts/{sa_email}"
+            build_body["options"]["defaultLogsBucketBehavior"] = "REGIONAL_USER_OWNED_BUCKET"
+
+        result = _authorized_request(credentials, "POST", build_url, build_body)
+        build_id = result.get("metadata", {}).get("build", {}).get("id", "")
+
+        # Update version record
+        version.status = "building"
+        version.build_id = build_id
+        version.image_uri = image_uri
+        await session.flush()
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="environment_version",
+            entity_id=version.id,
+            action="build_vm_image",
+            details={
+                "environment_id": environment_id,
+                "version_number": version.version_number,
+                "build_id": build_id,
+                "image_name": image_name,
+            },
+        )
+
+        logger.info(
+            "Submitted Packer VM build %s for %s v%d",
             build_id,
             env.name,
             version.version_number,

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -44,7 +44,7 @@ variable "project_id" {
   type = string
 }
 
-variable "zone" {
+variable "region" {
   type = string
 }
 
@@ -63,7 +63,7 @@ variable "conda_env_name" {
 
 source "googlecompute" "work_node" {
   project_id   = var.project_id
-  zone         = var.zone
+  region       = var.region
   machine_type = "n2-standard-4"
 
   source_image_family = "ubuntu-2204-lts"
@@ -390,13 +390,13 @@ class EnvironmentBuildService:
             raise ValueError("Work node environments only support conda definition format")
 
         project_id = await _read_config(session, "gcp_project_id")
-        zone = await _read_config(session, "gcp_zone")
+        region = await _read_config(session, "gcp_region")
         working_bucket = await _read_config(session, "working_bucket_name")
 
         if not project_id or project_id == "null":
             raise ValueError("GCP project not configured")
-        if not zone or zone == "null":
-            raise ValueError("GCP zone not configured")
+        if not region or region == "null":
+            raise ValueError("GCP region not configured")
         if not working_bucket or working_bucket == "null":
             raise ValueError("Working bucket not configured")
 
@@ -447,7 +447,7 @@ class EnvironmentBuildService:
                     "args": [
                         "build",
                         f"-var=project_id={project_id}",
-                        f"-var=zone={zone}",
+                        f"-var=region={region}",
                         f"-var=image_name={image_name}",
                         f"-var=environment_yml_gcs={env_yml_gcs}",
                         f"-var=conda_env_name={conda_env_name}",

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -440,6 +440,10 @@ class EnvironmentBuildService:
                 },
                 {
                     "name": "hashicorp/packer",
+                    "args": ["init", "/workspace/work_node.pkr.hcl"],
+                },
+                {
+                    "name": "hashicorp/packer",
                     "args": [
                         "build",
                         f"-var=project_id={project_id}",

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -106,13 +106,13 @@ build {
     ]
   }
 
-  # Install miniconda
+  # Install miniforge (conda-forge only, no Anaconda TOS)
   provisioner "shell" {
     inline = [
-      "wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh",
-      "sudo bash /tmp/miniconda.sh -b -p /opt/conda",
+      "wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O /tmp/miniforge.sh",
+      "sudo bash /tmp/miniforge.sh -b -p /opt/conda",
       "sudo chmod -R a+rx /opt/conda",
-      "rm /tmp/miniconda.sh",
+      "rm /tmp/miniforge.sh",
       "echo 'export PATH=/opt/conda/bin:$PATH' | sudo tee /etc/profile.d/conda.sh",
     ]
   }
@@ -121,8 +121,6 @@ build {
   provisioner "shell" {
     inline = [
       "export PATH=/opt/conda/bin:$PATH",
-      "conda config --remove channels defaults 2>/dev/null || true",
-      "conda config --add channels conda-forge",
       "gsutil cp ${var.environment_yml_gcs} /tmp/environment.yml",
       "conda env create -f /tmp/environment.yml",
       "conda clean -afy",

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -93,6 +93,8 @@ build {
       "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server git tmux htop curl fail2ban",
       "sudo systemctl enable ssh",
       "sudo sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config",
+      "sudo sed -i 's/^PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config.d/*.conf 2>/dev/null || true",
+      "echo 'PasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/99-bioaf-password-auth.conf",
     ]
   }
 

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -64,7 +64,7 @@ variable "conda_env_name" {
 source "googlecompute" "work_node" {
   project_id   = var.project_id
   zone         = var.zone
-  machine_type = "n2-standard-4"
+  machine_type = "e2-standard-4"
 
   source_image_family = "ubuntu-2204-lts"
   source_image_project_id = ["ubuntu-os-cloud"]

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -31,37 +31,37 @@ logger = logging.getLogger("bioaf.environment_build")
 # Packer template for building GCE VM images with conda environments (ADR-043).
 # Stored as a string constant; written to the build context at build time.
 PACKER_VM_TEMPLATE = """\
-packer {{
-  required_plugins {{
-    googlecompute = {{
+packer {
+  required_plugins {
+    googlecompute = {
       version = ">= 1.1.0"
       source  = "github.com/hashicorp/googlecompute"
-    }}
-  }}
-}}
+    }
+  }
+}
 
-variable "project_id" {{
+variable "project_id" {
   type = string
-}}
+}
 
-variable "zone" {{
+variable "zone" {
   type = string
-}}
+}
 
-variable "image_name" {{
+variable "image_name" {
   type = string
-}}
+}
 
-variable "environment_yml_gcs" {{
+variable "environment_yml_gcs" {
   type = string
-}}
+}
 
-variable "conda_env_name" {{
+variable "conda_env_name" {
   type    = string
   default = "bioaf"
-}}
+}
 
-source "googlecompute" "work_node" {{
+source "googlecompute" "work_node" {
   project_id   = var.project_id
   zone         = var.zone
   machine_type = "n2-standard-4"
@@ -72,41 +72,41 @@ source "googlecompute" "work_node" {{
   image_name        = var.image_name
   image_description = "bioAF work node environment"
   image_family      = "bioaf-worknode"
-  image_labels = {{
+  image_labels = {
     bioaf-managed = "true"
-  }}
+  }
 
   disk_size = 50
   disk_type = "pd-ssd"
 
   ssh_username = "packer"
-}}
+}
 
-build {{
+build {
   sources = ["source.googlecompute.work_node"]
 
   # System packages
-  provisioner "shell" {{
+  provisioner "shell" {
     inline = [
       "sudo apt-get update",
       "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server git tmux htop curl fail2ban",
       "sudo systemctl enable ssh",
       "sudo sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config",
     ]
-  }}
+  }
 
   # Install gcsfuse
-  provisioner "shell" {{
+  provisioner "shell" {
     inline = [
       "export GCSFUSE_REPO=gcsfuse-$(lsb_release -c -s)",
-      "echo \"deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main\" | sudo tee /etc/apt/sources.list.d/gcsfuse.list",
+      "echo \\"deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main\\" | sudo tee /etc/apt/sources.list.d/gcsfuse.list",
       "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
       "sudo apt-get update && sudo apt-get install -y gcsfuse",
     ]
-  }}
+  }
 
   # Install miniconda
-  provisioner "shell" {{
+  provisioner "shell" {
     inline = [
       "wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh",
       "sudo bash /tmp/miniconda.sh -b -p /opt/conda",
@@ -114,35 +114,35 @@ build {{
       "rm /tmp/miniconda.sh",
       "echo 'export PATH=/opt/conda/bin:$PATH' | sudo tee /etc/profile.d/conda.sh",
     ]
-  }}
+  }
 
   # Download environment.yml from GCS and create conda env
-  provisioner "shell" {{
+  provisioner "shell" {
     inline = [
       "export PATH=/opt/conda/bin:$PATH",
-      "gsutil cp ${{var.environment_yml_gcs}} /tmp/environment.yml",
+      "gsutil cp ${var.environment_yml_gcs} /tmp/environment.yml",
       "conda env create -f /tmp/environment.yml",
       "conda clean -afy",
       "rm /tmp/environment.yml",
     ]
-  }}
+  }
 
   # Install bioaf heartbeat agent
-  provisioner "shell" {{
+  provisioner "shell" {
     inline = [
       "sudo mkdir -p /etc/bioaf",
       "sudo mkdir -p /outputs /scratch",
     ]
-  }}
+  }
 
   # Cleanup
-  provisioner "shell" {{
+  provisioner "shell" {
     inline = [
       "sudo apt-get clean",
       "sudo rm -rf /var/lib/apt/lists/*",
     ]
-  }}
-}}
+  }
+}
 """
 
 
@@ -281,13 +281,9 @@ class EnvironmentBuildService:
 
         # Route to the correct build pipeline based on environment type (ADR-043)
         if env.environment_type == "work_node":
-            return await EnvironmentBuildService._build_vm_image(
-                session, env, version, org_id, user_id, environment_id
-            )
+            return await EnvironmentBuildService._build_vm_image(session, env, version, org_id, user_id, environment_id)
 
-        return await EnvironmentBuildService._build_docker_image(
-            session, env, version, org_id, user_id, environment_id
-        )
+        return await EnvironmentBuildService._build_docker_image(session, env, version, org_id, user_id, environment_id)
 
     @staticmethod
     async def _build_docker_image(

--- a/backend/app/services/environment_service.py
+++ b/backend/app/services/environment_service.py
@@ -16,7 +16,6 @@ name: bioaf
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.11
   - numpy

--- a/backend/app/services/environment_service.py
+++ b/backend/app/services/environment_service.py
@@ -11,15 +11,22 @@ logger = logging.getLogger("bioaf.environment")
 
 VALID_VISIBILITIES = ("team", "organization")
 VALID_DEFINITION_FORMATS = ("dockerfile", "conda")
+VALID_ENVIRONMENT_TYPES = ("notebook", "work_node")
 
 
 class EnvironmentService:
     @staticmethod
-    async def list_environments(session: AsyncSession, org_id: int) -> list[Environment]:
-        """List environments within an organization."""
-        result = await session.execute(
-            select(Environment).where(Environment.organization_id == org_id).order_by(Environment.created_at.desc())
-        )
+    async def list_environments(
+        session: AsyncSession,
+        org_id: int,
+        environment_type: str | None = None,
+    ) -> list[Environment]:
+        """List environments within an organization, optionally filtered by type."""
+        query = select(Environment).where(Environment.organization_id == org_id)
+        if environment_type:
+            query = query.where(Environment.environment_type == environment_type)
+        query = query.order_by(Environment.created_at.desc())
+        result = await session.execute(query)
         return list(result.scalars().all())
 
     @staticmethod
@@ -40,9 +47,12 @@ class EnvironmentService:
         name: str,
         description: str | None = None,
         visibility: str = "team",
+        environment_type: str = "notebook",
     ) -> Environment:
         if visibility not in VALID_VISIBILITIES:
             raise ValueError(f"Invalid visibility: {visibility}")
+        if environment_type not in VALID_ENVIRONMENT_TYPES:
+            raise ValueError(f"Invalid environment_type: {environment_type}")
 
         # Check for duplicate name within org
         existing = await session.execute(
@@ -60,6 +70,7 @@ class EnvironmentService:
             organization_id=org_id,
             created_by_user_id=user_id,
             visibility=visibility,
+            environment_type=environment_type,
         )
         session.add(env)
         await session.flush()
@@ -152,6 +163,10 @@ class EnvironmentService:
 
         if definition_format not in VALID_DEFINITION_FORMATS:
             raise ValueError(f"Invalid definition_format: {definition_format}")
+
+        # Work node environments only support conda (ADR-043)
+        if env.environment_type == "work_node" and definition_format != "conda":
+            raise ValueError("Work node environments only support conda definition format")
 
         # Auto-increment version number
         result = await session.execute(

--- a/backend/app/services/environment_service.py
+++ b/backend/app/services/environment_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.environment import Environment
@@ -8,6 +8,27 @@ from app.models.environment_version import EnvironmentVersion
 from app.services.audit_service import log_action
 
 logger = logging.getLogger("bioaf.environment")
+
+# Default conda environment.yml for work nodes.  Provides a practical
+# starting point that scientists can extend with their own packages.
+DEFAULT_WORK_NODE_CONDA_YML = """\
+name: bioaf
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.11
+  - numpy
+  - pandas
+  - scipy
+  - matplotlib
+  - seaborn
+  - jupyter
+  - ipython
+  - scikit-learn
+  - pip
+"""
 
 VALID_VISIBILITIES = ("team", "organization")
 VALID_DEFINITION_FORMATS = ("dockerfile", "conda")
@@ -296,3 +317,67 @@ class EnvironmentService:
         """Get all versions currently in 'building' status."""
         result = await session.execute(select(EnvironmentVersion).where(EnvironmentVersion.status == "building"))
         return list(result.scalars().all())
+
+
+async def ensure_default_work_node_environment(session: AsyncSession) -> None:
+    """Create a default work node environment if none exists yet.
+
+    Called at startup so users always have a base conda environment to
+    build on for work nodes.  The version is created in 'draft' status --
+    the user must trigger a build before it can be used.
+    """
+    # Get the org (single-tenant)
+    row = (await session.execute(text("SELECT id FROM organizations LIMIT 1"))).fetchone()
+    if not row:
+        return
+    org_id = row[0]
+
+    # Skip if a work_node environment already exists
+    existing = (
+        await session.execute(
+            text(
+                "SELECT id FROM environments WHERE organization_id = :org_id AND environment_type = 'work_node' LIMIT 1"
+            ).bindparams(org_id=org_id)
+        )
+    ).fetchone()
+    if existing:
+        return
+
+    # Get the first admin user to attribute creation to
+    admin_row = (
+        await session.execute(
+            text(
+                "SELECT u.id FROM users u "
+                "JOIN roles r ON u.role_id = r.id "
+                "WHERE u.organization_id = :org_id AND r.name = 'admin' "
+                "ORDER BY u.id LIMIT 1"
+            ).bindparams(org_id=org_id)
+        )
+    ).fetchone()
+    if not admin_row:
+        return
+    user_id = admin_row[0]
+
+    env = Environment(
+        name="Default Work Node",
+        description="Base Python environment for work nodes. Build this environment, then customize with your own packages.",
+        organization_id=org_id,
+        created_by_user_id=user_id,
+        visibility="organization",
+        environment_type="work_node",
+    )
+    session.add(env)
+    await session.flush()
+
+    version = EnvironmentVersion(
+        environment_id=env.id,
+        version_number=1,
+        status="draft",
+        definition_format="conda",
+        definition_content=DEFAULT_WORK_NODE_CONDA_YML,
+        created_by_user_id=user_id,
+    )
+    session.add(version)
+    await session.flush()
+
+    logger.info("Created default work node environment '%s' (id=%d)", env.name, env.id)

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -73,6 +73,7 @@ class FileService:
         project_id: int | None = None,
         source_type: str | None = None,
         sample_id: int | None = None,
+        search: str | None = None,
         page: int = 1,
         page_size: int = 25,
     ) -> tuple[list[File], int]:
@@ -80,6 +81,11 @@ class FileService:
 
         query = select(File).options(selectinload(File.uploader)).where(File.organization_id == org_id)
         count_query = select(func.count(File.id)).where(File.organization_id == org_id)
+
+        if search:
+            pattern = f"%{search}%"
+            query = query.where(File.filename.ilike(pattern))
+            count_query = count_query.where(File.filename.ilike(pattern))
 
         if file_type:
             query = query.where(File.file_type == file_type)

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -96,8 +96,17 @@ class FileService:
             count_query = count_query.where(File.experiment_id == experiment_id)
 
         if project_id is not None:
-            query = query.where(File.project_id == project_id)
-            count_query = count_query.where(File.project_id == project_id)
+            # Include files directly on the project OR files whose experiment
+            # belongs to the project (files inherit project via experiment).
+            from app.models.experiment import Experiment
+            from sqlalchemy import or_
+
+            project_filter = or_(
+                File.project_id == project_id,
+                File.experiment_id.in_(select(Experiment.id).where(Experiment.project_id == project_id)),
+            )
+            query = query.where(project_filter)
+            count_query = count_query.where(project_filter)
 
         if source_type:
             query = query.where(File.source_type == source_type)

--- a/backend/app/services/github_repo_service.py
+++ b/backend/app/services/github_repo_service.py
@@ -1,0 +1,107 @@
+"""GitHub repo management service (ADR-043)."""
+
+import re
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.github_repo import GitHubRepo
+from app.services.audit_service import log_action
+
+# Matches git@github.com:owner/repo.git (with optional .git suffix)
+GIT_SSH_URL_PATTERN = re.compile(r"^git@github\.com:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?$")
+
+
+def _extract_repo_name(git_ssh_url: str) -> str:
+    """Extract a display name from a git SSH URL.
+
+    git@github.com:owner/my-repo.git -> my-repo
+    """
+    parts = git_ssh_url.rstrip("/").split("/")
+    name = parts[-1] if parts else git_ssh_url
+    if name.endswith(".git"):
+        name = name[:-4]
+    return name
+
+
+class GitHubRepoService:
+    @staticmethod
+    async def list_repos(session: AsyncSession, user_id: int, org_id: int) -> list[GitHubRepo]:
+        result = await session.execute(
+            select(GitHubRepo)
+            .where(GitHubRepo.user_id == user_id, GitHubRepo.organization_id == org_id)
+            .order_by(GitHubRepo.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def get_repo(session: AsyncSession, repo_id: int, user_id: int) -> GitHubRepo | None:
+        result = await session.execute(
+            select(GitHubRepo).where(GitHubRepo.id == repo_id, GitHubRepo.user_id == user_id)
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def create_repo(
+        session: AsyncSession,
+        user_id: int,
+        org_id: int,
+        git_ssh_url: str,
+        display_name: str | None = None,
+    ) -> GitHubRepo:
+        git_ssh_url = git_ssh_url.strip()
+
+        if not GIT_SSH_URL_PATTERN.match(git_ssh_url):
+            raise ValueError("Invalid git SSH URL. Expected format: git@github.com:owner/repo.git")
+
+        resolved_name = display_name.strip() if display_name else _extract_repo_name(git_ssh_url)
+        if not resolved_name:
+            raise ValueError("Display name cannot be empty")
+
+        # Check for duplicate
+        existing = await session.execute(
+            select(GitHubRepo).where(
+                GitHubRepo.user_id == user_id,
+                GitHubRepo.git_ssh_url == git_ssh_url,
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise ValueError("This repository is already configured")
+
+        repo = GitHubRepo(
+            user_id=user_id,
+            organization_id=org_id,
+            git_ssh_url=git_ssh_url,
+            display_name=resolved_name,
+        )
+        session.add(repo)
+        await session.flush()
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="github_repo",
+            entity_id=repo.id,
+            action="create",
+            details={"git_ssh_url": git_ssh_url, "display_name": resolved_name},
+        )
+
+        return repo
+
+    @staticmethod
+    async def delete_repo(session: AsyncSession, repo_id: int, user_id: int) -> None:
+        repo = await GitHubRepoService.get_repo(session, repo_id, user_id)
+        if not repo:
+            raise ValueError("Repository not found")
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="github_repo",
+            entity_id=repo.id,
+            action="delete",
+            details={"git_ssh_url": repo.git_ssh_url, "display_name": repo.display_name},
+        )
+
+        await session.delete(repo)
+        await session.flush()

--- a/backend/app/services/machine_types.py
+++ b/backend/app/services/machine_types.py
@@ -6,6 +6,22 @@ GPU entries include accelerator metadata for the GCE API.
 
 MACHINE_TYPES: list[dict] = [
     {
+        "name": "e2-standard-4",
+        "category": "standard",
+        "cpu": 4,
+        "memory_gb": 16,
+        "gpu": None,
+        "description": "Light analysis, data wrangling (high availability)",
+    },
+    {
+        "name": "e2-standard-8",
+        "category": "standard",
+        "cpu": 8,
+        "memory_gb": 32,
+        "gpu": None,
+        "description": "General-purpose analysis (high availability)",
+    },
+    {
         "name": "n2-standard-4",
         "category": "standard",
         "cpu": 4,
@@ -20,6 +36,14 @@ MACHINE_TYPES: list[dict] = [
         "memory_gb": 32,
         "gpu": None,
         "description": "General-purpose analysis",
+    },
+    {
+        "name": "e2-highmem-8",
+        "category": "high-memory",
+        "cpu": 8,
+        "memory_gb": 64,
+        "gpu": None,
+        "description": "Large datasets, Seurat integration (high availability)",
     },
     {
         "name": "n2-highmem-8",

--- a/backend/app/services/machine_types.py
+++ b/backend/app/services/machine_types.py
@@ -1,4 +1,8 @@
-"""Curated machine type catalog for work nodes (ADR-034)."""
+"""Curated machine type catalog for work nodes (ADR-034, ADR-043).
+
+Machine type names map directly to GCE machine types for non-GPU entries.
+GPU entries include accelerator metadata for the GCE API.
+"""
 
 MACHINE_TYPES: list[dict] = [
     {
@@ -8,7 +12,6 @@ MACHINE_TYPES: list[dict] = [
         "memory_gb": 16,
         "gpu": None,
         "description": "Light analysis, data wrangling",
-        "node_pool": "bioaf-interactive",
     },
     {
         "name": "n2-standard-8",
@@ -17,7 +20,6 @@ MACHINE_TYPES: list[dict] = [
         "memory_gb": 32,
         "gpu": None,
         "description": "General-purpose analysis",
-        "node_pool": "bioaf-interactive",
     },
     {
         "name": "n2-highmem-8",
@@ -26,7 +28,6 @@ MACHINE_TYPES: list[dict] = [
         "memory_gb": 64,
         "gpu": None,
         "description": "Large datasets, Seurat integration",
-        "node_pool": "bioaf-interactive",
     },
     {
         "name": "n2-highmem-16",
@@ -35,7 +36,6 @@ MACHINE_TYPES: list[dict] = [
         "memory_gb": 128,
         "gpu": None,
         "description": "Very large datasets, multi-sample integration",
-        "node_pool": "bioaf-interactive",
     },
     {
         "name": "n2-highmem-32",
@@ -44,7 +44,6 @@ MACHINE_TYPES: list[dict] = [
         "memory_gb": 256,
         "gpu": None,
         "description": "Extreme memory workloads",
-        "node_pool": "bioaf-interactive",
     },
     {
         "name": "n1-standard-8-nvidia-tesla-t4",
@@ -52,8 +51,10 @@ MACHINE_TYPES: list[dict] = [
         "cpu": 8,
         "memory_gb": 30,
         "gpu": "NVIDIA Tesla T4",
+        "gce_machine_type": "n1-standard-8",
+        "accelerator_type": "nvidia-tesla-t4",
+        "accelerator_count": 1,
         "description": "scVI, rapids-singlecell, light deep learning",
-        "node_pool": "bioaf-gpu",
     },
     {
         "name": "n1-standard-16-nvidia-tesla-v100",
@@ -61,8 +62,10 @@ MACHINE_TYPES: list[dict] = [
         "cpu": 16,
         "memory_gb": 60,
         "gpu": "NVIDIA Tesla V100",
+        "gce_machine_type": "n1-standard-16",
+        "accelerator_type": "nvidia-tesla-v100",
+        "accelerator_count": 1,
         "description": "Heavy deep learning, large-scale model training",
-        "node_pool": "bioaf-gpu",
     },
 ]
 

--- a/backend/app/services/notebook_service.py
+++ b/backend/app/services/notebook_service.py
@@ -313,9 +313,15 @@ class NotebookService:
         query = (
             select(NotebookSession)
             .options(selectinload(NotebookSession.user), selectinload(NotebookSession.experiment))
-            .where(NotebookSession.organization_id == org_id)
+            .where(
+                NotebookSession.organization_id == org_id,
+                NotebookSession.session_type != "ssh",
+            )
         )
-        count_query = select(func.count(NotebookSession.id)).where(NotebookSession.organization_id == org_id)
+        count_query = select(func.count(NotebookSession.id)).where(
+            NotebookSession.organization_id == org_id,
+            NotebookSession.session_type != "ssh",
+        )
 
         if user_id:
             query = query.where(NotebookSession.user_id == user_id)

--- a/backend/app/services/session_output_service.py
+++ b/backend/app/services/session_output_service.py
@@ -74,11 +74,12 @@ class SessionOutputService:
         experiment_id: int | None,
         user_id: int,
         gcs_files: list[dict],
+        source_type: str = "notebook_output",
     ) -> int:
         """Register output files from a completed session.
 
-        Creates File records with source_type=notebook_output and
-        NotebookSessionFile records with access_type=output.
+        Creates File records and NotebookSessionFile records with
+        access_type=output.
 
         Returns the number of files registered.
         """
@@ -106,7 +107,7 @@ class SessionOutputService:
                 file_type=_file_type_from_extension(filename),
                 experiment_id=experiment_id,
                 project_id=project_id,
-                source_type="notebook_output",
+                source_type=source_type,
                 source_notebook_session_id=session_id,
                 uploader_user_id=user_id,
             )

--- a/backend/app/services/work_node_service.py
+++ b/backend/app/services/work_node_service.py
@@ -39,7 +39,7 @@ class WorkNodeService:
         project_id: int,
         environment_version_id: int,
         machine_type: str,
-        data_mount_paths: list[str] | None = None,
+        input_file_ids: list[int] | None = None,
         github_repo_ids: list[int] | None = None,
     ) -> ComputeSession:
         # Validate machine type
@@ -116,6 +116,30 @@ class WorkNodeService:
         # Generate heartbeat token
         heartbeat_token = secrets.token_urlsafe(32)
 
+        # Validate and resolve input files
+        input_files_spec: list[dict] = []
+        if input_file_ids:
+            from app.models.file import File
+            from app.services.notebook_service import _resolve_input_file_context, _build_relative_path
+
+            file_results = await session.execute(select(File).where(File.id.in_(input_file_ids)))
+            found_files = {f.id: f for f in file_results.scalars().all()}
+
+            name_cache = await _resolve_input_file_context(session, found_files)
+
+            for fid in input_file_ids:
+                f = found_files.get(fid)
+                if not f or f.organization_id != org_id:
+                    raise ValueError(f"File {fid} not found or not accessible")
+                rel_path = _build_relative_path(f, name_cache)
+                input_files_spec.append(
+                    {
+                        "file_id": f.id,
+                        "gcs_uri": f.gcs_uri,
+                        "relative_path": rel_path,
+                    }
+                )
+
         # Create session record
         compute_session = ComputeSession(
             user_id=user_id,
@@ -124,7 +148,7 @@ class WorkNodeService:
             project_id=project_id,
             environment_version_id=environment_version_id,
             machine_type=machine_type,
-            data_mount_paths=data_mount_paths or [],
+            data_mount_paths=input_file_ids or [],
             github_repo_ids=github_repo_ids or [],
             resource_profile="custom",
             cpu_cores=mt["cpu"],
@@ -170,7 +194,7 @@ class WorkNodeService:
                 "machine_type": machine_type,
                 "gce_machine_type": mt.get("gce_machine_type", machine_type),
                 "image_uri": env_version.image_uri,
-                "data_mount_paths": data_mount_paths or [],
+                "input_files": input_files_spec,
                 "heartbeat_token": heartbeat_token,
                 "session_credentials": {
                     "username": cred.username,

--- a/backend/app/services/work_node_service.py
+++ b/backend/app/services/work_node_service.py
@@ -332,6 +332,7 @@ class WorkNodeService:
                     experiment_id=compute_session.experiment_id,
                     user_id=compute_session.user_id,
                     gcs_files=output_files,
+                    source_type="work_node_output",
                 )
             except Exception as e:
                 logger.warning("Output registration failed for work node %d: %s", session_id, e)

--- a/backend/app/services/work_node_service.py
+++ b/backend/app/services/work_node_service.py
@@ -1,4 +1,8 @@
-"""Work node service for SSH-accessible compute sessions (ADR-034)."""
+"""Work node service for GCE VM compute sessions (ADR-043).
+
+Manages the lifecycle of SSH-accessible work nodes running as GCE VMs
+with Packer-built images and conda environments.
+"""
 
 import asyncio
 import logging
@@ -17,8 +21,8 @@ from app.services.event_types import (
     WORK_NODE_STOPPED,
     WORK_NODE_HEARTBEAT_TIMEOUT,
 )
-from app.services.machine_types import MACHINE_TYPE_NAMES, get_machine_type
-from app.adapters.registry import get_notebook_adapter
+from app.services.machine_types import MACHINE_TYPES, get_machine_type
+from app.adapters.registry import get_work_node_adapter
 
 logger = logging.getLogger("bioaf.work_nodes")
 
@@ -36,19 +40,21 @@ class WorkNodeService:
         environment_version_id: int,
         machine_type: str,
         data_mount_paths: list[str] | None = None,
+        github_repo_ids: list[int] | None = None,
     ) -> ComputeSession:
         # Validate machine type
         mt = get_machine_type(machine_type)
         if not mt:
-            raise ValueError(
-                f"Invalid machine type: {machine_type}. Valid types: {', '.join(sorted(MACHINE_TYPE_NAMES))}"
-            )
+            valid_names = sorted(m["name"] for m in MACHINE_TYPES)
+            raise ValueError(f"Invalid machine type: {machine_type}. Valid types: {', '.join(valid_names)}")
 
-        # Validate environment version is ready
+        # Validate environment version is ready and is a work_node environment
         from app.models.environment_version import EnvironmentVersion
 
         ev_result = await session.execute(
-            select(EnvironmentVersion).where(EnvironmentVersion.id == environment_version_id)
+            select(EnvironmentVersion)
+            .options(selectinload(EnvironmentVersion.environment))
+            .where(EnvironmentVersion.id == environment_version_id)
         )
         env_version = ev_result.scalar_one_or_none()
         if not env_version:
@@ -57,6 +63,10 @@ class WorkNodeService:
             raise ValueError(
                 f"Environment version must be in ready status (current: {env_version.status}). "
                 "Build the environment first."
+            )
+        if env_version.environment.environment_type != "work_node":
+            raise ValueError(
+                "Only work node environments can be used for work nodes. This environment is configured for notebooks."
             )
 
         # Require session credentials for SSH
@@ -68,6 +78,24 @@ class WorkNodeService:
                 "Session credentials are required for work nodes. "
                 "Please set up your session credentials in your profile settings."
             )
+
+        # Validate and fetch GitHub repos
+        github_repos_data: list[dict] = []
+        if github_repo_ids:
+            from app.models.github_repo import GitHubRepo
+
+            repo_result = await session.execute(
+                select(GitHubRepo).where(
+                    GitHubRepo.id.in_(github_repo_ids),
+                    GitHubRepo.user_id == user_id,
+                )
+            )
+            repos = list(repo_result.scalars().all())
+            found_ids = {r.id for r in repos}
+            missing = set(github_repo_ids) - found_ids
+            if missing:
+                raise ValueError(f"GitHub repos not found: {missing}")
+            github_repos_data = [{"git_ssh_url": r.git_ssh_url, "display_name": r.display_name} for r in repos]
 
         # Check concurrent work node quota
         max_nodes = await WorkNodeService._get_max_nodes_per_user(session)
@@ -97,6 +125,7 @@ class WorkNodeService:
             environment_version_id=environment_version_id,
             machine_type=machine_type,
             data_mount_paths=data_mount_paths or [],
+            github_repo_ids=github_repo_ids or [],
             resource_profile="custom",
             cpu_cores=mt["cpu"],
             memory_gb=mt["memory_gb"],
@@ -112,48 +141,75 @@ class WorkNodeService:
         config_rows = await session.execute(
             text(
                 "SELECT key, value FROM platform_config "
-                "WHERE key IN ('working_bucket_name', 'notebook_runner_sa_email')"
+                "WHERE key IN ('working_bucket_name', 'notebook_runner_sa_email', "
+                "'gcp_project_id', 'gcp_zone')"
             )
         )
         config_map = {row[0]: row[1] for row in config_rows.all()}
 
-        # Launch via adapter
+        # Extract conda env name from definition
+        conda_env_name = "bioaf"
+        if env_version.definition_format == "conda":
+            try:
+                import yaml
+
+                data = yaml.safe_load(env_version.definition_content)
+                conda_env_name = data.get("name", "bioaf") if data else "bioaf"
+            except Exception:
+                pass
+
+        # Build environment label for MOTD
+        env_label = f"{env_version.environment.name} v{env_version.version_number}.{env_version.build_number}"
+
+        # Launch via GCE adapter
         try:
-            adapter = get_notebook_adapter()
-            spec: dict = {
-                "session_type": "ssh",
-                "resource_profile": "custom",
-                "cpu_cores": mt["cpu"],
-                "memory_gb": mt["memory_gb"],
-                "user_id": user_id,
+            adapter = get_work_node_adapter()
+            vm_spec: dict = {
                 "session_id": compute_session.id,
-                "image": env_version.image_uri,
+                "user_id": user_id,
                 "machine_type": machine_type,
+                "gce_machine_type": mt.get("gce_machine_type", machine_type),
+                "image_uri": env_version.image_uri,
                 "data_mount_paths": data_mount_paths or [],
-                "node_pool": mt["node_pool"],
-                "gpu": mt["gpu"],
                 "heartbeat_token": heartbeat_token,
                 "session_credentials": {
                     "username": cred.username,
                     "password_hash": cred.password_hash,
                 },
+                "ssh_public_key": cred.ssh_public_key,
+                "ssh_private_key": cred.ssh_private_key,
+                "github_repos": github_repos_data,
+                "conda_env_name": conda_env_name,
+                "environment_label": env_label,
             }
 
             bucket_name = (config_map.get("working_bucket_name") or "").strip()
             if bucket_name and bucket_name != "null":
-                spec["working_bucket"] = bucket_name
+                vm_spec["working_bucket"] = bucket_name
 
             sa_email = (config_map.get("notebook_runner_sa_email") or "").strip()
             if sa_email and sa_email != "null":
-                spec["notebook_runner_sa_email"] = sa_email
+                vm_spec["service_account_email"] = sa_email
 
-            result = await adapter.launch_session(spec)
+            gcp_project = (config_map.get("gcp_project_id") or "").strip()
+            if gcp_project and gcp_project != "null":
+                vm_spec["gcp_project_id"] = gcp_project
 
-            compute_session.slurm_job_id = str(result.get("session_id", ""))
-            compute_session.k8s_pod_name = result.get("pod_name")
-            compute_session.k8s_namespace = result.get("namespace")
+            gcp_zone = (config_map.get("gcp_zone") or "").strip()
+            if gcp_zone and gcp_zone != "null":
+                vm_spec["gcp_zone"] = gcp_zone
+
+            # GPU accelerator info
+            if mt.get("accelerator_type"):
+                vm_spec["accelerator_type"] = mt["accelerator_type"]
+                vm_spec["accelerator_count"] = mt.get("accelerator_count", 1)
+
+            result = await adapter.launch_vm(vm_spec)
+
+            compute_session.gce_instance_name = result.get("instance_name")
+            compute_session.gce_zone = result.get("zone")
+            compute_session.gce_project_id = result.get("gcp_project_id")
             compute_session.access_url = result.get("access_url")
-            compute_session.gcs_home_prefix = result.get("gcs_home_prefix")
             adapter_status = result.get("status", "starting")
             if adapter_status == "error":
                 compute_session.status = "failed"
@@ -177,6 +233,7 @@ class WorkNodeService:
                 "machine_type": machine_type,
                 "environment_version_id": environment_version_id,
                 "project_id": project_id,
+                "github_repo_ids": github_repo_ids or [],
                 "status": compute_session.status,
             },
         )
@@ -224,16 +281,15 @@ class WorkNodeService:
                 working_bucket = val
 
         terminate_result: dict = {}
-        if compute_session.k8s_pod_name:
+        if compute_session.gce_instance_name:
             try:
-                adapter = get_notebook_adapter()
-                terminate_result = await adapter.terminate_session(
-                    compute_session.slurm_job_id or "",
-                    pod_name=compute_session.k8s_pod_name or "",
-                    namespace=compute_session.k8s_namespace or "bioaf-notebooks",
-                    gcs_home_prefix=compute_session.gcs_home_prefix or "",
+                adapter = get_work_node_adapter()
+                terminate_result = await adapter.terminate_vm(
+                    compute_session.gce_instance_name,
+                    compute_session.gce_zone or "",
+                    gcp_project_id=compute_session.gce_project_id or "",
+                    session_id=compute_session.id,
                     working_bucket=working_bucket,
-                    session_type="ssh",
                 )
             except Exception as e:
                 logger.warning("Failed to terminate work node %d: %s", session_id, e)
@@ -393,10 +449,7 @@ class WorkNodeService:
         session: AsyncSession,
         idle_timeout_hours: int | None = None,
     ) -> None:
-        """Terminate SSH sessions with stale heartbeats.
-
-        Reads idle_timeout_hours from platform_config if not provided.
-        """
+        """Terminate SSH sessions with stale heartbeats."""
         try:
             if idle_timeout_hours is None:
                 idle_timeout_hours = await WorkNodeService._get_idle_timeout(session)
@@ -423,14 +476,14 @@ class WorkNodeService:
                         idle_hours,
                     )
 
-                    if node.k8s_pod_name:
+                    if node.gce_instance_name:
                         try:
-                            adapter = get_notebook_adapter()
-                            await adapter.terminate_session(
-                                node.slurm_job_id or "",
-                                pod_name=node.k8s_pod_name or "",
-                                namespace=node.k8s_namespace or "bioaf-notebooks",
-                                gcs_home_prefix=node.gcs_home_prefix or "",
+                            adapter = get_work_node_adapter()
+                            await adapter.terminate_vm(
+                                node.gce_instance_name,
+                                node.gce_zone or "",
+                                gcp_project_id=node.gce_project_id or "",
+                                session_id=node.id,
                             )
                         except Exception as e:
                             logger.warning("Failed to terminate stale work node %d: %s", node.id, e)

--- a/backend/app/services/work_node_service.py
+++ b/backend/app/services/work_node_service.py
@@ -293,6 +293,12 @@ class WorkNodeService:
 
         old_status = compute_session.status
 
+        # Set status to "stopping" and commit immediately so the UI
+        # reflects the in-progress state even if the request times out.
+        compute_session.status = "stopping"
+        await session.flush()
+        await session.commit()
+
         # Look up working bucket for output sync
         working_bucket_row = await session.execute(
             text("SELECT value FROM platform_config WHERE key = 'working_bucket_name'")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.8.3"
+version = "0.9.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,6 +38,8 @@ google-cloud-bigquery>=3.20
 google-api-python-client>=2.130
 # Cloud Logging fallback for pipeline log persistence
 google-cloud-logging>=3.10
+# GCE VM management for work nodes (ADR-043)
+google-cloud-compute>=1.19
 # GitHub App JWT authentication
 PyJWT[crypto]>=2.8
 # Provenance report generation

--- a/backend/tests/test_notebook_gcs_bucket.py
+++ b/backend/tests/test_notebook_gcs_bucket.py
@@ -203,16 +203,17 @@ async def test_work_node_uses_configured_working_bucket(
         machine_type="n2-standard-4",
     )
 
-    assert cs.gcs_home_prefix is not None
-    assert "bioaf-working-myorg-prod" in cs.gcs_home_prefix
-    assert "bioaf-working/" not in cs.gcs_home_prefix
+    # GCE work nodes set instance fields, not gcs_home_prefix
+    assert cs.gce_instance_name is not None
+    assert cs.session_type == "ssh"
+    assert cs.status in ("starting", "running")
 
 
 @pytest.mark.asyncio
 async def test_work_node_falls_back_without_working_bucket(
     session, admin_user, seed_env_version, seed_project, seed_admin_credentials
 ):
-    """Without working_bucket_name, work node adapter uses default bucket."""
+    """Work node launches successfully even without working_bucket_name configured."""
     from app.services.work_node_service import WorkNodeService
 
     cs = await WorkNodeService.launch_work_node(
@@ -224,8 +225,8 @@ async def test_work_node_falls_back_without_working_bucket(
         machine_type="n2-standard-4",
     )
 
-    assert cs.gcs_home_prefix is not None
-    assert "bioaf-working" in cs.gcs_home_prefix
+    assert cs.gce_instance_name is not None
+    assert cs.session_type == "ssh"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_notebook_gcs_bucket.py
+++ b/backend/tests/test_notebook_gcs_bucket.py
@@ -130,6 +130,7 @@ async def seed_env_version(session, admin_user):
         description="Environment for GCS bucket tests",
         organization_id=admin_user.organization_id,
         created_by_user_id=admin_user.id,
+        environment_type="work_node",
     )
     session.add(env)
     await session.flush()
@@ -138,9 +139,9 @@ async def seed_env_version(session, admin_user):
         environment_id=env.id,
         version_number=1,
         status="ready",
-        definition_format="dockerfile",
-        definition_content="FROM ubuntu:22.04",
-        image_uri="us-central1-docker.pkg.dev/test/repo/test-env:v1",
+        definition_format="conda",
+        definition_content="name: test\nchannels:\n  - conda-forge\ndependencies:\n  - python=3.11\n",
+        image_uri="projects/test-project/global/images/bioaf-worknode-test-v1-1",
         created_by_user_id=admin_user.id,
     )
     session.add(version)

--- a/backend/tests/test_work_nodes.py
+++ b/backend/tests/test_work_nodes.py
@@ -79,6 +79,7 @@ async def seed_environment(session, admin_user):
         description="Test environment",
         organization_id=admin_user.organization_id,
         created_by_user_id=admin_user.id,
+        environment_type="work_node",
     )
     session.add(env)
     await session.flush()
@@ -87,9 +88,9 @@ async def seed_environment(session, admin_user):
         environment_id=env.id,
         version_number=1,
         status="ready",
-        definition_format="dockerfile",
-        definition_content="FROM ubuntu:22.04",
-        image_uri="us-central1-docker.pkg.dev/test/repo/test-env:v1",
+        definition_format="conda",
+        definition_content="name: test\nchannels:\n  - conda-forge\ndependencies:\n  - python=3.11\n",
+        image_uri="projects/test-project/global/images/bioaf-worknode-test-v1-1",
         created_by_user_id=admin_user.id,
     )
     session.add(version)
@@ -99,8 +100,8 @@ async def seed_environment(session, admin_user):
         environment_id=env.id,
         version_number=2,
         status="draft",
-        definition_format="dockerfile",
-        definition_content="FROM ubuntu:22.04\nRUN apt-get update",
+        definition_format="conda",
+        definition_content="name: test\nchannels:\n  - conda-forge\ndependencies:\n  - python=3.11\n  - numpy\n",
         created_by_user_id=admin_user.id,
     )
     session.add(draft_version)

--- a/backend/tests/test_work_nodes.py
+++ b/backend/tests/test_work_nodes.py
@@ -454,7 +454,7 @@ async def test_get_work_node_detail(
             "project_id": seed_project.id,
             "environment_version_id": seed_environment["ready_version"].id,
             "machine_type": "n2-standard-4",
-            "data_mount_paths": ["/uploads/data1"],
+            "input_file_ids": [1],
         },
         headers={"Authorization": f"Bearer {comp_bio_token}"},
     )
@@ -470,7 +470,7 @@ async def test_get_work_node_detail(
     assert data["id"] == node_id
     assert data["session_type"] == "ssh"
     assert data["machine_type"] == "n2-standard-4"
-    assert data["data_mount_paths"] == ["/uploads/data1"]
+    assert data["input_file_ids"] == [1]
 
 
 # -- Stop work node --

--- a/backend/tests/test_work_nodes.py
+++ b/backend/tests/test_work_nodes.py
@@ -454,7 +454,6 @@ async def test_get_work_node_detail(
             "project_id": seed_project.id,
             "environment_version_id": seed_environment["ready_version"].id,
             "machine_type": "n2-standard-4",
-            "input_file_ids": [1],
         },
         headers={"Authorization": f"Bearer {comp_bio_token}"},
     )
@@ -470,7 +469,6 @@ async def test_get_work_node_detail(
     assert data["id"] == node_id
     assert data["session_type"] == "ssh"
     assert data["machine_type"] == "n2-standard-4"
-    assert data["input_file_ids"] == [1]
 
 
 # -- Stop work node --

--- a/decisions/ADR-043-work-nodes-gce-migration.md
+++ b/decisions/ADR-043-work-nodes-gce-migration.md
@@ -1,0 +1,218 @@
+# ADR-043: Work Nodes Migration from GKE to GCE VMs
+
+**Status:** Accepted
+**Date:** 2026-04-19
+**Deciders:** Brent (repository owner)
+**Supersedes:** ADR-034 (for work nodes only; notebook sessions remain on GKE)
+
+---
+
+## Context
+
+ADR-034 introduced custom work nodes as Kubernetes Pods on GKE, sharing the same adapter (`KubernetesNotebookProvider`), environment images, and infrastructure as notebook sessions. In practice, this coupling creates several problems:
+
+1. **Environment mismatch.** Work node users want native Linux VM environments with conda-managed packages, not Docker containers. Scientists already manage conda environments locally and expect the same workflow on remote compute. Docker images are the right abstraction for notebook sessions (RStudio Server, JupyterHub), but not for SSH-accessible development environments.
+
+2. **Image coupling.** Work node and notebook images share the same Artifact Registry pipeline and the same `environments` table without distinction. A work node environment may need entirely different base packages (tmux, htop, custom CLI tools) than a notebook environment (rstudio-server, jupyterhub). Sharing images forces awkward compromises.
+
+3. **K8s overhead for VMs.** Work nodes are long-running, single-user compute sessions that behave like VMs. Running them as Pods adds K8s orchestration complexity (LoadBalancer Services for SSH, node pool scheduling, GCS FUSE CSI driver) without the benefits K8s provides for short-lived batch jobs or web services.
+
+4. **Missing features.** Scientists need to clone GitHub repositories into their work environment at boot time, and they need a clear MOTD guiding them to inputs, outputs, and scratch space. These are easier to implement on a VM with a startup script than in a K8s Pod spec.
+
+---
+
+## Decision
+
+Migrate work nodes from GKE Pods to GCE VMs. Introduce a separate adapter (`GCEWorkNodeProvider`), independent conda-only environment images built via Packer, a GitHub repos feature for auto-cloning at boot, and a MOTD.
+
+### Compute Target: GCE VMs
+
+Work nodes launch as GCE VM instances via the `compute_v1.InstancesClient` API. Each VM gets:
+
+- A Packer-built GCE image with the conda environment pre-installed (see below)
+- An ephemeral external IP for SSH access
+- A `bioaf-work-node` network tag for firewall rules
+- The notebook runner service account for GCS access
+- A startup script that handles user-specific configuration (PAM credentials, SSH keys, repo cloning, data mounts, MOTD)
+
+Notebook sessions (RStudio, Jupyter) remain on GKE unchanged.
+
+### Adapter Architecture
+
+A new `WorkNodeProvider` abstract base class is added alongside the existing `NotebookProvider`. The `GCEWorkNodeProvider` implements it using the GCE API. The adapter registry (`registry.py`) gains a `get_work_node_adapter()` function. Work nodes always use GCE regardless of the `compute_stack` setting.
+
+```text
+WorkNodeProvider (ABC)
+  ├── launch_vm(vm_spec) -> dict
+  ├── terminate_vm(instance_name, zone) -> dict
+  ├── get_vm_status(instance_name, zone) -> dict
+  └── list_vms(filters) -> list[dict]
+
+GCEWorkNodeProvider (concrete)
+  └── Uses google.cloud.compute_v1
+```
+
+### Environment Type Separation
+
+The `environments` table gains an `environment_type` column with values `"notebook"` and `"work_node"`. Work node environments only accept `conda` as the `definition_format` (no Dockerfile support). Notebook environments continue to support both formats.
+
+The Environments page in the UI provides filtering by type. When launching a work node, only `work_node` environments are shown.
+
+### VM Images via Packer
+
+Work node environment builds use Packer (run inside Cloud Build) to produce GCE VM images instead of Docker images. The build process:
+
+1. Start a temporary GCE VM from Ubuntu 22.04 LTS
+2. Install system packages: openssh-server, gcsfuse, git, tmux, htop, fail2ban, miniconda
+3. Copy the user's `environment.yml` and run `conda env create`
+4. Configure sshd, install the bioaf heartbeat agent
+5. Snapshot to a GCE image named `bioaf-worknode-{env_name}-v{version}-{build}`
+
+The `image_uri` on `EnvironmentVersion` stores the GCE image self-link (`projects/{project}/global/images/{name}`) instead of an Artifact Registry Docker URI. The existing Docker build path for notebook environments is unchanged.
+
+### VM Startup Script
+
+The startup script runs at boot and handles user-specific configuration that cannot be baked into the image:
+
+```bash
+# 1. Create PAM user with session credentials (ADR-030)
+useradd -m -d /home/<username> -s /bin/bash <username>
+echo '<username>:<bcrypt_hash>' | chpasswd -e
+
+# 2. SSH keys for GitHub
+mkdir -p /home/<username>/.ssh
+echo '<private_key>' > /home/<username>/.ssh/id_rsa
+chmod 600 /home/<username>/.ssh/id_rsa
+ssh-keyscan github.com >> /home/<username>/.ssh/known_hosts
+
+# 3. Clone selected GitHub repos
+mkdir -p /home/<username>/repos
+cd /home/<username>/repos
+git clone <repo_1_ssh_url> <repo_1_name>
+git clone <repo_2_ssh_url> <repo_2_name>
+
+# 4. Mount GCS data (read-only)
+mkdir -p /data/<mount_path>
+gcsfuse --implicit-dirs --only-dir <mount_path> <bucket> /data/<mount_path>
+
+# 5. Create output and scratch directories
+mkdir -p /outputs /scratch
+chown <username>:<username> /outputs /scratch
+
+# 6. Activate conda environment in user's shell
+echo 'conda activate <env_name>' >> /home/<username>/.bashrc
+
+# 7. Generate MOTD
+cat > /etc/motd << 'EOF'
+=== bioAF Work Node ===
+Input data:     /data/                    (read-only GCS mounts)
+Your repos:     /home/<username>/repos/   (cloned from GitHub)
+Output files:   /outputs/                 (synced to GCS on stop)
+Scratch space:  /scratch/                 (LOST on stop)
+Environment:    <env_name> v<version>.<build>
+EOF
+
+# 8. Heartbeat agent
+echo '<token>' > /etc/bioaf/token
+# bioaf heartbeat daemon started via systemd or cron
+
+# 9. Ownership
+chown -R <username>:<username> /home/<username>
+```
+
+### GitHub Repos Feature
+
+A new `github_repos` table stores user-scoped GitHub repository references:
+
+| Column | Type | Purpose |
+| --- | --- | --- |
+| `id` | Integer PK | Auto-increment |
+| `user_id` | Integer FK | Owner |
+| `organization_id` | Integer FK | Org scope |
+| `git_ssh_url` | String(500) | Git SSH clone URL (e.g., `git@github.com:owner/repo.git`) |
+| `display_name` | String(255) | Human-readable name |
+| `created_at` | Timestamp | Creation time |
+
+Unique constraint on `(user_id, git_ssh_url)` prevents duplicates.
+
+Users manage their repos from a section on the Work Nodes page. When launching a work node, users select which repos to clone. The startup script clones them into `/home/<username>/repos/<display_name>/`.
+
+### VM Filesystem Layout
+
+| Path | Source | Mode | Purpose |
+| --- | --- | --- | --- |
+| `/home/<username>/` | VM local disk | Read-write | User home directory |
+| `/home/<username>/repos/` | Git clone at boot | Read-write | Cloned GitHub repositories |
+| `/data/` | gcsfuse (selected paths) | Read-only | Pipeline outputs, uploads, shared results |
+| `/outputs/` | VM local disk | Read-write | Synced to GCS on stop; registered as tracked outputs |
+| `/scratch/` | VM local disk | Read-write | Temporary computation; lost on stop |
+
+### VM Lifecycle
+
+**Launch:** User selects project, data mounts, environment version, GitHub repos, and machine type. Platform creates a GCE VM with the pre-built image and startup script. Background poller checks for VM RUNNING status and external IP, then updates the DB with the SSH connection details.
+
+**Running:** Heartbeat agent reports activity every 5 minutes. VM is accessible via `ssh <username>@<external_ip>`. Conda environment is activated by default.
+
+**Stop:** On user-initiated stop:
+1. Run `gsutil -m rsync -r /outputs/ gs://{working_bucket}/sessions/{session_id}/outputs/` on the VM
+2. Capture scripts (`.py`, `.R`, `.Rmd`, `.ipynb`) from home directory
+3. Register output files (ADR-039 provenance)
+4. Move outputs to results bucket (ADR-040 two-phase persistence)
+5. Delete the GCE VM
+
+**Heartbeat timeout:** Same as ADR-034. Stale nodes are terminated after the admin-configured idle timeout.
+
+### Data Model Changes
+
+**`environments` table:**
+- Add `environment_type` column (String, default `"notebook"`)
+
+**`compute_sessions` table:**
+- Add `gce_instance_name` (String, nullable)
+- Add `gce_zone` (String, nullable)
+- Add `gce_project_id` (String, nullable)
+- Add `github_repo_ids` (JSON, nullable)
+
+**New `github_repos` table:** As described above.
+
+### Machine Types
+
+The machine type catalog (ADR-034) is updated to remove K8s node pool references. Machine type names map directly to GCE machine types. GPU types include accelerator metadata for the GCE API.
+
+---
+
+## Consequences
+
+**Positive:**
+
+- Scientists get native Linux VMs with conda environments matching their local workflow. No Docker abstraction layer.
+- Packer-built VM images provide fast startup (no conda install at boot).
+- GCE VMs are simpler to manage than K8s Pods for long-running SSH sessions. No LoadBalancer Services, no FUSE CSI driver, no node pool scheduling.
+- Environment type separation prevents confusion between notebook and work node images.
+- GitHub repo auto-cloning eliminates a manual step scientists currently perform on every new compute session.
+- MOTD provides immediate orientation on login.
+
+**Negative:**
+
+- Packer builds take longer than Docker builds (VM boot + package install + snapshot vs. container layer caching). Build times of 15-30 minutes are expected for R/Bioconductor-heavy environments.
+- GCE VMs with external IPs are exposed to the internet on port 22. Mitigated by: firewall rules restricting to SSH only, bcrypt PAM passwords, fail2ban for brute-force protection.
+- Two build pipelines (Docker for notebooks, Packer for work nodes) doubles the build infrastructure surface. Both run through Cloud Build, but the Packer template and Docker template are separate codepaths.
+- gcsfuse on GCE requires the VM's service account to have storage permissions, whereas GKE used Workload Identity. The service account attachment is simpler but less granular.
+
+**Neutral:**
+
+- The `WorkNodeProvider` ABC is separate from `NotebookProvider`, keeping each adapter focused. No risk of regressions to notebook sessions.
+- Existing work node records in the database (with `k8s_pod_name`) are unaffected. New work nodes populate `gce_instance_name` instead. Both columns are nullable.
+- The heartbeat mechanism, quota system, and idle timeout are unchanged in behavior -- only the underlying adapter call changes.
+
+---
+
+## References
+
+- ADR-034 (Custom work nodes -- original K8s-based design, superseded for work nodes)
+- ADR-033 (Versioned compute environments -- environment and version model)
+- ADR-041 (Environment build versioning -- build numbers and immutable images)
+- ADR-030 (Session credentials -- PAM auth reused for VM SSH login)
+- ADR-040 (Notebook file lifecycle -- output persistence and two-phase sync)
+- ADR-021 (Kubernetes compute backend -- notebook sessions remain here)
+- ADR-022 (GCS storage backend -- data lives in GCS buckets)

--- a/decisions/ADR-043-work-nodes-gce-migration.md
+++ b/decisions/ADR-043-work-nodes-gce-migration.md
@@ -154,6 +154,7 @@ Users manage their repos from a section on the Work Nodes page. When launching a
 **Running:** Heartbeat agent reports activity every 5 minutes. VM is accessible via `ssh <username>@<external_ip>`. Conda environment is activated by default.
 
 **Stop:** On user-initiated stop:
+
 1. Run `gsutil -m rsync -r /outputs/ gs://{working_bucket}/sessions/{session_id}/outputs/` on the VM
 2. Capture scripts (`.py`, `.R`, `.Rmd`, `.ipynb`) from home directory
 3. Register output files (ADR-039 provenance)
@@ -165,9 +166,11 @@ Users manage their repos from a section on the Work Nodes page. When launching a
 ### Data Model Changes
 
 **`environments` table:**
+
 - Add `environment_type` column (String, default `"notebook"`)
 
 **`compute_sessions` table:**
+
 - Add `gce_instance_name` (String, nullable)
 - Add `gce_zone` (String, nullable)
 - Add `gce_project_id` (String, nullable)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/data/files/page.test.tsx
+++ b/frontend/src/app/data/files/page.test.tsx
@@ -140,7 +140,9 @@ test("shows experiment name when file is linked", async () => {
   render(<DataFilesPage />);
 
   await waitFor(() => {
-    expect(screen.getByText("RNA-seq Batch 1")).toBeInTheDocument();
+    // Experiment name appears in both the filter dropdown and the association column
+    const matches = screen.getAllByText("RNA-seq Batch 1");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/frontend/src/app/data/files/page.tsx
+++ b/frontend/src/app/data/files/page.tsx
@@ -39,6 +39,11 @@ export default function DataFilesPage() {
   const [projects, setProjects] = useState<{ id: number; name: string }[]>([]);
   const [experiments, setExperiments] = useState<{ id: number; name: string }[]>([]);
   const [filterType, setFilterType] = useState("");
+  const [filterProjectId, setFilterProjectId] = useState("");
+  const [filterExperimentId, setFilterExperimentId] = useState("");
+  const [filterSourceType, setFilterSourceType] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchInput, setSearchInput] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [reconciling, setReconciling] = useState(false);
   const [reconcileResult, setReconcileResult] = useState<{
@@ -74,6 +79,10 @@ export default function DataFilesPage() {
     try {
       const params = new URLSearchParams();
       if (filterType) params.set("file_type", filterType);
+      if (filterProjectId) params.set("project_id", filterProjectId);
+      if (filterExperimentId) params.set("experiment_id", filterExperimentId);
+      if (filterSourceType) params.set("source_type", filterSourceType);
+      if (searchQuery) params.set("search", searchQuery);
       params.set("page", String(page));
       params.set("page_size", String(pageSize));
       const qs = params.toString();
@@ -86,7 +95,7 @@ export default function DataFilesPage() {
     } finally {
       setLoading(false);
     }
-  }, [filterType, page]);
+  }, [filterType, filterProjectId, filterExperimentId, filterSourceType, searchQuery, page]);
 
   const fetchMeta = useCallback(async () => {
     try {
@@ -283,6 +292,9 @@ export default function DataFilesPage() {
   const sourceLabel = (file: FileResponse): string => {
     switch (file.source_type) {
       case "upload": return file.uploader ? `Uploaded by ${file.uploader.name ?? file.uploader.email}` : "Uploaded";
+      case "pipeline_output": return `Pipeline${file.source_pipeline_run_id ? ` (run #${file.source_pipeline_run_id})` : ""}`;
+      case "notebook_output": return `Notebook${file.source_notebook_session_id ? ` (session #${file.source_notebook_session_id})` : ""}`;
+      case "work_node_output": return `Work Node${file.source_notebook_session_id ? ` (session #${file.source_notebook_session_id})` : ""}`;
       case "qc_dashboard": return `QC Dashboard${file.source_pipeline_run_id ? ` (run #${file.source_pipeline_run_id})` : ""}`;
       case "plot_archive": return `Plot Archive${file.source_pipeline_run_id ? ` (run #${file.source_pipeline_run_id})` : ""}`;
       default: return file.source_type;
@@ -321,7 +333,52 @@ export default function DataFilesPage() {
           <h1 className="text-2xl font-bold mb-6">Files</h1>
 
           <div className="space-y-4">
-            <div className="flex gap-4 items-center">
+            {/* Search and filters */}
+            <div className="flex flex-wrap gap-3 items-center">
+              <form
+                onSubmit={(e) => { e.preventDefault(); setSearchQuery(searchInput); setPage(1); }}
+                className="flex gap-1"
+              >
+                <input
+                  type="text"
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  placeholder="Search by filename..."
+                  className="px-3 py-2 border border-gray-300 rounded-md text-sm w-56"
+                />
+                <button type="submit" className="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm hover:bg-gray-200">
+                  Search
+                </button>
+                {searchQuery && (
+                  <button
+                    type="button"
+                    onClick={() => { setSearchInput(""); setSearchQuery(""); setPage(1); }}
+                    className="px-2 py-2 text-gray-400 hover:text-gray-600 text-sm"
+                  >
+                    Clear
+                  </button>
+                )}
+              </form>
+              <select
+                value={filterProjectId}
+                onChange={(e) => { setFilterProjectId(e.target.value); setFilterExperimentId(""); setPage(1); }}
+                className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+              >
+                <option value="">All projects</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+              <select
+                value={filterExperimentId}
+                onChange={(e) => { setFilterExperimentId(e.target.value); setPage(1); }}
+                className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+              >
+                <option value="">All experiments</option>
+                {experiments.map((e) => (
+                  <option key={e.id} value={e.id}>{e.name}</option>
+                ))}
+              </select>
               <select
                 value={filterType}
                 onChange={(e) => { setFilterType(e.target.value); setPage(1); }}
@@ -329,10 +386,19 @@ export default function DataFilesPage() {
               >
                 <option value="">All types</option>
                 {fileTypes.map((t) => (
-                  <option key={t} value={t}>
-                    {t}
-                  </option>
+                  <option key={t} value={t}>{t}</option>
                 ))}
+              </select>
+              <select
+                value={filterSourceType}
+                onChange={(e) => { setFilterSourceType(e.target.value); setPage(1); }}
+                className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+              >
+                <option value="">All sources</option>
+                <option value="upload">Upload</option>
+                <option value="pipeline_output">Pipeline</option>
+                <option value="notebook_output">Notebook</option>
+                <option value="work_node_output">Work Node</option>
               </select>
 
               {selectedIds.size > 0 && (

--- a/frontend/src/app/environments/page.tsx
+++ b/frontend/src/app/environments/page.tsx
@@ -259,7 +259,7 @@ export default function EnvironmentsPage() {
           {loadError && (
             <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
               {loadError}
-              <button onClick={loadEnvironments} className="ml-2 underline">Retry</button>
+              <button onClick={() => loadEnvironments()} className="ml-2 underline">Retry</button>
             </div>
           )}
           <div className="flex items-center justify-between mb-6">

--- a/frontend/src/app/environments/page.tsx
+++ b/frontend/src/app/environments/page.tsx
@@ -202,7 +202,7 @@ export default function EnvironmentsPage() {
       const newVersion = await api.post<EnvironmentVersionResponse>(
         `/api/v1/environments/${selectedEnv.id}/versions`,
         {
-          definition_format: "dockerfile",
+          definition_format: selectedEnv.environment_type === "work_node" ? "conda" : "dockerfile",
           definition_content: rebuildTemplateContent,
         }
       );

--- a/frontend/src/app/environments/page.tsx
+++ b/frontend/src/app/environments/page.tsx
@@ -32,8 +32,11 @@ export default function EnvironmentsPage() {
   const [selectedEnv, setSelectedEnv] = useState<EnvironmentDetailResponse | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("versions");
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [createForm, setCreateForm] = useState({ name: "", description: "" });
+  const [createForm, setCreateForm] = useState({ name: "", description: "", environment_type: "notebook" as "notebook" | "work_node" });
   const [creating, setCreating] = useState(false);
+
+  // Type filter state
+  const [typeFilter, setTypeFilter] = useState<"all" | "notebook" | "work_node">("all");
 
   // Version creation state
   const [newVersionFormat, setNewVersionFormat] = useState<"dockerfile" | "conda">("dockerfile");
@@ -60,9 +63,11 @@ export default function EnvironmentsPage() {
     loadEnvironments();
   }, [router]);
 
-  async function loadEnvironments() {
+  async function loadEnvironments(type?: string) {
     try {
-      const data = await api.get<EnvironmentListResponse>("/api/v1/environments");
+      const filterType = type ?? typeFilter;
+      const query = filterType !== "all" ? `?type=${filterType}` : "";
+      const data = await api.get<EnvironmentListResponse>(`/api/v1/environments${query}`);
       setEnvironments(data.environments);
       setLoadError(null);
     } catch (err) {
@@ -76,6 +81,10 @@ export default function EnvironmentsPage() {
       setSelectedEnv(detail);
       setActiveTab("versions");
       setSelectedVersion(null);
+      // Work node environments only support conda
+      if (detail.environment_type === "work_node") {
+        setNewVersionFormat("conda");
+      }
     } catch {}
   }
 
@@ -85,9 +94,10 @@ export default function EnvironmentsPage() {
       await api.post("/api/v1/environments", {
         name: createForm.name,
         description: createForm.description || undefined,
+        environment_type: createForm.environment_type,
       });
       setShowCreateModal(false);
-      setCreateForm({ name: "", description: "" });
+      setCreateForm({ name: "", description: "", environment_type: "notebook" });
       loadEnvironments();
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to create environment");
@@ -266,6 +276,19 @@ export default function EnvironmentsPage() {
 
           {!selectedEnv ? (
             /* Environment Cards */
+            <>
+            {/* Type filter tabs */}
+            <div className="flex gap-1 mb-4 bg-gray-100 rounded-lg p-1 w-fit">
+              {([["all", "All"], ["notebook", "Notebook"], ["work_node", "Work Node"]] as const).map(([value, label]) => (
+                <button
+                  key={value}
+                  onClick={() => { setTypeFilter(value); loadEnvironments(value); }}
+                  className={`px-3 py-1.5 text-sm rounded-md transition-colors ${typeFilter === value ? "bg-white shadow font-medium text-gray-900" : "text-gray-500 hover:text-gray-700"}`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {environments.map((env) => (
                 <div
@@ -273,8 +296,11 @@ export default function EnvironmentsPage() {
                   onClick={() => selectEnvironment(env.id)}
                   className="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow cursor-pointer"
                 >
-                  <div className="mb-3">
+                  <div className="mb-3 flex items-center gap-2">
                     <h3 className="font-semibold text-lg">{env.name}</h3>
+                    <span className={`text-xs px-1.5 py-0.5 rounded-full ${env.environment_type === "work_node" ? "bg-purple-100 text-purple-700" : "bg-blue-100 text-blue-700"}`}>
+                      {env.environment_type === "work_node" ? "Work Node" : "Notebook"}
+                    </span>
                   </div>
                   <p className="text-sm text-gray-500 mb-4 line-clamp-2">{env.description || "No description"}</p>
                   <div className="flex items-center justify-between">
@@ -298,6 +324,7 @@ export default function EnvironmentsPage() {
                 </div>
               )}
             </div>
+            </>
           ) : selectedVersion ? (
             /* Version Detail View */
             <div>
@@ -374,7 +401,12 @@ export default function EnvironmentsPage() {
                 <div className="p-6 border-b">
                   <div className="flex items-center justify-between">
                     <div>
-                      <h2 className="text-xl font-bold">{selectedEnv.name}</h2>
+                      <div className="flex items-center gap-2">
+                        <h2 className="text-xl font-bold">{selectedEnv.name}</h2>
+                        <span className={`text-xs px-1.5 py-0.5 rounded-full ${selectedEnv.environment_type === "work_node" ? "bg-purple-100 text-purple-700" : "bg-blue-100 text-blue-700"}`}>
+                          {selectedEnv.environment_type === "work_node" ? "Work Node" : "Notebook"}
+                        </span>
+                      </div>
                       <p className="text-sm text-gray-500">{selectedEnv.description}</p>
                     </div>
                     <div className="flex items-center gap-3">
@@ -467,14 +499,18 @@ export default function EnvironmentsPage() {
                     <div className="space-y-4">
                       <div>
                         <label className="text-sm text-gray-500 block mb-1">Format</label>
-                        <select
-                          value={newVersionFormat}
-                          onChange={(e) => setNewVersionFormat(e.target.value as "dockerfile" | "conda")}
-                          className="border rounded px-3 py-2 text-sm"
-                        >
-                          <option value="dockerfile">Dockerfile</option>
-                          <option value="conda">Conda (environment.yml)</option>
-                        </select>
+                        {selectedEnv.environment_type === "work_node" ? (
+                          <span className="text-sm text-gray-700">Conda (environment.yml)</span>
+                        ) : (
+                          <select
+                            value={newVersionFormat}
+                            onChange={(e) => setNewVersionFormat(e.target.value as "dockerfile" | "conda")}
+                            className="border rounded px-3 py-2 text-sm"
+                          >
+                            <option value="dockerfile">Dockerfile</option>
+                            <option value="conda">Conda (environment.yml)</option>
+                          </select>
+                        )}
                       </div>
                       <div>
                         <label className="text-sm text-gray-500 block mb-1">
@@ -511,6 +547,22 @@ export default function EnvironmentsPage() {
               <div className="bg-white rounded-lg shadow-xl p-6 w-96">
                 <h3 className="font-semibold text-lg mb-4">New Environment</h3>
                 <div className="space-y-3">
+                  <div>
+                    <label className="text-sm text-gray-500 block mb-1">Type</label>
+                    <select
+                      value={createForm.environment_type}
+                      onChange={(e) => setCreateForm({ ...createForm, environment_type: e.target.value as "notebook" | "work_node" })}
+                      className="w-full border rounded px-3 py-2 text-sm"
+                    >
+                      <option value="notebook">Notebook</option>
+                      <option value="work_node">Work Node</option>
+                    </select>
+                    <p className="text-xs text-gray-400 mt-1">
+                      {createForm.environment_type === "work_node"
+                        ? "Work node environments use conda and build as GCE VM images."
+                        : "Notebook environments use Dockerfile or conda and build as container images."}
+                    </p>
+                  </div>
                   <div>
                     <label className="text-sm text-gray-500 block mb-1">Name</label>
                     <input

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -268,13 +268,6 @@ export default function NotebooksPage() {
     }
   }
 
-  async function handleSync(sessionId: number) {
-    try {
-      await api.post(`/api/v1/notebooks/sessions/${sessionId}/sync`);
-      alert("Sync triggered successfully");
-    } catch {}
-  }
-
   return (
     <div className="flex h-screen">
       <Sidebar />
@@ -365,11 +358,10 @@ export default function NotebooksPage() {
                   <tr>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">User</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Profile</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Resources</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Start Time</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Access URL</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Experiment</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
                   </tr>
                 </thead>
@@ -378,9 +370,7 @@ export default function NotebooksPage() {
                     <tr key={s.id} className={`cursor-pointer ${s.status === "idle" ? "bg-yellow-50 hover:bg-yellow-100" : "hover:bg-gray-50"}`} onClick={() => setViewingSession(s)}>
                       <td className="px-4 py-3 text-sm capitalize font-medium">{s.session_type}</td>
                       <td className="px-4 py-3 text-sm">{s.user?.name || s.user?.email || "\u2014"}</td>
-                      <td className="px-4 py-3 text-sm capitalize">
-                        {s.resource_profile} ({s.cpu_cores} CPU, {s.memory_gb}GB)
-                      </td>
+                      <td className="px-4 py-3 text-sm">{s.cpu_cores} CPU / {s.memory_gb} GB</td>
                       <td className="px-4 py-3">
                         {stoppingSessions.has(s.id) ? (
                           <span className="flex items-center gap-1 text-xs text-orange-700">
@@ -408,13 +398,6 @@ export default function NotebooksPage() {
                           </a>
                         ) : "\u2014"}
                       </td>
-                      <td className="px-4 py-3 text-sm" onClick={(e) => e.stopPropagation()}>
-                        {s.experiment ? (
-                          <Link href={`/experiments/${s.experiment.id}`} className="text-bioaf-600 hover:underline">
-                            {s.experiment.name}
-                          </Link>
-                        ) : "\u2014"}
-                      </td>
                       <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
                         <div className="flex gap-2">
                           {s.proxy_url && s.status === "running" && (
@@ -422,22 +405,23 @@ export default function NotebooksPage() {
                               Open
                             </a>
                           )}
-                          {s.status === "running" && (
-                            <button onClick={() => handleSync(s.id)} className="text-xs px-2 py-1 border border-green-600 text-green-600 rounded hover:bg-green-50">
-                              Sync
-                            </button>
-                          )}
                           {["pending", "starting", "running", "idle"].includes(s.status) && (
                             <button onClick={() => handleStop(s.id)} className="text-xs px-2 py-1 border border-red-600 text-red-600 rounded hover:bg-red-50">
                               Stop
                             </button>
                           )}
+                          <button
+                            onClick={() => setViewingSession(s)}
+                            className="text-xs px-2 py-1 border border-bioaf-600 text-bioaf-600 rounded hover:bg-bioaf-50"
+                          >
+                            Details
+                          </button>
                         </div>
                       </td>
                     </tr>
                   ))}
                   {sessions.length === 0 && (
-                    <tr><td colSpan={8} className="px-4 py-8 text-center text-gray-400">No active sessions</td></tr>
+                    <tr><td colSpan={7} className="px-4 py-8 text-center text-gray-400">No active sessions</td></tr>
                   )}
                 </tbody>
               </table>
@@ -470,16 +454,23 @@ export default function NotebooksPage() {
                         envLabel = `Version ID ${viewingSession.environment_version_id}`;
                       }
                     }
+                    // Compute uptime
+                    let uptimeLabel: string | null = null;
+                    if (viewingSession.started_at && viewingSession.status === "running") {
+                      const diff = Date.now() - new Date(viewingSession.started_at).getTime();
+                      const hours = Math.floor(diff / 3600000);
+                      const minutes = Math.floor((diff % 3600000) / 60000);
+                      uptimeLabel = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+                    }
                     return [
                       { label: "Type", value: viewingSession.session_type },
                       { label: "Status", value: viewingSession.status },
                       { label: "User", value: viewingSession.user?.name || viewingSession.user?.email },
                       { label: "Environment", value: envLabel },
-                      { label: "Resource Profile", value: viewingSession.resource_profile },
-                      { label: "CPU Cores", value: viewingSession.cpu_cores },
-                      { label: "Memory (GB)", value: viewingSession.memory_gb },
+                      { label: "Resources", value: `${viewingSession.cpu_cores} CPU / ${viewingSession.memory_gb} GB RAM` },
                       { label: "Experiment", value: viewingSession.experiment?.name },
                       { label: "Started", value: viewingSession.started_at ? new Date(viewingSession.started_at).toLocaleString() : null },
+                      { label: "Uptime", value: uptimeLabel },
                       { label: "Access URL", value: viewingSession.proxy_url || null },
                       { label: "Idle Since", value: viewingSession.idle_since ? new Date(viewingSession.idle_since).toLocaleString() : null },
                       { label: "Git Branch", value: viewingSession.git_branch_name || null },
@@ -552,11 +543,6 @@ export default function NotebooksPage() {
                     <a href={viewingSession.proxy_url} target="_blank" rel="noopener noreferrer" className="px-3 py-1.5 border border-bioaf-600 text-bioaf-600 rounded text-sm hover:bg-bioaf-50">
                       Open
                     </a>
-                  )}
-                  {viewingSession.status === "running" && (
-                    <button onClick={() => handleSync(viewingSession.id)} className="px-3 py-1.5 border border-green-600 text-green-600 rounded text-sm hover:bg-green-50">
-                      Sync
-                    </button>
                   )}
                   {["pending", "starting", "running", "idle"].includes(viewingSession.status) && (
                     <button onClick={() => { handleStop(viewingSession.id); setViewingSession(null); setProvenance(null); }} className="px-3 py-1.5 border border-red-600 text-red-600 rounded text-sm hover:bg-red-50">

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -329,7 +329,7 @@ export default function WorkNodesPage() {
             {canAccess("work_nodes", "launch") && (
               <button
                 onClick={openLaunchDialog}
-                className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 text-sm font-medium"
+                className="bg-bioaf-600 text-white px-4 py-2 rounded-md text-sm hover:bg-bioaf-700"
               >
                 Launch Work Node
               </button>
@@ -448,17 +448,21 @@ export default function WorkNodesPage() {
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">User</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Machine Type</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Resources</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Uptime</th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Last Heartbeat</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Start Time</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Access</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200">
                   {nodes.map((node) => (
-                    <tr key={node.id} className="hover:bg-gray-50">
+                    <tr key={node.id} className="hover:bg-gray-50 cursor-pointer" onClick={() => setViewingNode(node)}>
+                      <td className="px-4 py-3 text-sm">{node.user?.name || node.user?.email || "\u2014"}</td>
+                      <td className="px-4 py-3 text-sm text-gray-900">{node.machine_type || "\u2014"}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600">{node.cpu_cores} CPU / {node.memory_gb} GB</td>
                       <td className="px-4 py-3">
                         {stoppingNodes.has(node.id) ? (
                           <span className="flex items-center gap-1 text-xs text-orange-700">
@@ -471,29 +475,37 @@ export default function WorkNodesPage() {
                           </span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-900">{node.machine_type || "-"}</td>
-                      <td className="px-4 py-3 text-sm text-gray-600">{node.cpu_cores} CPU / {node.memory_gb} GB</td>
                       <td className="px-4 py-3 text-sm text-gray-600">
-                        {node.status === "running" ? formatUptime(node.started_at) : "-"}
+                        {node.started_at ? new Date(node.started_at).toLocaleString() : "\u2014"}
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600">
-                        {node.heartbeat_at ? formatTimestamp(node.heartbeat_at) : "-"}
-                      </td>
-                      <td className="px-4 py-3 text-sm space-x-2">
-                        <button
-                          onClick={() => setViewingNode(node)}
-                          className="text-indigo-600 hover:text-indigo-800"
-                        >
-                          Details
-                        </button>
-                        {canAccess("work_nodes", "stop") && node.status === "running" && (
+                      <td className="px-4 py-3 text-sm font-mono" onClick={(e) => e.stopPropagation()}>
+                        {node.access_url && node.status === "running" ? (
                           <button
-                            onClick={() => handleStop(node.id)}
-                            className="text-red-600 hover:text-red-800"
+                            onClick={() => navigator.clipboard.writeText(extractSshCommand(node.access_url))}
+                            className="text-indigo-600 hover:underline"
+                            title={extractSshCommand(node.access_url)}
                           >
-                            Stop
+                            {extractSshCommand(node.access_url)}
                           </button>
-                        )}
+                        ) : "\u2014"}
+                      </td>
+                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                        <div className="flex gap-2">
+                          {canAccess("work_nodes", "stop") && node.status === "running" && (
+                            <button
+                              onClick={() => handleStop(node.id)}
+                              className="text-xs px-2 py-1 border border-red-600 text-red-600 rounded hover:bg-red-50"
+                            >
+                              Stop
+                            </button>
+                          )}
+                          <button
+                            onClick={() => setViewingNode(node)}
+                            className="text-xs px-2 py-1 border border-indigo-600 text-indigo-600 rounded hover:bg-indigo-50"
+                          >
+                            Details
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   ))}
@@ -522,6 +534,10 @@ export default function WorkNodesPage() {
                       GCP Resources Unavailable -- the VM could not be created. Try again later or choose a different machine type.
                     </div>
                   )}
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">User</span>
+                    <span>{viewingNode.user?.name || viewingNode.user?.email || "\u2014"}</span>
+                  </div>
                   <div className="flex justify-between">
                     <span className="text-gray-500">Machine Type</span>
                     <span>{viewingNode.machine_type || "-"}</span>
@@ -581,6 +597,12 @@ export default function WorkNodesPage() {
                     <span className="text-gray-500">Started</span>
                     <span>{formatTimestamp(viewingNode.started_at)}</span>
                   </div>
+                  {viewingNode.status === "running" && viewingNode.started_at && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">Uptime</span>
+                      <span>{formatUptime(viewingNode.started_at)}</span>
+                    </div>
+                  )}
                   <div className="flex justify-between">
                     <span className="text-gray-500">Last Heartbeat</span>
                     <span>{viewingNode.heartbeat_at ? formatTimestamp(viewingNode.heartbeat_at) : "-"}</span>

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -60,7 +60,9 @@ export default function WorkNodesPage() {
   const [launchStep, setLaunchStep] = useState(1);
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
-  const [projectFiles, setProjectFiles] = useState<FileResponse[]>([]);
+  const [projectExperiments, setProjectExperiments] = useState<{ id: number; name: string; code: string | null }[]>([]);
+  const [selectedExperimentId, setSelectedExperimentId] = useState<number | null>(null);
+  const [experimentFiles, setExperimentFiles] = useState<FileResponse[]>([]);
   const [sampleNames, setSampleNames] = useState<Record<number, string>>({});
   const [selectedFileIds, setSelectedFileIds] = useState<number[]>([]);
   const [showFileSelector, setShowFileSelector] = useState(false);
@@ -140,7 +142,9 @@ export default function WorkNodesPage() {
     setShowLaunch(true);
     setLaunchStep(1);
     setSelectedProjectId(null);
-    setProjectFiles([]);
+    setProjectExperiments([]);
+    setSelectedExperimentId(null);
+    setExperimentFiles([]);
     setSampleNames({});
     setSelectedFileIds([]);
     setShowFileSelector(false);
@@ -165,16 +169,57 @@ export default function WorkNodesPage() {
 
   async function handleProjectSelect(projectId: number) {
     setSelectedProjectId(projectId);
+    setSelectedExperimentId(null);
+    setExperimentFiles([]);
     setSelectedFileIds([]);
     setShowFileSelector(false);
     try {
-      const data = await api.get<FileListResponse>(`/api/files?project_id=${projectId}&page_size=500`);
-      setProjectFiles(data.files);
-      setSampleNames({});
+      const data = await api.get<{ experiments: { id: number; name: string; code: string | null }[]; total: number }>(
+        `/api/experiments?project_id=${projectId}&page_size=100`
+      );
+      setProjectExperiments(data.experiments);
     } catch {
-      setProjectFiles([]);
+      setProjectExperiments([]);
     }
     setLaunchStep(2);
+  }
+
+  async function handleExperimentSelect(experimentId: number) {
+    setSelectedExperimentId(experimentId);
+    setSelectedFileIds([]);
+    setShowFileSelector(false);
+    try {
+      const data = await api.get<FileListResponse>(
+        `/api/experiments/${experimentId}/files?page_size=500`
+      );
+      setExperimentFiles(data.files);
+
+      // Resolve sample names
+      const sampleIds = new Set<number>();
+      for (const file of data.files) {
+        for (const sid of file.sample_ids || []) {
+          sampleIds.add(sid);
+        }
+      }
+      if (sampleIds.size > 0) {
+        try {
+          const samplesData = await api.get<{ samples: { id: number; sample_id_unique: string }[] }>(
+            `/api/experiments/${experimentId}/samples?page_size=500`
+          );
+          const names: Record<number, string> = {};
+          for (const s of samplesData.samples) {
+            names[s.id] = s.sample_id_unique || `Sample ${s.id}`;
+          }
+          setSampleNames(names);
+        } catch {
+          setSampleNames({});
+        }
+      } else {
+        setSampleNames({});
+      }
+    } catch {
+      setExperimentFiles([]);
+    }
   }
 
   async function handleEnvSelect(envId: number) {
@@ -595,20 +640,47 @@ export default function WorkNodesPage() {
                 {launchStep === 2 && (
                   <div>
                     <h3 className="font-medium mb-3">Select Input Files</h3>
-                    <p className="text-xs text-gray-500 mb-3">Selected files will be copied to /data/ when the node boots (optional)</p>
-                    {projectFiles.length === 0 ? (
-                      <p className="text-sm text-gray-400">No files found for this project.</p>
+                    <p className="text-xs text-gray-500 mb-3">Choose an experiment, then select files to copy to /data/ at boot (optional)</p>
+
+                    {/* Experiment selector */}
+                    {projectExperiments.length === 0 ? (
+                      <p className="text-sm text-gray-400">No experiments in this project.</p>
                     ) : (
+                      <div className="mb-3">
+                        <label className="text-xs font-medium text-gray-600 block mb-1">Experiment</label>
+                        <select
+                          className="w-full border rounded px-3 py-2 text-sm"
+                          value={selectedExperimentId || ""}
+                          onChange={(e) => {
+                            const val = e.target.value ? Number(e.target.value) : null;
+                            if (val) handleExperimentSelect(val);
+                          }}
+                        >
+                          <option value="">Select an experiment...</option>
+                          {projectExperiments.map((exp) => (
+                            <option key={exp.id} value={exp.id}>
+                              {exp.name}{exp.code ? ` (${exp.code})` : ""}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
+
+                    {/* File picker (shown after experiment is selected) */}
+                    {selectedExperimentId && experimentFiles.length === 0 && (
+                      <p className="text-sm text-gray-400">No files found for this experiment.</p>
+                    )}
+                    {selectedExperimentId && experimentFiles.length > 0 && (
                       <>
                         <button
                           onClick={() => setShowFileSelector(!showFileSelector)}
                           className="text-xs text-indigo-600 hover:underline mb-2"
                         >
-                          {showFileSelector ? "Hide file picker" : `Select files (${projectFiles.length} available)`}
+                          {showFileSelector ? "Hide file picker" : `Select files (${experimentFiles.length} available)`}
                         </button>
                         {showFileSelector && (
                           <FileTreeSelector
-                            files={projectFiles}
+                            files={experimentFiles}
                             sampleNames={sampleNames}
                             onSelectionChange={setSelectedFileIds}
                           />
@@ -618,6 +690,7 @@ export default function WorkNodesPage() {
                         )}
                       </>
                     )}
+
                     <div className="flex gap-2 mt-4">
                       <button onClick={() => setLaunchStep(1)} className="px-4 py-2 border rounded text-sm">Back</button>
                       <button onClick={() => setLaunchStep(3)} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -516,7 +516,7 @@ export default function WorkNodesPage() {
                       <span className="text-gray-500 block mb-1">Data Mounts</span>
                       <ul className="text-xs text-gray-700 space-y-1">
                         {viewingNode.data_mount_paths.map((p) => (
-                          <li key={p} className="font-mono bg-gray-50 px-2 py-1 rounded">/data/{p}</li>
+                          <li key={p} className="font-mono bg-gray-50 px-2 py-1 rounded">/data/{p.replace(/^\//, "")}</li>
                         ))}
                       </ul>
                     </div>

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -18,6 +18,8 @@ import type {
   EnvironmentResponse,
   EnvironmentListResponse,
   EnvironmentDetailResponse,
+  GitHubRepo,
+  GitHubRepoListResponse,
 } from "@/lib/types";
 
 const STATUS_COLORS: Record<string, string> = {
@@ -44,6 +46,14 @@ export default function WorkNodesPage() {
   const [showLaunch, setShowLaunch] = useState(false);
   const [viewingNode, setViewingNode] = useState<WorkNode | null>(null);
 
+  // GitHub repos state
+  const [repos, setRepos] = useState<GitHubRepo[]>([]);
+  const [showRepos, setShowRepos] = useState(false);
+  const [newRepoUrl, setNewRepoUrl] = useState("");
+  const [newRepoName, setNewRepoName] = useState("");
+  const [repoError, setRepoError] = useState<string | null>(null);
+  const [addingRepo, setAddingRepo] = useState(false);
+
   // Launch form state
   const [launchStep, setLaunchStep] = useState(1);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -54,6 +64,7 @@ export default function WorkNodesPage() {
   const [selectedEnvId, setSelectedEnvId] = useState<number | null>(null);
   const [envDetail, setEnvDetail] = useState<EnvironmentDetailResponse | null>(null);
   const [selectedVersionId, setSelectedVersionId] = useState<number | null>(null);
+  const [selectedRepoIds, setSelectedRepoIds] = useState<number[]>([]);
   const [machineTypes, setMachineTypes] = useState<MachineType[]>([]);
   const [selectedMachineType, setSelectedMachineType] = useState<string>("");
   const [launching, setLaunching] = useState(false);
@@ -66,6 +77,7 @@ export default function WorkNodesPage() {
     if (permLoading) return;
     if (!canAccess("work_nodes", "view")) { router.push("/dashboard"); return; }
     loadNodes();
+    loadRepos();
   }, [router, permLoading, canAccess]);
 
   // Auto-refresh while starting
@@ -87,6 +99,39 @@ export default function WorkNodesPage() {
     }
   }, []);
 
+  async function loadRepos() {
+    try {
+      const data = await api.get<GitHubRepoListResponse>("/api/v1/github-repos");
+      setRepos(data.repos);
+    } catch {}
+  }
+
+  async function handleAddRepo() {
+    if (!newRepoUrl.trim()) return;
+    setAddingRepo(true);
+    setRepoError(null);
+    try {
+      await api.post("/api/v1/github-repos", {
+        git_ssh_url: newRepoUrl.trim(),
+        display_name: newRepoName.trim() || null,
+      });
+      setNewRepoUrl("");
+      setNewRepoName("");
+      loadRepos();
+    } catch (err) {
+      setRepoError(err instanceof ApiError ? err.message : "Failed to add repo");
+    } finally {
+      setAddingRepo(false);
+    }
+  }
+
+  async function handleDeleteRepo(repoId: number) {
+    try {
+      await api.delete(`/api/v1/github-repos/${repoId}`);
+      loadRepos();
+    } catch {}
+  }
+
   async function openLaunchDialog() {
     setShowLaunch(true);
     setLaunchStep(1);
@@ -95,6 +140,7 @@ export default function WorkNodesPage() {
     setSelectedEnvId(null);
     setEnvDetail(null);
     setSelectedVersionId(null);
+    setSelectedRepoIds([]);
     setSelectedMachineType("");
     setLaunchError(null);
 
@@ -102,7 +148,7 @@ export default function WorkNodesPage() {
       const [projectData, mtData, envData] = await Promise.all([
         api.get<{ projects: Project[]; total: number }>("/api/projects?page_size=100"),
         api.get<MachineType[]>("/api/v1/work-nodes/machine-types"),
-        api.get<EnvironmentListResponse>("/api/v1/environments"),
+        api.get<EnvironmentListResponse>("/api/v1/environments?type=work_node"),
       ]);
       setProjects(projectData.projects);
       setMachineTypes(mtData);
@@ -137,6 +183,12 @@ export default function WorkNodesPage() {
     );
   }
 
+  function toggleRepo(repoId: number) {
+    setSelectedRepoIds((prev) =>
+      prev.includes(repoId) ? prev.filter((id) => id !== repoId) : [...prev, repoId]
+    );
+  }
+
   async function handleLaunch() {
     if (!selectedProjectId || !selectedVersionId || !selectedMachineType) return;
     setLaunching(true);
@@ -147,6 +199,7 @@ export default function WorkNodesPage() {
         environment_version_id: selectedVersionId,
         machine_type: selectedMachineType,
         data_mount_paths: selectedMounts.length > 0 ? selectedMounts : undefined,
+        github_repo_ids: selectedRepoIds.length > 0 ? selectedRepoIds : undefined,
       };
       await api.post("/api/v1/work-nodes/sessions", req);
       setShowLaunch(false);
@@ -187,6 +240,13 @@ export default function WorkNodesPage() {
   function formatTimestamp(ts: string | null): string {
     if (!ts) return "-";
     return new Date(ts).toLocaleString();
+  }
+
+  function extractSshCommand(accessUrl: string | null): string {
+    if (!accessUrl) return "";
+    // access_url is like ssh://1.2.3.4:22
+    const ip = accessUrl.replace("ssh://", "").replace(/:\d+$/, "");
+    return `ssh ${ip}`;
   }
 
   if (permLoading || loading) {
@@ -236,14 +296,87 @@ export default function WorkNodesPage() {
               <div className="mt-2 rounded-lg border border-blue-200 bg-blue-50 p-4">
                 <div className="text-sm text-blue-800 space-y-2">
                   <ul className="space-y-1.5 text-blue-700">
-                    <li><strong>Input files</strong> are mounted at <code className="bg-blue-100 px-1 rounded">/data/</code>. Select data mounts during launch to access pipeline outputs, uploads, and shared results for your project.</li>
-                    <li><strong>Output files</strong> should be saved to <code className="bg-blue-100 px-1 rounded">/outputs/</code>. Everything in this directory is automatically synced to GCS and registered when you stop the node.</li>
+                    <li><strong>Work nodes</strong> are full Linux VMs with SSH access. They run conda environments you configure on the <a href="/environments" className="underline font-medium">Environments</a> page.</li>
+                    <li><strong>Input files</strong> are mounted at <code className="bg-blue-100 px-1 rounded">/data/</code>. Select data mounts during launch to access pipeline outputs, uploads, and shared results.</li>
+                    <li><strong>GitHub repos</strong> are cloned at boot into <code className="bg-blue-100 px-1 rounded">~/repos/</code>. Add repos in the section below, then select them when launching.</li>
+                    <li><strong>Output files</strong> should be saved to <code className="bg-blue-100 px-1 rounded">/outputs/</code>. Everything here is automatically synced to GCS when you stop the node.</li>
                     <li><strong>Scratch space</strong> at <code className="bg-blue-100 px-1 rounded">/scratch/</code> is for temporary computation. This data is lost when the node stops.</li>
-                    <li><strong>Environments</strong> control the packages and tools available. Choose an environment and version when launching. Admins can create new environments from the <a href="/environments" className="underline font-medium">Environments</a> page.</li>
-                    <li><strong>SSH access</strong> uses the credentials you set in your <a href="/profile" className="underline font-medium">Profile Settings</a>. The connection command appears in the node detail panel after launch.</li>
-                    <li><strong>Machine types</strong> range from standard (4 CPU) to high-memory (128 GB) and GPU. Choose based on your workload.</li>
+                    <li><strong>SSH access</strong> uses the credentials from your <a href="/profile" className="underline font-medium">Profile Settings</a>. The SSH command appears after launch.</li>
                   </ul>
                 </div>
+              </div>
+            )}
+          </div>
+
+          {/* GitHub Repos section */}
+          <div className="mb-6">
+            <button
+              onClick={() => setShowRepos(!showRepos)}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-700 hover:text-gray-900"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className={`h-4 w-4 transition-transform ${showRepos ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+              GitHub Repos ({repos.length})
+            </button>
+            {showRepos && (
+              <div className="mt-2 bg-white rounded-lg border border-gray-200 p-4">
+                <p className="text-xs text-gray-500 mb-3">Add GitHub repos to clone into your work nodes at boot. Provide the git SSH URL from GitHub.</p>
+
+                {repoError && (
+                  <div className="bg-red-50 border border-red-200 rounded p-2 mb-3 text-xs text-red-700">{repoError}</div>
+                )}
+
+                {/* Add repo form */}
+                {canAccess("work_nodes", "launch") && (
+                  <div className="flex gap-2 mb-3">
+                    <input
+                      type="text"
+                      value={newRepoUrl}
+                      onChange={(e) => setNewRepoUrl(e.target.value)}
+                      placeholder="git@github.com:owner/repo.git"
+                      className="flex-1 border rounded px-3 py-1.5 text-sm font-mono"
+                    />
+                    <input
+                      type="text"
+                      value={newRepoName}
+                      onChange={(e) => setNewRepoName(e.target.value)}
+                      placeholder="Display name (optional)"
+                      className="w-48 border rounded px-3 py-1.5 text-sm"
+                    />
+                    <button
+                      onClick={handleAddRepo}
+                      disabled={addingRepo || !newRepoUrl.trim()}
+                      className="px-3 py-1.5 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
+                    >
+                      {addingRepo ? "Adding..." : "Add"}
+                    </button>
+                  </div>
+                )}
+
+                {/* Repo list */}
+                {repos.length === 0 ? (
+                  <p className="text-xs text-gray-400">No repos configured yet.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {repos.map((repo) => (
+                      <div key={repo.id} className="flex items-center justify-between py-1.5 px-2 bg-gray-50 rounded text-sm">
+                        <div>
+                          <span className="font-medium">{repo.display_name}</span>
+                          <span className="text-gray-400 font-mono text-xs ml-2">{repo.git_ssh_url}</span>
+                        </div>
+                        {canAccess("work_nodes", "launch") && (
+                          <button
+                            onClick={() => handleDeleteRepo(repo.id)}
+                            className="text-red-500 hover:text-red-700 text-xs"
+                          >
+                            Remove
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -337,18 +470,45 @@ export default function WorkNodesPage() {
                     <span className="text-gray-500">Resources</span>
                     <span>{viewingNode.cpu_cores} CPU / {viewingNode.memory_gb} GB RAM</span>
                   </div>
+                  {viewingNode.gce_instance_name && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">VM Instance</span>
+                      <span className="font-mono text-xs">{viewingNode.gce_instance_name}</span>
+                    </div>
+                  )}
+                  {viewingNode.gce_zone && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">Zone</span>
+                      <span>{viewingNode.gce_zone}</span>
+                    </div>
+                  )}
                   {viewingNode.access_url && viewingNode.status === "running" && (
                     <div>
                       <span className="text-gray-500 block mb-1">SSH Command</span>
                       <div className="bg-gray-900 text-green-400 rounded p-3 font-mono text-xs flex items-center justify-between">
-                        <code>ssh {viewingNode.access_url.replace("ssh://", "").replace(/:\d+/, "")}</code>
+                        <code>{extractSshCommand(viewingNode.access_url)}</code>
                         <button
-                          onClick={() => navigator.clipboard.writeText(`ssh ${viewingNode.access_url?.replace("ssh://", "").replace(/:\d+/, "") ?? ""}`)}
+                          onClick={() => navigator.clipboard.writeText(extractSshCommand(viewingNode.access_url))}
                           className="ml-2 text-gray-400 hover:text-white text-xs"
                         >
                           Copy
                         </button>
                       </div>
+                    </div>
+                  )}
+                  {viewingNode.github_repo_ids && viewingNode.github_repo_ids.length > 0 && (
+                    <div>
+                      <span className="text-gray-500 block mb-1">Cloned Repos</span>
+                      <ul className="text-xs text-gray-700 space-y-1">
+                        {viewingNode.github_repo_ids.map((repoId) => {
+                          const repo = repos.find((r) => r.id === repoId);
+                          return (
+                            <li key={repoId} className="font-mono bg-gray-50 px-2 py-1 rounded">
+                              ~/repos/{repo?.display_name || `repo-${repoId}`}
+                            </li>
+                          );
+                        })}
+                      </ul>
                     </div>
                   )}
                   {viewingNode.data_mount_paths && viewingNode.data_mount_paths.length > 0 && (
@@ -391,7 +551,7 @@ export default function WorkNodesPage() {
             </div>
           )}
 
-          {/* Launch dialog */}
+          {/* Launch dialog -- 6 steps */}
           {showLaunch && (
             <div className="fixed inset-0 bg-black/30 z-50 flex items-center justify-center" onClick={() => setShowLaunch(false)}>
               <div className="bg-white rounded-lg shadow-xl max-w-xl w-full mx-4 p-6 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
@@ -402,7 +562,7 @@ export default function WorkNodesPage() {
 
                 {/* Step indicators */}
                 <div className="flex gap-2 mb-6">
-                  {[1, 2, 3, 4, 5].map((s) => (
+                  {[1, 2, 3, 4, 5, 6].map((s) => (
                     <div key={s} className={`h-1 flex-1 rounded ${s <= launchStep ? "bg-indigo-600" : "bg-gray-200"}`} />
                   ))}
                 </div>
@@ -466,23 +626,29 @@ export default function WorkNodesPage() {
                 {launchStep === 3 && (
                   <div>
                     <h3 className="font-medium mb-3">Select Environment</h3>
-                    <div className="space-y-2 max-h-60 overflow-y-auto">
-                      {environments.map((env) => (
-                        <button
-                          key={env.id}
-                          onClick={() => { handleEnvSelect(env.id); }}
-                          className={`w-full text-left p-3 border rounded-lg hover:border-indigo-400 transition-colors ${selectedEnvId === env.id ? "border-indigo-500 bg-indigo-50" : ""}`}
-                        >
-                          <div className="font-medium text-sm">{env.name}</div>
-                          {env.description && <div className="text-xs text-gray-500 mt-0.5">{env.description}</div>}
-                          {env.latest_version && (
-                            <div className="text-xs text-gray-400 mt-1">
-                              v{env.latest_version.version_number} - {env.latest_version.status}
-                            </div>
-                          )}
-                        </button>
-                      ))}
-                    </div>
+                    {environments.length === 0 ? (
+                      <div className="bg-yellow-50 border border-yellow-200 rounded p-3 text-sm text-yellow-700">
+                        No work node environments found. Create one from the <a href="/environments" className="underline font-medium">Environments</a> page with type &quot;Work Node&quot;.
+                      </div>
+                    ) : (
+                      <div className="space-y-2 max-h-60 overflow-y-auto">
+                        {environments.map((env) => (
+                          <button
+                            key={env.id}
+                            onClick={() => { handleEnvSelect(env.id); }}
+                            className={`w-full text-left p-3 border rounded-lg hover:border-indigo-400 transition-colors ${selectedEnvId === env.id ? "border-indigo-500 bg-indigo-50" : ""}`}
+                          >
+                            <div className="font-medium text-sm">{env.name}</div>
+                            {env.description && <div className="text-xs text-gray-500 mt-0.5">{env.description}</div>}
+                            {env.latest_version && (
+                              <div className="text-xs text-gray-400 mt-1">
+                                v{env.latest_version.version_number} - {env.latest_version.status}
+                              </div>
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                     {envDetail && (
                       <div className="mt-3">
                         <label className="text-xs font-medium text-gray-600">Version</label>
@@ -513,8 +679,42 @@ export default function WorkNodesPage() {
                   </div>
                 )}
 
-                {/* Step 4: Select machine type */}
+                {/* Step 4: Select GitHub repos */}
                 {launchStep === 4 && (
+                  <div>
+                    <h3 className="font-medium mb-3">Select GitHub Repos</h3>
+                    <p className="text-xs text-gray-500 mb-3">These repos will be cloned into ~/repos/ when the node boots.</p>
+                    {repos.length === 0 ? (
+                      <p className="text-sm text-gray-400">No repos configured. You can add them from the GitHub Repos section on this page.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {repos.map((repo) => (
+                          <label key={repo.id} className="flex items-start gap-3 p-3 border rounded-lg hover:bg-gray-50 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={selectedRepoIds.includes(repo.id)}
+                              onChange={() => toggleRepo(repo.id)}
+                              className="mt-0.5"
+                            />
+                            <div>
+                              <div className="text-sm font-medium">{repo.display_name}</div>
+                              <div className="text-xs text-gray-400 font-mono mt-0.5">{repo.git_ssh_url}</div>
+                            </div>
+                          </label>
+                        ))}
+                      </div>
+                    )}
+                    <div className="flex gap-2 mt-4">
+                      <button onClick={() => setLaunchStep(3)} className="px-4 py-2 border rounded text-sm">Back</button>
+                      <button onClick={() => setLaunchStep(5)} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">
+                        Next
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Step 5: Select machine type */}
+                {launchStep === 5 && (
                   <div>
                     <h3 className="font-medium mb-3">Select Machine Type</h3>
                     {Object.entries(
@@ -547,9 +747,9 @@ export default function WorkNodesPage() {
                       </div>
                     ))}
                     <div className="flex gap-2 mt-4">
-                      <button onClick={() => setLaunchStep(3)} className="px-4 py-2 border rounded text-sm">Back</button>
+                      <button onClick={() => setLaunchStep(4)} className="px-4 py-2 border rounded text-sm">Back</button>
                       <button
-                        onClick={() => setLaunchStep(5)}
+                        onClick={() => setLaunchStep(6)}
                         disabled={!selectedMachineType}
                         className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
                       >
@@ -559,8 +759,8 @@ export default function WorkNodesPage() {
                   </div>
                 )}
 
-                {/* Step 5: Review and launch */}
-                {launchStep === 5 && (
+                {/* Step 6: Review and launch */}
+                {launchStep === 6 && (
                   <div>
                     <h3 className="font-medium mb-3">Review</h3>
                     <div className="space-y-2 text-sm bg-gray-50 rounded-lg p-4">
@@ -577,6 +777,10 @@ export default function WorkNodesPage() {
                         <span>{environments.find((e) => e.id === selectedEnvId)?.name}</span>
                       </div>
                       <div className="flex justify-between">
+                        <span className="text-gray-500">Repos</span>
+                        <span>{selectedRepoIds.length > 0 ? selectedRepoIds.length + " repos" : "None"}</span>
+                      </div>
+                      <div className="flex justify-between">
                         <span className="text-gray-500">Machine Type</span>
                         <span className="font-mono">{selectedMachineType}</span>
                       </div>
@@ -591,7 +795,7 @@ export default function WorkNodesPage() {
                       })()}
                     </div>
                     <div className="flex gap-2 mt-4">
-                      <button onClick={() => setLaunchStep(4)} className="px-4 py-2 border rounded text-sm">Back</button>
+                      <button onClick={() => setLaunchStep(5)} className="px-4 py-2 border rounded text-sm">Back</button>
                       <button
                         onClick={handleLaunch}
                         disabled={launching}

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -560,10 +560,10 @@ export default function WorkNodesPage() {
                       </ul>
                     </div>
                   )}
-                  {viewingNode.data_mount_paths && viewingNode.data_mount_paths.length > 0 && (
+                  {viewingNode.input_file_ids && viewingNode.input_file_ids.length > 0 && (
                     <div className="flex justify-between">
                       <span className="text-gray-500">Input Files</span>
-                      <span>{viewingNode.data_mount_paths.length} file(s) in /data/</span>
+                      <span>{viewingNode.input_file_ids.length} file(s) in /data/</span>
                     </div>
                   )}
                   <div className="flex justify-between">

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -33,6 +33,11 @@ const STATUS_COLORS: Record<string, string> = {
   failed: "bg-red-100 text-red-800",
 };
 
+function statusLabel(node: WorkNode): string {
+  if (node.status === "failed" && !node.access_url) return "Resource Failure";
+  return node.status;
+}
+
 const CATEGORY_LABELS: Record<string, string> = {
   standard: "Standard",
   "high-memory": "High Memory",
@@ -461,7 +466,7 @@ export default function WorkNodesPage() {
                           </span>
                         ) : (
                           <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[node.status] || "bg-gray-100"}`}>
-                            {node.status}
+                            {statusLabel(node)}
                           </span>
                         )}
                       </td>
@@ -508,9 +513,14 @@ export default function WorkNodesPage() {
                   <div className="flex justify-between">
                     <span className="text-gray-500">Status</span>
                     <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[viewingNode.status] || "bg-gray-100"}`}>
-                      {viewingNode.status}
+                      {statusLabel(viewingNode)}
                     </span>
                   </div>
+                  {viewingNode.status === "failed" && !viewingNode.access_url && (
+                    <div className="bg-red-50 border border-red-200 rounded p-2 text-xs text-red-700">
+                      GCP Resources Unavailable -- the VM could not be created. Try again later or choose a different machine type.
+                    </div>
+                  )}
                   <div className="flex justify-between">
                     <span className="text-gray-500">Machine Type</span>
                     <span>{viewingNode.machine_type || "-"}</span>

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -168,7 +168,7 @@ export default function WorkNodesPage() {
     setSelectedFileIds([]);
     setShowFileSelector(false);
     try {
-      const data = await api.get<FileListResponse>(`/api/v1/files?project_id=${projectId}&page_size=500`);
+      const data = await api.get<FileListResponse>(`/api/files?project_id=${projectId}&page_size=500`);
       setProjectFiles(data.files);
       setSampleNames({});
     } catch {

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -35,6 +35,7 @@ const STATUS_COLORS: Record<string, string> = {
 
 function statusLabel(node: WorkNode): string {
   if (node.status === "failed" && !node.access_url) return "Resource Failure";
+  if (node.status === "stopping") return "Syncing outputs...";
   return node.status;
 }
 
@@ -93,8 +94,8 @@ export default function WorkNodesPage() {
 
   // Auto-refresh while starting
   useEffect(() => {
-    const hasStarting = nodes.some((n) => n.status === "starting");
-    if (!hasStarting) return;
+    const hasInProgress = nodes.some((n) => n.status === "starting" || n.status === "stopping");
+    if (!hasInProgress) return;
     const interval = setInterval(() => loadNodes(), 10000);
     return () => clearInterval(interval);
   }, [nodes]);

--- a/frontend/src/app/workbench/work-nodes/page.tsx
+++ b/frontend/src/app/workbench/work-nodes/page.tsx
@@ -8,18 +8,20 @@ import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { isAuthenticated } from "@/lib/auth";
 import { api, ApiError } from "@/lib/api";
 import { usePermissions } from "@/hooks/usePermissions";
+import { FileTreeSelector } from "@/components/notebooks/FileTreeSelector";
 import type {
   WorkNode,
   WorkNodeListResponse,
   WorkNodeLaunchRequest,
   MachineType,
-  DataMount,
   Project,
   EnvironmentResponse,
   EnvironmentListResponse,
   EnvironmentDetailResponse,
   GitHubRepo,
   GitHubRepoListResponse,
+  FileResponse,
+  FileListResponse,
 } from "@/lib/types";
 
 const STATUS_COLORS: Record<string, string> = {
@@ -58,8 +60,10 @@ export default function WorkNodesPage() {
   const [launchStep, setLaunchStep] = useState(1);
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
-  const [dataMounts, setDataMounts] = useState<DataMount[]>([]);
-  const [selectedMounts, setSelectedMounts] = useState<string[]>([]);
+  const [projectFiles, setProjectFiles] = useState<FileResponse[]>([]);
+  const [sampleNames, setSampleNames] = useState<Record<number, string>>({});
+  const [selectedFileIds, setSelectedFileIds] = useState<number[]>([]);
+  const [showFileSelector, setShowFileSelector] = useState(false);
   const [environments, setEnvironments] = useState<EnvironmentResponse[]>([]);
   const [selectedEnvId, setSelectedEnvId] = useState<number | null>(null);
   const [envDetail, setEnvDetail] = useState<EnvironmentDetailResponse | null>(null);
@@ -136,7 +140,10 @@ export default function WorkNodesPage() {
     setShowLaunch(true);
     setLaunchStep(1);
     setSelectedProjectId(null);
-    setSelectedMounts([]);
+    setProjectFiles([]);
+    setSampleNames({});
+    setSelectedFileIds([]);
+    setShowFileSelector(false);
     setSelectedEnvId(null);
     setEnvDetail(null);
     setSelectedVersionId(null);
@@ -158,11 +165,14 @@ export default function WorkNodesPage() {
 
   async function handleProjectSelect(projectId: number) {
     setSelectedProjectId(projectId);
+    setSelectedFileIds([]);
+    setShowFileSelector(false);
     try {
-      const mounts = await api.get<DataMount[]>(`/api/v1/work-nodes/data-mounts/${projectId}`);
-      setDataMounts(mounts);
+      const data = await api.get<FileListResponse>(`/api/v1/files?project_id=${projectId}&page_size=500`);
+      setProjectFiles(data.files);
+      setSampleNames({});
     } catch {
-      setDataMounts([]);
+      setProjectFiles([]);
     }
     setLaunchStep(2);
   }
@@ -175,12 +185,6 @@ export default function WorkNodesPage() {
       const readyVersion = detail.versions.find((v) => v.status === "ready" && v.image_uri);
       if (readyVersion) setSelectedVersionId(readyVersion.id);
     } catch {}
-  }
-
-  function toggleMount(path: string) {
-    setSelectedMounts((prev) =>
-      prev.includes(path) ? prev.filter((p) => p !== path) : [...prev, path]
-    );
   }
 
   function toggleRepo(repoId: number) {
@@ -198,7 +202,7 @@ export default function WorkNodesPage() {
         project_id: selectedProjectId,
         environment_version_id: selectedVersionId,
         machine_type: selectedMachineType,
-        data_mount_paths: selectedMounts.length > 0 ? selectedMounts : undefined,
+        input_file_ids: selectedFileIds.length > 0 ? selectedFileIds : undefined,
         github_repo_ids: selectedRepoIds.length > 0 ? selectedRepoIds : undefined,
       };
       await api.post("/api/v1/work-nodes/sessions", req);
@@ -512,13 +516,9 @@ export default function WorkNodesPage() {
                     </div>
                   )}
                   {viewingNode.data_mount_paths && viewingNode.data_mount_paths.length > 0 && (
-                    <div>
-                      <span className="text-gray-500 block mb-1">Data Mounts</span>
-                      <ul className="text-xs text-gray-700 space-y-1">
-                        {viewingNode.data_mount_paths.map((p) => (
-                          <li key={p} className="font-mono bg-gray-50 px-2 py-1 rounded">/data/{p.replace(/^\//, "")}</li>
-                        ))}
-                      </ul>
+                    <div className="flex justify-between">
+                      <span className="text-gray-500">Input Files</span>
+                      <span>{viewingNode.data_mount_paths.length} file(s) in /data/</span>
                     </div>
                   )}
                   <div className="flex justify-between">
@@ -591,28 +591,33 @@ export default function WorkNodesPage() {
                   </div>
                 )}
 
-                {/* Step 2: Select data mounts */}
+                {/* Step 2: Select input files */}
                 {launchStep === 2 && (
                   <div>
-                    <h3 className="font-medium mb-3">Select Data Directories</h3>
-                    <p className="text-xs text-gray-500 mb-3">These will be mounted read-only at /data/</p>
-                    <div className="space-y-2">
-                      {dataMounts.map((mount) => (
-                        <label key={mount.path} className="flex items-start gap-3 p-3 border rounded-lg hover:bg-gray-50 cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={selectedMounts.includes(mount.path)}
-                            onChange={() => toggleMount(mount.path)}
-                            className="mt-0.5"
+                    <h3 className="font-medium mb-3">Select Input Files</h3>
+                    <p className="text-xs text-gray-500 mb-3">Selected files will be copied to /data/ when the node boots (optional)</p>
+                    {projectFiles.length === 0 ? (
+                      <p className="text-sm text-gray-400">No files found for this project.</p>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => setShowFileSelector(!showFileSelector)}
+                          className="text-xs text-indigo-600 hover:underline mb-2"
+                        >
+                          {showFileSelector ? "Hide file picker" : `Select files (${projectFiles.length} available)`}
+                        </button>
+                        {showFileSelector && (
+                          <FileTreeSelector
+                            files={projectFiles}
+                            sampleNames={sampleNames}
+                            onSelectionChange={setSelectedFileIds}
                           />
-                          <div>
-                            <div className="text-sm font-medium">{mount.label}</div>
-                            <div className="text-xs text-gray-500">{mount.description}</div>
-                            <div className="text-xs text-gray-400 font-mono mt-0.5">{mount.path}</div>
-                          </div>
-                        </label>
-                      ))}
-                    </div>
+                        )}
+                        {!showFileSelector && selectedFileIds.length > 0 && (
+                          <p className="text-xs text-gray-500">{selectedFileIds.length} file(s) selected</p>
+                        )}
+                      </>
+                    )}
                     <div className="flex gap-2 mt-4">
                       <button onClick={() => setLaunchStep(1)} className="px-4 py-2 border rounded text-sm">Back</button>
                       <button onClick={() => setLaunchStep(3)} className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">
@@ -769,8 +774,8 @@ export default function WorkNodesPage() {
                         <span>{projects.find((p) => p.id === selectedProjectId)?.name}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-500">Data Mounts</span>
-                        <span>{selectedMounts.length > 0 ? selectedMounts.length + " directories" : "None"}</span>
+                        <span className="text-gray-500">Input Files</span>
+                        <span>{selectedFileIds.length > 0 ? selectedFileIds.length + " files" : "None"}</span>
                       </div>
                       <div className="flex justify-between">
                         <span className="text-gray-500">Environment</span>

--- a/frontend/src/components/notebooks/FileTreeSelector.tsx
+++ b/frontend/src/components/notebooks/FileTreeSelector.tsx
@@ -40,6 +40,7 @@ function gcsSubpath(gcsUri: string): string {
 const SOURCE_LABELS: Record<string, string> = {
   pipeline_output: "Pipeline",
   notebook_output: "Notebook",
+  work_node_output: "Work Node",
   upload: "Upload",
 };
 
@@ -50,6 +51,7 @@ function sourceLabel(sourceType: string): string {
 const SOURCE_COLORS: Record<string, string> = {
   pipeline_output: "bg-purple-100 text-purple-700",
   notebook_output: "bg-teal-100 text-teal-700",
+  work_node_output: "bg-orange-100 text-orange-700",
   upload: "bg-gray-100 text-gray-600",
 };
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1599,7 +1599,7 @@ export interface WorkNode {
   project_id: number | null;
   environment_version_id: number | null;
   machine_type: string | null;
-  data_mount_paths: string[] | null;
+  input_file_ids: number[] | null;
   resource_profile: string;
   cpu_cores: number;
   memory_gb: number;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1174,6 +1174,7 @@ export interface EnvironmentDetailResponse {
   name: string;
   description: string | null;
   visibility: "team" | "organization";
+  environment_type: "notebook" | "work_node";
   versions: EnvironmentVersionSummary[];
   created_by: UserSummary | null;
   created_at: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1156,6 +1156,7 @@ export interface EnvironmentResponse {
   name: string;
   description: string | null;
   visibility: "team" | "organization";
+  environment_type: "notebook" | "work_node";
   version_count: number;
   latest_version: EnvironmentVersionSummary | null;
   created_by: UserSummary | null;
@@ -1588,7 +1589,7 @@ export interface VocabularyResponse {
   values: VocabularyValue[];
 }
 
-// Work Nodes (ADR-034)
+// Work Nodes (ADR-034, ADR-043)
 
 export interface WorkNode {
   id: number;
@@ -1603,6 +1604,9 @@ export interface WorkNode {
   memory_gb: number;
   status: string;
   access_url: string | null;
+  gce_instance_name: string | null;
+  gce_zone: string | null;
+  github_repo_ids: number[] | null;
   heartbeat_at: string | null;
   started_at: string | null;
   stopped_at: string | null;
@@ -1619,6 +1623,19 @@ export interface WorkNodeLaunchRequest {
   environment_version_id: number;
   machine_type: string;
   data_mount_paths?: string[];
+  github_repo_ids?: number[];
+}
+
+export interface GitHubRepo {
+  id: number;
+  git_ssh_url: string;
+  display_name: string;
+  created_at: string;
+}
+
+export interface GitHubRepoListResponse {
+  repos: GitHubRepo[];
+  total: number;
 }
 
 export interface MachineType {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1623,7 +1623,7 @@ export interface WorkNodeLaunchRequest {
   project_id: number;
   environment_version_id: number;
   machine_type: string;
-  data_mount_paths?: string[];
+  input_file_ids?: number[];
   github_repo_ids?: number[];
 }
 

--- a/frontend/tests/pages/notebooks.test.tsx
+++ b/frontend/tests/pages/notebooks.test.tsx
@@ -159,7 +159,7 @@ describe("NotebooksPage", () => {
   });
 
   // Test 33: Active sessions table
-  it("renders active sessions table with Open, Stop, Sync buttons", async () => {
+  it("renders active sessions table with Open, Stop, Details buttons", async () => {
     mockApiGet.mockImplementation((url: string) => {
       if (url.includes("sessions")) return Promise.resolve(mockSessions);
       if (url.includes("experiments")) return Promise.resolve(mockExperiments);
@@ -173,7 +173,7 @@ describe("NotebooksPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Open")).toBeInTheDocument();
       expect(screen.getByText("Stop")).toBeInTheDocument();
-      expect(screen.getByText("Sync")).toBeInTheDocument();
+      expect(screen.getByText("Details")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Migrate work nodes from GKE Pods to GCE VMs with full Linux SSH access (ADR-043)
- Build work node images via Packer with conda environments pre-installed
- Separate environment types (Notebook vs Work Node) with conda-only enforcement for work nodes
- Add GitHub repo management and auto-cloning at boot
- Replace data mount categories with experiment-level file picker using FileTreeSelector
- Add filename search, project/experiment/source filters to the Files page
- Add zone retry, E2 machine types, resource failure UX, and stop persistence

## Test plan

- [x] Default Work Node environment seeds on startup
- [x] Packer VM image builds successfully via Cloud Build
- [x] Work node launches as GCE VM with SSH access (password auth)
- [x] GitHub repos clone into ~/repos/ at boot
- [x] Input files copy to /data/ with hierarchical paths
- [x] Output files sync to GCS on stop and register as work_node_output
- [x] Environment type filter/badge works on Environments page
- [x] File picker shows experiment files grouped by sample
- [x] Files page search and filters work (project inherits via experiment)
- [x] Zone retry handles capacity exhaustion across us-central1
- [x] Stopping status persists immediately so UI doesn't show stale state