### PR TITLE
Bump backend version to 0.10.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.9.0"
+version = "0.10.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

- Bumps `backend/pyproject.toml` from `0.9.0` to `0.10.0`. The custom-pipelines work merged in #254 added a `## v0.10.0` section to RELEASE_NOTES but didn't bump the version string, so the Release workflow on the post-merge push read `0.9.0`, found the existing `v0.9.0` tag, and skipped both `Tag & Release` and `publish-images`. As a result no `v0.10.0` tag was cut and no Docker images were pushed to GHCR.

## Test plan

- [ ] Merge to main triggers `.github/workflows/release.yml`
- [ ] `Tag & Release` step reads `VERSION=0.10.0`, creates tag `v0.10.0`, and creates the GitHub release with the v0.10.0 release notes
- [ ] `Publish Docker Images` runs and pushes `ghcr.io/not-that-guy-again/bioaf-{backend,frontend,cellxgene}:v0.10.0` and `:latest`