### PR TITLE
v0.10.3: Reference Data Ingest

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## v0.11.0
+## v0.10.3
 
 Reference Data Ingest — completes the four user-facing capabilities of ADR-017 / ADR-047 (upload, import-from-URL, versioning, and pipeline linkage). Existing reference data CRUD is unchanged; this release adds everything around getting bytes into the registry and using them in pipelines.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,49 @@
 # Release Notes
 
+## v0.11.0
+
+Reference Data Ingest — completes the four user-facing capabilities of ADR-017 / ADR-047 (upload, import-from-URL, versioning, and pipeline linkage). Existing reference data CRUD is unchanged; this release adds everything around getting bytes into the registry and using them in pipelines.
+
+### New features
+
+- **Reference upload** -- drag-drop multi-file upload page at `/data/references/new`. Bytes go directly to GCS via resumable session URLs (8 MiB chunks; 64 MiB for files > 1 GiB) so 30+ GB CellRanger references survive flaky lab Wi-Fi
+- **Import from URL** -- separate page at `/data/references/import` for pulling references from public sources (GENCODE, 10x, etc.). A per-import GKE Job streams the source into GCS, supports `none`/`gzip`/`tar`/`tar.gz` extraction modes, and reports progress via a polling endpoint
+- **Versioning UX** -- reference detail page gets a Versions tab listing every `(name, category)` sibling, with the current row highlighted and deprecated rows dimmed. New "Upload new version" button pre-fills name + category + scope and locks them so only version + files differ
+- **Reference parameter type for custom pipelines** -- custom pipelines can declare a parameter as `variable_type='reference'` with a `reference_category` (`genome`/`annotation`/`index`/`atlas`/`markers`/`other`/`any`). At launch, those parameters render a searchable dropdown of active references in that category; the selected dataset's path is stored in run parameters so the existing auto-linker picks it up
+- **Linked references on run detail** -- the "References Used" table on `/pipelines/runs/[id]` adds a Category column and turns each reference name into a link back to its detail page
+
+### New endpoints
+
+- `POST /api/references/upload-init` -- create a reference in `status='uploading'` and return per-file GCS resumable session URLs
+- `POST /api/references/{id}/upload-complete` -- list the GCS prefix, verify every declared file arrived, persist md5 + size, flip status (`internal -> active`, `public -> pending_approval`, mismatch -> `failed` with prefix purge)
+- `POST /api/references/{id}/abort` -- purge GCS objects and delete the reference row (idempotent)
+- `POST /api/references/import` -- launch the importer GKE Job
+- `GET /api/references/{id}/import-status` -- read progress (`pending`/`downloading`/`verifying`/`extracting`/`finalizing`/`active`/`failed`)
+- `POST /api/references/{id}/import-cancel` -- terminate the GKE Job and abort the reference
+- `GET /api/references/by-name?name=...&category=...` -- return every version for a `(name, category)` tuple in one round-trip
+- `POST /api/internal/references/{id}/import-progress` -- importer-container callback authenticated by `X-Internal-Token` (settings.internal_token); the auth middleware exempts `/api/internal/*` so the container can reach it without a user JWT
+
+### Roles & permissions
+
+- New `references` resource with `view` and `upload` actions. Migration 071 backfills both for `admin`/`comp_bio` and `view` for `bench`/`viewer` on existing system roles. Existing endpoints unchanged; new endpoints use `references:upload`
+
+### Database (additive only)
+
+- Migration 071: backfill `references:view`/`upload` permissions
+- Migration 072: `reference_import_progress` table tracking GKE-job-driven imports (PK `reference_id`, cascade delete)
+- Migration 073: `custom_pipeline_variables.reference_category` column
+- `REFERENCE_STATUSES` extended with `uploading` and `failed`
+
+### Infrastructure
+
+- Terraform `storage` module gains a `bioaf-references-{org_slug}-{stack_uid}` bucket with versioning + CORS for browser PUT/POST
+- New platform_config key `references_bucket_name`, populated by the storage stack on apply
+- New env var `BIOAF_INTERNAL_TOKEN` for the importer-callback secret
+
+### Spec
+
+- `documentation/spec-reference-data-ingest.md` is the source of truth for this release
+
 ## v0.10.2
 
 Point release adding per-pipeline QC dashboard configuration. Existing scRNA-seq dashboards render identically; new templates plug in by shipping a config + extractor instead of forking the dashboard page.

--- a/backend/alembic/versions/071_add_references_resource_permissions.py
+++ b/backend/alembic/versions/071_add_references_resource_permissions.py
@@ -1,0 +1,52 @@
+"""Backfill `references` resource permissions for existing system roles.
+
+Revision ID: 071
+Revises: 070
+Create Date: 2026-05-04
+
+The Reference Data Ingest spec (ADR-047) introduces a dedicated
+`references` resource with `view` and `upload` actions, replacing the
+prior reuse of `pipelines:*` for reference data CRUD. Bootstrap_roles
+seeds these for new orgs; this migration backfills existing system
+roles (admin, comp_bio, bench, viewer).
+"""
+
+from alembic import op
+
+revision = "071"
+down_revision = "070"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # admin and comp_bio: view + upload
+    op.execute(
+        """
+        INSERT INTO role_permissions (role_id, resource, action)
+        SELECT r.id, perm.resource, perm.action
+        FROM roles r
+        CROSS JOIN (VALUES ('references', 'view'), ('references', 'upload')) AS perm(resource, action)
+        WHERE r.name IN ('admin', 'comp_bio') AND r.is_system = true
+        ON CONFLICT DO NOTHING
+        """
+    )
+    # bench and viewer: view only
+    op.execute(
+        """
+        INSERT INTO role_permissions (role_id, resource, action)
+        SELECT r.id, 'references', 'view'
+        FROM roles r
+        WHERE r.name IN ('bench', 'viewer') AND r.is_system = true
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM role_permissions
+        WHERE resource = 'references'
+        """
+    )

--- a/backend/alembic/versions/072_add_reference_import_progress.py
+++ b/backend/alembic/versions/072_add_reference_import_progress.py
@@ -1,0 +1,45 @@
+"""Add reference_import_progress table.
+
+Revision ID: 072
+Revises: 071
+Create Date: 2026-05-04
+
+Spec §3 — tracks GKE-job-driven reference imports. One row per
+ReferenceDataset (1:1 via reference_id PK with cascade delete).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "072"
+down_revision = "071"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reference_import_progress",
+        sa.Column(
+            "reference_id",
+            sa.Integer(),
+            sa.ForeignKey("reference_datasets.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column("import_job_id", sa.String(length=100), nullable=True),
+        sa.Column("progress_pct", sa.Integer(), nullable=True),
+        sa.Column("bytes_downloaded", sa.BigInteger(), nullable=True),
+        sa.Column("total_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reference_import_progress")

--- a/backend/alembic/versions/073_add_reference_category_to_pipeline_vars.py
+++ b/backend/alembic/versions/073_add_reference_category_to_pipeline_vars.py
@@ -1,0 +1,29 @@
+"""Add `reference_category` column to custom_pipeline_variables.
+
+Revision ID: 073
+Revises: 072
+Create Date: 2026-05-04
+
+Spec §5 — when variable_type='reference', this column scopes the
+launch-time dropdown to a single reference category. Nullable because
+existing string/number/boolean variables don't use it.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "073"
+down_revision = "072"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "custom_pipeline_variables",
+        sa.Column("reference_category", sa.String(length=50), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("custom_pipeline_variables", "reference_category")

--- a/backend/app/api/internal_references.py
+++ b/backend/app/api/internal_references.py
@@ -1,0 +1,47 @@
+"""Internal callback endpoints used by the reference-import GKE container.
+
+Authenticated by `X-Internal-Token` matching settings.internal_token (rotated,
+not user-scoped). The importer container has no user identity.
+"""
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_session
+from app.schemas.reference_dataset import ReferenceImportProgressUpdate
+from app.services.reference_data_service import ReferenceDataService
+
+router = APIRouter(prefix="/api/internal/references", tags=["internal"])
+
+
+def _require_internal_token(x_internal_token: str | None = Header(default=None)) -> None:
+    expected = settings.internal_token
+    if not expected or not x_internal_token or x_internal_token != expected:
+        raise HTTPException(401, "Invalid or missing internal token")
+
+
+@router.post("/{reference_id}/import-progress")
+async def report_import_progress(
+    reference_id: int,
+    payload: ReferenceImportProgressUpdate,
+    _auth: None = Depends(_require_internal_token),
+    session: AsyncSession = Depends(get_session),
+):
+    """Update the import-progress row. Called by the importer container."""
+    try:
+        await ReferenceDataService.record_import_progress(
+            session,
+            reference_id=reference_id,
+            status=payload.status,
+            progress_pct=payload.progress_pct,
+            bytes_downloaded=payload.bytes_downloaded,
+            total_bytes=payload.total_bytes,
+            error_message=payload.error_message,
+        )
+        await session.commit()
+    except ValueError as e:
+        await session.rollback()
+        raise HTTPException(404, str(e))
+
+    return {"ok": True}

--- a/backend/app/api/references.py
+++ b/backend/app/api/references.py
@@ -1,6 +1,6 @@
 """Reference data management API endpoints."""
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_permission
@@ -109,6 +109,55 @@ async def init_upload(
         gcs_prefix=dataset.gcs_prefix,
         uploads=[ReferenceUploadSlot(**u) for u in uploads],
     )
+
+
+@router.post("/{reference_id}/upload-complete", response_model=ReferenceDatasetDetailResponse)
+async def upload_complete(
+    reference_id: int,
+    current_user: dict = require_permission("references", "upload"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Finalize a resumable upload — list GCS, verify files, persist md5+size."""
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+
+    try:
+        await ReferenceDataService.upload_complete(session, reference_id, org_id, user_id)
+        await session.commit()
+    except ValueError as e:
+        await session.rollback()
+        msg = str(e)
+        if "not found" in msg.lower():
+            raise HTTPException(404, msg)
+        if "not configured" in msg.lower():
+            raise HTTPException(503, msg)
+        raise HTTPException(400, msg)
+
+    dataset = await ReferenceDataService.get_reference(session, reference_id, org_id)
+    return _detail_response(dataset)
+
+
+@router.post("/{reference_id}/abort", status_code=204)
+async def abort_upload(
+    reference_id: int,
+    current_user: dict = require_permission("references", "upload"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Abort an in-flight upload: purge GCS objects and delete the row. Idempotent."""
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+
+    try:
+        await ReferenceDataService.abort_upload(session, reference_id, org_id, user_id)
+        await session.commit()
+    except ValueError as e:
+        await session.rollback()
+        msg = str(e)
+        if "not configured" in msg.lower():
+            raise HTTPException(503, msg)
+        raise HTTPException(400, msg)
+
+    return Response(status_code=204)
 
 
 @router.post("", response_model=ReferenceDatasetDetailResponse, status_code=201)

--- a/backend/app/api/references.py
+++ b/backend/app/api/references.py
@@ -72,9 +72,7 @@ async def list_versions_by_name(
 ):
     """Return every version for a (name, category) tuple, newest first."""
     org_id = int(current_user["org_id"])
-    refs, total = await ReferenceDataService.list_versions_by_name(
-        session, org_id, name=name, category=category
-    )
+    refs, total = await ReferenceDataService.list_versions_by_name(session, org_id, name=name, category=category)
     return ReferenceDatasetListResponse(
         references=[_response(r) for r in refs],
         total=total,

--- a/backend/app/api/references.py
+++ b/backend/app/api/references.py
@@ -63,6 +63,24 @@ async def list_references(
     )
 
 
+@router.get("/by-name", response_model=ReferenceDatasetListResponse)
+async def list_versions_by_name(
+    name: str,
+    category: str,
+    current_user: dict = require_permission("pipelines", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Return every version for a (name, category) tuple, newest first."""
+    org_id = int(current_user["org_id"])
+    refs, total = await ReferenceDataService.list_versions_by_name(
+        session, org_id, name=name, category=category
+    )
+    return ReferenceDatasetListResponse(
+        references=[_response(r) for r in refs],
+        total=total,
+    )
+
+
 @router.get("/{reference_id}", response_model=ReferenceDatasetDetailResponse)
 async def get_reference(
     reference_id: int,

--- a/backend/app/api/references.py
+++ b/backend/app/api/references.py
@@ -12,6 +12,9 @@ from app.schemas.reference_dataset import (
     ReferenceDatasetListResponse,
     ReferenceDatasetResponse,
     ReferenceDeprecateRequest,
+    ReferenceImportRequest,
+    ReferenceImportStartResponse,
+    ReferenceImportStatusResponse,
     ReferenceUploadInitRequest,
     ReferenceUploadInitResponse,
     ReferenceUploadSlot,
@@ -109,6 +112,64 @@ async def init_upload(
         gcs_prefix=dataset.gcs_prefix,
         uploads=[ReferenceUploadSlot(**u) for u in uploads],
     )
+
+
+@router.post("/import", response_model=ReferenceImportStartResponse)
+async def start_import(
+    payload: ReferenceImportRequest,
+    current_user: dict = require_permission("references", "upload"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Launch a per-import GKE Job to download a reference from a public URL."""
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+
+    try:
+        dataset, job_id = await ReferenceDataService.start_import(session, org_id, user_id, payload)
+        await session.commit()
+    except ValueError as e:
+        await session.rollback()
+        msg = str(e)
+        if "already exists" in msg:
+            raise HTTPException(409, msg)
+        if "not configured" in msg:
+            raise HTTPException(503, msg)
+        raise HTTPException(400, msg)
+
+    return ReferenceImportStartResponse(reference_id=dataset.id, import_job_id=job_id, status="pending")
+
+
+@router.get("/{reference_id}/import-status", response_model=ReferenceImportStatusResponse)
+async def get_import_status(
+    reference_id: int,
+    current_user: dict = require_permission("references", "view"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Read the in-flight import progress row."""
+    org_id = int(current_user["org_id"])
+    try:
+        return await ReferenceDataService.get_import_status(session, reference_id, org_id)
+    except ValueError as e:
+        raise HTTPException(404, str(e))
+
+
+@router.post("/{reference_id}/import-cancel", status_code=204)
+async def cancel_import(
+    reference_id: int,
+    current_user: dict = require_permission("references", "upload"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Terminate the GKE job and purge the in-flight reference."""
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    try:
+        await ReferenceDataService.cancel_import(session, reference_id, org_id, user_id)
+        await session.commit()
+    except ValueError as e:
+        await session.rollback()
+        raise HTTPException(400, str(e))
+
+    return Response(status_code=204)
 
 
 @router.post("/{reference_id}/upload-complete", response_model=ReferenceDatasetDetailResponse)

--- a/backend/app/api/references.py
+++ b/backend/app/api/references.py
@@ -1,6 +1,6 @@
 """Reference data management API endpoints."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_permission
@@ -12,6 +12,9 @@ from app.schemas.reference_dataset import (
     ReferenceDatasetListResponse,
     ReferenceDatasetResponse,
     ReferenceDeprecateRequest,
+    ReferenceUploadInitRequest,
+    ReferenceUploadInitResponse,
+    ReferenceUploadSlot,
 )
 from app.services.reference_data_service import ReferenceDataService
 
@@ -69,6 +72,43 @@ async def get_reference(
     if not dataset:
         raise HTTPException(404, "Reference dataset not found")
     return _detail_response(dataset)
+
+
+@router.post("/upload-init", response_model=ReferenceUploadInitResponse)
+async def init_upload(
+    payload: ReferenceUploadInitRequest,
+    request: Request,
+    current_user: dict = require_permission("references", "upload"),
+    session: AsyncSession = Depends(get_session),
+):
+    """Initiate a resumable upload session for a new reference dataset.
+
+    Returns one GCS resumable session URL per declared file. The browser then
+    PUTs chunks against those URLs directly.
+    """
+    org_id = int(current_user["org_id"])
+    user_id = int(current_user["sub"])
+    origin = request.headers.get("origin")
+
+    try:
+        dataset, uploads = await ReferenceDataService.init_upload(
+            session, org_id, user_id, payload, request_origin=origin
+        )
+        await session.commit()
+    except ValueError as e:
+        await session.rollback()
+        msg = str(e)
+        if "already exists" in msg:
+            raise HTTPException(409, msg)
+        if "not configured" in msg:
+            raise HTTPException(503, msg)
+        raise HTTPException(400, msg)
+
+    return ReferenceUploadInitResponse(
+        reference_id=dataset.id,
+        gcs_prefix=dataset.gcs_prefix,
+        uploads=[ReferenceUploadSlot(**u) for u in uploads],
+    )
 
 
 @router.post("", response_model=ReferenceDatasetDetailResponse, status_code=201)

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -38,6 +38,7 @@ from app.api.activity_feed import router as activity_feed_router
 from app.api.vocabularies import router as vocabularies_router
 from app.api.pipeline_run_reviews import router as pipeline_run_reviews_router
 from app.api.references import router as references_router
+from app.api.internal_references import router as internal_references_router
 from app.api.geo_export import router as geo_export_router
 from app.api.snapshots import router as snapshots_router
 from app.api.infrastructure import router as infrastructure_router
@@ -107,6 +108,7 @@ api_router.include_router(activity_feed_router)
 api_router.include_router(vocabularies_router)
 api_router.include_router(pipeline_run_reviews_router)
 api_router.include_router(references_router)
+api_router.include_router(internal_references_router)
 api_router.include_router(geo_export_router)
 api_router.include_router(snapshots_router)
 api_router.include_router(infrastructure_router)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -116,6 +116,9 @@ class Settings(BaseSettings):
     # Bcrypt
     bcrypt_rounds: int = 12
 
+    # Internal callbacks (importer container -> bioAF API)
+    internal_token: str = ""
+
     model_config = {"env_prefix": "BIOAF_", "env_file": ".env", "extra": "ignore"}
 
 

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -30,6 +30,10 @@ PUBLIC_PATHS = {
 _FILE_CONTENT_RE = re.compile(r"^/api/files/\d+/content$")
 _PLOT_THUMBNAIL_CONTENT_RE = re.compile(r"^/api/plots/\d+/thumbnail/content$")
 
+# Internal callback endpoints authenticate via X-Internal-Token, not user JWT.
+# The handler validates the header itself; the middleware just lets it through.
+_INTERNAL_CALLBACK_RE = re.compile(r"^/api/internal/")
+
 
 def _is_file_content_path(path: str) -> bool:
     """Return True for paths that accept content-token query-param auth."""
@@ -49,8 +53,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
 
-        is_public = path in PUBLIC_PATHS or (
-            path.startswith("/api/v1/work-nodes/sessions/") and path.endswith("/heartbeat")
+        is_public = (
+            path in PUBLIC_PATHS
+            or (path.startswith("/api/v1/work-nodes/sessions/") and path.endswith("/heartbeat"))
+            or _INTERNAL_CALLBACK_RE.match(path) is not None
         )
 
         # For public endpoints, still attempt to populate current_user if a

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -44,6 +44,7 @@ from app.models.cost_record import CostRecord
 from app.models.controlled_vocabulary import ControlledVocabulary
 from app.models.pipeline_run_review import PipelineRunReview
 from app.models.reference_dataset import ReferenceDataset, ReferenceDatasetFile, pipeline_run_references
+from app.models.reference_import_progress import ReferenceImportProgress
 from app.models.naming_profile import NamingProfile
 from app.models.file_parse_result import FileParseResult
 from app.models.ingest_event import IngestEvent
@@ -117,6 +118,7 @@ __all__ = [
     "PipelineRunReview",
     "ReferenceDataset",
     "ReferenceDatasetFile",
+    "ReferenceImportProgress",
     "pipeline_run_references",
     "NamingProfile",
     "FileParseResult",

--- a/backend/app/models/custom_pipeline_variable.py
+++ b/backend/app/models/custom_pipeline_variable.py
@@ -14,6 +14,9 @@ class CustomPipelineVariable(Base):
     variable_name: Mapped[str] = mapped_column(String(255), nullable=False)
     default_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     variable_type: Mapped[str] = mapped_column(String(50), nullable=False, server_default="string")
+    # When variable_type='reference', this scopes the launch-time picker to a
+    # single reference category (or 'any'). NULL for non-reference variables.
+    reference_category: Mapped[str | None] = mapped_column(String(50), nullable=True)
     is_required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
     version = relationship("CustomPipelineVersion", back_populates="variables")

--- a/backend/app/models/reference_dataset.py
+++ b/backend/app/models/reference_dataset.py
@@ -16,7 +16,7 @@ pipeline_run_references = Table(
 
 REFERENCE_CATEGORIES = ["genome", "annotation", "index", "atlas", "markers", "other"]
 REFERENCE_SCOPES = ["public", "internal"]
-REFERENCE_STATUSES = ["active", "deprecated", "pending_approval"]
+REFERENCE_STATUSES = ["active", "deprecated", "pending_approval", "uploading", "failed"]
 
 
 class ReferenceDataset(Base):

--- a/backend/app/models/reference_import_progress.py
+++ b/backend/app/models/reference_import_progress.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+# Spec §3: status reported on GET /api/references/{id}/import-status
+REFERENCE_IMPORT_STATUSES = [
+    "pending",
+    "downloading",
+    "verifying",
+    "extracting",
+    "finalizing",
+    "active",
+    "failed",
+]
+
+
+class ReferenceImportProgress(Base):
+    """Per-reference import job state, written by the importer container's
+    callback into POST /api/internal/references/{id}/import-progress."""
+
+    __tablename__ = "reference_import_progress"
+
+    reference_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("reference_datasets.id", ondelete="CASCADE"), primary_key=True
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="pending")
+    import_job_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    progress_pct: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    bytes_downloaded: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    total_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/schemas/custom_pipeline.py
+++ b/backend/app/schemas/custom_pipeline.py
@@ -1,6 +1,18 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+# Match REFERENCE_CATEGORIES from app.models.reference_dataset, plus 'any'
+# meaning "match any category".
+VALID_REFERENCE_CATEGORIES = {
+    "genome",
+    "annotation",
+    "index",
+    "atlas",
+    "markers",
+    "other",
+    "any",
+}
 
 
 # --- Request schemas ---
@@ -19,8 +31,22 @@ class CustomPipelineUpdateRequest(BaseModel):
 class CustomPipelineVariableDefinition(BaseModel):
     variable_name: str = Field(..., min_length=1, max_length=255)
     default_value: str | None = None
-    variable_type: str = Field("string", pattern="^(string|number|boolean)$")
+    variable_type: str = Field("string", pattern="^(string|number|boolean|reference)$")
+    reference_category: str | None = None
     is_required: bool = False
+
+    @model_validator(mode="after")
+    def _validate_reference_category(self) -> "CustomPipelineVariableDefinition":
+        if self.variable_type == "reference":
+            if not self.reference_category:
+                raise ValueError("reference_category is required when variable_type='reference'")
+            if self.reference_category not in VALID_REFERENCE_CATEGORIES:
+                raise ValueError(f"reference_category must be one of: {', '.join(sorted(VALID_REFERENCE_CATEGORIES))}")
+        elif self.reference_category is not None:
+            # Silently drop reference_category for non-reference types so we
+            # never persist nonsense.
+            self.reference_category = None
+        return self
 
 
 class CustomPipelineVariableValue(BaseModel):
@@ -58,6 +84,7 @@ class CustomPipelineVariableResponse(BaseModel):
     variable_name: str
     default_value: str | None = None
     variable_type: str
+    reference_category: str | None = None
     is_required: bool
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/reference_dataset.py
+++ b/backend/app/schemas/reference_dataset.py
@@ -93,6 +93,75 @@ class ReferenceUploadInitResponse(BaseModel):
     uploads: list[ReferenceUploadSlot]
 
 
+# --- Import-from-URL (GKE Job) schemas — spec §3 ---
+
+
+VALID_EXTRACT_MODES = ["none", "gzip", "tar", "tar.gz"]
+
+
+class ReferenceImportRequest(BaseModel):
+    name: str
+    category: str
+    scope: str
+    version: str
+    source_url: str
+    source_md5_url: str | None = None
+    auth_header: str | None = None
+    extract: str = "none"
+    expected_files: list[str] | None = None
+    description: str | None = None
+
+    @field_validator("category")
+    @classmethod
+    def validate_category(cls, v: str) -> str:
+        if v not in REFERENCE_CATEGORIES:
+            raise ValueError(f"category must be one of: {', '.join(REFERENCE_CATEGORIES)}")
+        return v
+
+    @field_validator("scope")
+    @classmethod
+    def validate_scope(cls, v: str) -> str:
+        if v not in REFERENCE_SCOPES:
+            raise ValueError(f"scope must be one of: {', '.join(REFERENCE_SCOPES)}")
+        return v
+
+    @field_validator("extract")
+    @classmethod
+    def validate_extract(cls, v: str) -> str:
+        if v not in VALID_EXTRACT_MODES:
+            raise ValueError(f"extract must be one of: {', '.join(VALID_EXTRACT_MODES)}")
+        return v
+
+
+class ReferenceImportStartResponse(BaseModel):
+    reference_id: int
+    import_job_id: str
+    status: str
+
+
+class ReferenceImportStatusResponse(BaseModel):
+    reference_id: int
+    status: str
+    progress_pct: int | None = None
+    bytes_downloaded: int | None = None
+    total_bytes: int | None = None
+    error_message: str | None = None
+    import_job_id: str | None = None
+    updated_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class ReferenceImportProgressUpdate(BaseModel):
+    """Internal callback body — written by the importer container."""
+
+    status: str
+    progress_pct: int | None = None
+    bytes_downloaded: int | None = None
+    total_bytes: int | None = None
+    error_message: str | None = None
+
+
 # --- Response schemas ---
 
 

--- a/backend/app/schemas/reference_dataset.py
+++ b/backend/app/schemas/reference_dataset.py
@@ -47,6 +47,52 @@ class ReferenceDeprecateRequest(BaseModel):
     superseded_by_id: int | None = None
 
 
+# --- Upload (resumable session) schemas ---
+
+
+class ReferenceUploadFileSpec(BaseModel):
+    filename: str
+    size_bytes: int
+    content_type: str | None = None
+    md5_checksum: str | None = None  # advanced path: client-supplied md5 for verify
+
+
+class ReferenceUploadInitRequest(BaseModel):
+    name: str
+    category: str
+    scope: str
+    version: str
+    source_url: str | None = None
+    description: str | None = None
+    files: list[ReferenceUploadFileSpec]
+
+    @field_validator("category")
+    @classmethod
+    def validate_category(cls, v: str) -> str:
+        if v not in REFERENCE_CATEGORIES:
+            raise ValueError(f"category must be one of: {', '.join(REFERENCE_CATEGORIES)}")
+        return v
+
+    @field_validator("scope")
+    @classmethod
+    def validate_scope(cls, v: str) -> str:
+        if v not in REFERENCE_SCOPES:
+            raise ValueError(f"scope must be one of: {', '.join(REFERENCE_SCOPES)}")
+        return v
+
+
+class ReferenceUploadSlot(BaseModel):
+    filename: str
+    session_url: str
+    expires_at: datetime
+
+
+class ReferenceUploadInitResponse(BaseModel):
+    reference_id: int
+    gcs_prefix: str
+    uploads: list[ReferenceUploadSlot]
+
+
 # --- Response schemas ---
 
 

--- a/backend/app/services/bootstrap_roles.py
+++ b/backend/app/services/bootstrap_roles.py
@@ -21,6 +21,7 @@ ALL_RESOURCES_ACTIONS: dict[str, list[str]] = {
     "roles": ["view", "create", "edit", "delete"],
     "quotas": ["view", "configure"],
     "settings": ["view", "configure"],
+    "references": ["view", "upload"],
 }
 
 BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
@@ -44,6 +45,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "infrastructure": ["view"],
             "audit_log": ["view"],
             "cost_center": ["view"],
+            "references": ["view", "upload"],
         },
     ),
     "bench": (
@@ -57,6 +59,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "environments": ["view"],
             "files": ["view", "upload"],
             "projects": ["view"],
+            "references": ["view"],
         },
     ),
     "viewer": (
@@ -68,6 +71,7 @@ BUILTIN_ROLES: dict[str, tuple[str, dict[str, list[str]]]] = {
             "environments": ["view"],
             "files": ["view"],
             "projects": ["view"],
+            "references": ["view"],
         },
     ),
 }

--- a/backend/app/services/custom_pipeline_service.py
+++ b/backend/app/services/custom_pipeline_service.py
@@ -320,6 +320,7 @@ class CustomPipelineService:
                     variable_name=var.variable_name,
                     default_value=var.default_value,
                     variable_type=var.variable_type,
+                    reference_category=var.reference_category,
                     is_required=var.is_required,
                 )
             )

--- a/backend/app/services/gcs_storage.py
+++ b/backend/app/services/gcs_storage.py
@@ -35,6 +35,7 @@ _BUCKET_CONFIG_KEYS = {
     "raw_bucket_name": "raw",
     "working_bucket_name": "working",
     "results_bucket_name": "results",
+    "references_bucket_name": "references",
     "config_backups_bucket_name": "config_backups",
 }
 

--- a/backend/app/services/reference_data_service.py
+++ b/backend/app/services/reference_data_service.py
@@ -497,6 +497,17 @@ class ReferenceDataService:
         expires_at = datetime.now(timezone.utc) + RESUMABLE_SESSION_TTL
         for spec in request.files:
             blob_path = f"{gcs_prefix}{spec.filename}"
+            # Persist skeleton file row so upload_complete can verify each
+            # declared file arrived. md5/size are filled in at finalize.
+            session.add(
+                ReferenceDatasetFile(
+                    reference_dataset_id=dataset.id,
+                    filename=spec.filename,
+                    gcs_uri=f"gs://{bucket_name}/{blob_path}",
+                    size_bytes=spec.size_bytes,
+                    md5_checksum=spec.md5_checksum,
+                )
+            )
             session_url = ReferenceDataService._create_resumable_session(
                 bucket_name=bucket_name,
                 blob_path=blob_path,
@@ -531,3 +542,153 @@ class ReferenceDataService:
         )
 
         return dataset, uploads
+
+    # --- Upload finalize / abort -----------------------------------------------
+
+    @staticmethod
+    def _list_uploaded_blobs(bucket_name: str, prefix: str, credentials=None):
+        """List blobs under `prefix`. Tests monkey-patch this."""
+        from google.cloud import storage as gcs_storage
+
+        client = gcs_storage.Client(credentials=credentials)
+        bucket = client.bucket(bucket_name)
+        return list(bucket.list_blobs(prefix=prefix))
+
+    @staticmethod
+    def _delete_blobs(bucket_name: str, prefix: str, credentials=None) -> None:
+        """Delete every blob under `prefix`. Tests monkey-patch this."""
+        from google.cloud import storage as gcs_storage
+
+        client = gcs_storage.Client(credentials=credentials)
+        bucket = client.bucket(bucket_name)
+        for blob in bucket.list_blobs(prefix=prefix):
+            try:
+                blob.delete()
+            except Exception as e:
+                logger.warning("Failed to delete blob %s: %s", blob.name, e)
+
+    @staticmethod
+    async def upload_complete(
+        session: AsyncSession,
+        reference_id: int,
+        org_id: int,
+        user_id: int,
+    ) -> ReferenceDataset:
+        """Finalize a resumable upload — list GCS, verify, persist files, flip status.
+
+        Lifecycle (spec §2):
+          - status='uploading' → 'active' (internal scope)
+          - status='uploading' → 'pending_approval' (public scope)
+          - status='uploading' → 'failed' on md5 mismatch (objects purged)
+        """
+        dataset = await ReferenceDataService.get_reference(session, reference_id, org_id)
+        if not dataset:
+            raise ValueError("Reference dataset not found")
+        if dataset.status != "uploading":
+            raise ValueError(f"Cannot finalize: status is '{dataset.status}', expected 'uploading'")
+
+        bucket_name = await ReferenceDataService._get_references_bucket(session)
+        from app.services.upload_service import UploadService
+
+        credentials = await UploadService._get_gcs_credentials(session)
+
+        blobs = ReferenceDataService._list_uploaded_blobs(bucket_name, dataset.gcs_prefix, credentials=credentials)
+        # Index blobs by their basename (relative to gcs_prefix)
+        blob_by_name: dict[str, object] = {}
+        for b in blobs:
+            base = b.name[len(dataset.gcs_prefix) :] if b.name.startswith(dataset.gcs_prefix) else b.name
+            blob_by_name[base] = b
+
+        expected = list(dataset.files)
+        missing = [f.filename for f in expected if f.filename not in blob_by_name]
+        if missing:
+            raise ValueError(f"Upload incomplete: missing files in GCS: {', '.join(missing)}")
+
+        # MD5 verification: compare client-supplied md5 (if any) to GCS metadata
+        manifest: dict[str, str] = {}
+        total_size = 0
+        for file_row in expected:
+            blob = blob_by_name[file_row.filename]
+            gcs_md5 = getattr(blob, "md5_hash", None)
+            gcs_size = int(getattr(blob, "size", 0) or 0)
+            if file_row.md5_checksum and gcs_md5 and file_row.md5_checksum != gcs_md5:
+                # Mark failed and purge objects, then raise.
+                dataset.status = "failed"
+                dataset.deprecation_note = (
+                    f"md5 mismatch for {file_row.filename}: declared {file_row.md5_checksum}, bucket reports {gcs_md5}"
+                )
+                await session.flush()
+                try:
+                    ReferenceDataService._delete_blobs(bucket_name, dataset.gcs_prefix, credentials=credentials)
+                except Exception as e:
+                    logger.warning("Failed to purge blobs for failed upload %s: %s", dataset.id, e)
+                await log_action(
+                    session,
+                    user_id=user_id,
+                    entity_type="reference_dataset",
+                    entity_id=dataset.id,
+                    action="upload_failed",
+                    details={"reason": "md5_mismatch", "filename": file_row.filename},
+                )
+                raise ValueError(dataset.deprecation_note)
+            file_row.md5_checksum = gcs_md5
+            file_row.size_bytes = gcs_size
+            if gcs_md5:
+                manifest[file_row.filename] = gcs_md5
+            total_size += gcs_size
+
+        dataset.md5_manifest_json = manifest
+        dataset.total_size_bytes = total_size
+        dataset.status = "pending_approval" if dataset.scope == "public" else "active"
+        await session.flush()
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="reference_dataset",
+            entity_id=dataset.id,
+            action="upload_completed",
+            details={
+                "name": dataset.name,
+                "version": dataset.version,
+                "scope": dataset.scope,
+                "file_count": len(expected),
+                "total_size_bytes": total_size,
+                "final_status": dataset.status,
+            },
+        )
+
+        return dataset
+
+    @staticmethod
+    async def abort_upload(
+        session: AsyncSession,
+        reference_id: int,
+        org_id: int,
+        user_id: int,
+    ) -> None:
+        """Idempotent abort: purge GCS objects under prefix and delete the row."""
+        dataset = await ReferenceDataService.get_reference(session, reference_id, org_id)
+        if not dataset:
+            return  # idempotent
+
+        bucket_name = await ReferenceDataService._get_references_bucket(session)
+        from app.services.upload_service import UploadService
+
+        credentials = await UploadService._get_gcs_credentials(session)
+        try:
+            ReferenceDataService._delete_blobs(bucket_name, dataset.gcs_prefix, credentials=credentials)
+        except Exception as e:
+            logger.warning("Failed to purge blobs while aborting %s: %s", reference_id, e)
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="reference_dataset",
+            entity_id=dataset.id,
+            action="upload_aborted",
+            details={"name": dataset.name, "version": dataset.version},
+        )
+
+        await session.delete(dataset)
+        await session.flush()

--- a/backend/app/services/reference_data_service.py
+++ b/backend/app/services/reference_data_service.py
@@ -17,11 +17,14 @@ from app.models.reference_dataset import (
     ReferenceDatasetFile,
     pipeline_run_references,
 )
+from app.models.reference_import_progress import ReferenceImportProgress
 from app.schemas.reference_dataset import (
     ImpactPipelineRun,
     ImpactSummary,
     ReferenceDatasetCreate,
     ReferenceDeprecateRequest,
+    ReferenceImportRequest,
+    ReferenceImportStatusResponse,
     ReferenceUploadInitRequest,
 )
 from app.services.audit_service import log_action
@@ -692,3 +695,261 @@ class ReferenceDataService:
 
         await session.delete(dataset)
         await session.flush()
+
+    # --- Import-from-URL (GKE Job) flow — spec §3 ------------------------------
+
+    @staticmethod
+    def _create_import_job(
+        *,
+        reference_id: int,
+        source_url: str,
+        source_md5_url: str | None,
+        gcs_prefix: str,
+        bucket_name: str,
+        extract: str,
+        auth_header: str | None,
+    ) -> str:
+        """Launch the importer GKE Job and return its name. Tests monkey-patch.
+
+        Production: builds a kubernetes BatchV1 Job from the spec in
+        documentation/spec-reference-data-ingest.md §3 and returns the Job's
+        metadata.name.
+        """
+        from kubernetes import client as k8s_client, config as k8s_config
+
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            k8s_config.load_kube_config()
+
+        nonce = re.sub(r"[^a-z0-9]", "", str(reference_id))[:6] or "0"
+        job_name = f"refimport-{reference_id}-{nonce}"
+        env = [
+            k8s_client.V1EnvVar(name="REFERENCE_ID", value=str(reference_id)),
+            k8s_client.V1EnvVar(name="SOURCE_URL", value=source_url),
+            k8s_client.V1EnvVar(name="GCS_PREFIX", value=gcs_prefix),
+            k8s_client.V1EnvVar(name="GCS_BUCKET", value=bucket_name),
+            k8s_client.V1EnvVar(name="EXTRACT_MODE", value=extract),
+        ]
+        if source_md5_url:
+            env.append(k8s_client.V1EnvVar(name="SOURCE_MD5_URL", value=source_md5_url))
+        if auth_header:
+            env.append(k8s_client.V1EnvVar(name="SOURCE_AUTH_HEADER", value=auth_header))
+
+        container = k8s_client.V1Container(
+            name="importer",
+            image="us-central1-docker.pkg.dev/bioaf/bioaf-reference-importer:latest",
+            env=env,
+            resources=k8s_client.V1ResourceRequirements(
+                requests={"cpu": "1", "memory": "2Gi"},
+                limits={"cpu": "2", "memory": "4Gi"},
+            ),
+        )
+        pod_spec = k8s_client.V1PodSpec(
+            restart_policy="Never",
+            service_account_name="bioaf-reference-importer",
+            containers=[container],
+        )
+        job = k8s_client.V1Job(
+            api_version="batch/v1",
+            kind="Job",
+            metadata=k8s_client.V1ObjectMeta(
+                name=job_name,
+                labels={
+                    "bioaf.app/job-type": "reference-import",
+                    "bioaf.app/reference-id": str(reference_id),
+                },
+            ),
+            spec=k8s_client.V1JobSpec(
+                backoff_limit=1,
+                ttl_seconds_after_finished=3600,
+                template=k8s_client.V1PodTemplateSpec(spec=pod_spec),
+            ),
+        )
+        k8s_client.BatchV1Api().create_namespaced_job(namespace="default", body=job)
+        return job_name
+
+    @staticmethod
+    def _delete_import_job(job_name: str) -> None:
+        """Delete the importer GKE Job. Tests monkey-patch."""
+        from kubernetes import client as k8s_client, config as k8s_config
+
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            k8s_config.load_kube_config()
+        k8s_client.BatchV1Api().delete_namespaced_job(
+            name=job_name,
+            namespace="default",
+            propagation_policy="Background",
+        )
+
+    @staticmethod
+    async def start_import(
+        session: AsyncSession,
+        org_id: int,
+        user_id: int,
+        request: ReferenceImportRequest,
+    ) -> tuple[ReferenceDataset, str]:
+        """Create the dataset, progress row, and launch the importer GKE Job."""
+        # Up-front uniqueness check
+        existing = await session.execute(
+            select(ReferenceDataset.id).where(
+                ReferenceDataset.organization_id == org_id,
+                ReferenceDataset.name == request.name,
+                ReferenceDataset.version == request.version,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise ValueError(f"Reference '{request.name}' version '{request.version}' already exists")
+
+        bucket_name = await ReferenceDataService._get_references_bucket(session)
+        gcs_prefix = f"{request.category}/{_slugify(request.name)}/{_slugify(request.version)}/"
+
+        dataset = ReferenceDataset(
+            organization_id=org_id,
+            name=request.name,
+            category=request.category,
+            scope=request.scope,
+            version=request.version,
+            source_url=request.source_url,
+            gcs_prefix=gcs_prefix,
+            uploaded_by_user_id=user_id,
+            status="uploading",
+        )
+        session.add(dataset)
+        await session.flush()
+
+        job_id = ReferenceDataService._create_import_job(
+            reference_id=dataset.id,
+            source_url=request.source_url,
+            source_md5_url=request.source_md5_url,
+            gcs_prefix=gcs_prefix,
+            bucket_name=bucket_name,
+            extract=request.extract,
+            auth_header=request.auth_header,
+        )
+
+        progress = ReferenceImportProgress(
+            reference_id=dataset.id,
+            status="pending",
+            import_job_id=job_id,
+        )
+        session.add(progress)
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="reference_dataset",
+            entity_id=dataset.id,
+            action="import_started",
+            details={
+                "name": request.name,
+                "version": request.version,
+                "category": request.category,
+                "scope": request.scope,
+                "source_url": request.source_url,
+                "extract": request.extract,
+                "import_job_id": job_id,
+                "gcs_prefix": gcs_prefix,
+                "bucket": bucket_name,
+            },
+        )
+        await session.flush()
+        return dataset, job_id
+
+    @staticmethod
+    async def get_import_status(
+        session: AsyncSession,
+        reference_id: int,
+        org_id: int,
+    ) -> ReferenceImportStatusResponse:
+        """Read the import_progress row for a reference owned by org_id."""
+        # Make sure the dataset exists & is org-scoped before reading progress.
+        dataset = await session.execute(
+            select(ReferenceDataset.id).where(
+                ReferenceDataset.id == reference_id,
+                ReferenceDataset.organization_id == org_id,
+            )
+        )
+        if dataset.scalar_one_or_none() is None:
+            raise ValueError("Reference dataset not found")
+
+        result = await session.execute(
+            select(
+                ReferenceImportProgress.reference_id,
+                ReferenceImportProgress.status,
+                ReferenceImportProgress.progress_pct,
+                ReferenceImportProgress.bytes_downloaded,
+                ReferenceImportProgress.total_bytes,
+                ReferenceImportProgress.error_message,
+                ReferenceImportProgress.import_job_id,
+                ReferenceImportProgress.updated_at,
+            ).where(ReferenceImportProgress.reference_id == reference_id)
+        )
+        row = result.one_or_none()
+        if row is None:
+            raise ValueError("No import progress record for this reference")
+
+        return ReferenceImportStatusResponse(
+            reference_id=row.reference_id,
+            status=row.status,
+            progress_pct=row.progress_pct,
+            bytes_downloaded=row.bytes_downloaded,
+            total_bytes=row.total_bytes,
+            error_message=row.error_message,
+            import_job_id=row.import_job_id,
+            updated_at=row.updated_at,
+        )
+
+    @staticmethod
+    async def cancel_import(
+        session: AsyncSession,
+        reference_id: int,
+        org_id: int,
+        user_id: int,
+    ) -> None:
+        """Terminate the GKE job + abort the in-flight reference (purge + delete)."""
+        progress = await session.get(ReferenceImportProgress, reference_id)
+        if progress and progress.import_job_id:
+            try:
+                ReferenceDataService._delete_import_job(progress.import_job_id)
+            except Exception as e:
+                logger.warning("Failed to delete import job %s: %s", progress.import_job_id, e)
+
+        await ReferenceDataService.abort_upload(session, reference_id, org_id, user_id)
+
+    @staticmethod
+    async def record_import_progress(
+        session: AsyncSession,
+        reference_id: int,
+        *,
+        status: str,
+        progress_pct: int | None = None,
+        bytes_downloaded: int | None = None,
+        total_bytes: int | None = None,
+        error_message: str | None = None,
+    ) -> ReferenceImportProgress:
+        """Update the progress row. Called by the importer container's callback."""
+        progress = await session.get(ReferenceImportProgress, reference_id)
+        if not progress:
+            raise ValueError("No import progress record for this reference")
+
+        progress.status = status
+        if progress_pct is not None:
+            progress.progress_pct = progress_pct
+        if bytes_downloaded is not None:
+            progress.bytes_downloaded = bytes_downloaded
+        if total_bytes is not None:
+            progress.total_bytes = total_bytes
+        if error_message is not None:
+            progress.error_message = error_message
+
+        if status == "failed":
+            dataset = await session.get(ReferenceDataset, reference_id)
+            if dataset:
+                dataset.status = "failed"
+                dataset.deprecation_note = error_message or "Import failed"
+
+        await session.flush()
+        return progress

--- a/backend/app/services/reference_data_service.py
+++ b/backend/app/services/reference_data_service.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import logging
+import re
+from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -20,12 +22,23 @@ from app.schemas.reference_dataset import (
     ImpactSummary,
     ReferenceDatasetCreate,
     ReferenceDeprecateRequest,
+    ReferenceUploadInitRequest,
 )
 from app.services.audit_service import log_action
 from app.services.event_bus import event_bus
 from app.services.event_types import REFERENCE_DEPRECATED
 
 logger = logging.getLogger("bioaf.reference_data")
+
+# GCS resumable upload sessions are valid for ~7 days; report a conservative
+# 6-day expiry so the UI prompts to re-init before the actual server cutoff.
+RESUMABLE_SESSION_TTL = timedelta(days=6)
+
+
+def _slugify(value: str) -> str:
+    """Lowercase, replace runs of non-alphanumeric with `-`, strip ends."""
+    out = re.sub(r"[^a-zA-Z0-9]+", "-", value).strip("-").lower()
+    return out or "ref"
 
 
 class ReferenceDataService:
@@ -391,3 +404,130 @@ class ReferenceDataService:
                     reference_dataset_id=ref_id,
                 )
             )
+
+    # --- Upload (resumable session) flow — spec §2 -----------------------------
+
+    @staticmethod
+    async def _get_references_bucket(session: AsyncSession) -> str:
+        result = await session.execute(text("SELECT value FROM platform_config WHERE key = 'references_bucket_name'"))
+        name = result.scalar_one_or_none()
+        if not name or name == "null":
+            raise ValueError("References bucket not configured. Deploy storage infrastructure first.")
+        return name
+
+    @staticmethod
+    def _create_resumable_session(
+        bucket_name: str,
+        blob_path: str,
+        content_type: str,
+        size_bytes: int,
+        origin: str | None = None,
+        credentials=None,
+    ) -> str:
+        """Create a GCS resumable upload session and return its session URL.
+
+        Tests monkey-patch this to avoid real GCS calls; production calls
+        Google Cloud Storage via the SDK.
+        """
+        from google.cloud import storage as gcs_storage
+
+        client = gcs_storage.Client(credentials=credentials)
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_path)
+        return blob.create_resumable_upload_session(
+            content_type=content_type,
+            size=size_bytes,
+            origin=origin,
+        )
+
+    @staticmethod
+    async def init_upload(
+        session: AsyncSession,
+        org_id: int,
+        user_id: int,
+        request: ReferenceUploadInitRequest,
+        *,
+        request_origin: str | None = None,
+    ) -> tuple[ReferenceDataset, list[dict]]:
+        """Initiate a multi-file resumable upload to the references bucket.
+
+        Creates the ReferenceDataset row in status='uploading' and returns
+        per-file resumable session URLs the browser can PUT chunks against.
+        See spec §2 for the state machine.
+        """
+        if not request.files:
+            raise ValueError("init_upload requires at least one file in `files`")
+
+        # Up-front uniqueness check so we don't create a GCS session before failing
+        existing = await session.execute(
+            select(ReferenceDataset.id).where(
+                ReferenceDataset.organization_id == org_id,
+                ReferenceDataset.name == request.name,
+                ReferenceDataset.version == request.version,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise ValueError(f"Reference '{request.name}' version '{request.version}' already exists")
+
+        bucket_name = await ReferenceDataService._get_references_bucket(session)
+
+        # GCS prefix: {category}/{slug-name}/{slug-version}/
+        gcs_prefix = f"{request.category}/{_slugify(request.name)}/{_slugify(request.version)}/"
+
+        dataset = ReferenceDataset(
+            organization_id=org_id,
+            name=request.name,
+            category=request.category,
+            scope=request.scope,
+            version=request.version,
+            source_url=request.source_url,
+            gcs_prefix=gcs_prefix,
+            file_count=len(request.files),
+            uploaded_by_user_id=user_id,
+            status="uploading",
+        )
+        session.add(dataset)
+        await session.flush()
+
+        from app.services.upload_service import UploadService
+
+        credentials = await UploadService._get_gcs_credentials(session)
+
+        uploads: list[dict] = []
+        expires_at = datetime.now(timezone.utc) + RESUMABLE_SESSION_TTL
+        for spec in request.files:
+            blob_path = f"{gcs_prefix}{spec.filename}"
+            session_url = ReferenceDataService._create_resumable_session(
+                bucket_name=bucket_name,
+                blob_path=blob_path,
+                content_type=spec.content_type or "application/octet-stream",
+                size_bytes=spec.size_bytes,
+                origin=request_origin,
+                credentials=credentials,
+            )
+            uploads.append(
+                {
+                    "filename": spec.filename,
+                    "session_url": session_url,
+                    "expires_at": expires_at,
+                }
+            )
+
+        await log_action(
+            session,
+            user_id=user_id,
+            entity_type="reference_dataset",
+            entity_id=dataset.id,
+            action="upload_initiated",
+            details={
+                "name": request.name,
+                "version": request.version,
+                "category": request.category,
+                "scope": request.scope,
+                "file_count": len(request.files),
+                "bucket": bucket_name,
+                "gcs_prefix": gcs_prefix,
+            },
+        )
+
+        return dataset, uploads

--- a/backend/app/services/reference_data_service.py
+++ b/backend/app/services/reference_data_service.py
@@ -85,6 +85,32 @@ class ReferenceDataService:
         return list(result.scalars().all()), total
 
     @staticmethod
+    async def list_versions_by_name(
+        session: AsyncSession,
+        org_id: int,
+        *,
+        name: str,
+        category: str,
+    ) -> tuple[list[ReferenceDataset], int]:
+        """Return every version of a (name, category) within an org, newest first.
+
+        Spec §4 versioning UX — drives the version-history view on the
+        reference detail page in a single round-trip.
+        """
+        query = (
+            select(ReferenceDataset)
+            .where(
+                ReferenceDataset.organization_id == org_id,
+                ReferenceDataset.name == name,
+                ReferenceDataset.category == category,
+            )
+            .order_by(ReferenceDataset.created_at.desc())
+        )
+        result = await session.execute(query)
+        rows = list(result.scalars().all())
+        return rows, len(rows)
+
+    @staticmethod
     async def get_reference(
         session: AsyncSession,
         reference_id: int,

--- a/backend/app/services/stack_deployment.py
+++ b/backend/app/services/stack_deployment.py
@@ -362,6 +362,7 @@ async def deploy_stack(
                     "raw_bucket_name",
                     "working_bucket_name",
                     "results_bucket_name",
+                    "references_bucket_name",
                     "config_backups_bucket_name",
                     "pubsub_topic_name",
                     "pubsub_subscription_name",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.11.0"
+version = "0.10.3"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.10.2"
+version = "0.11.0"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/terraform/modules/storage/main.tf
+++ b/backend/terraform/modules/storage/main.tf
@@ -100,6 +100,34 @@ resource "google_storage_bucket" "results" {
   }
 }
 
+# Reference data bucket — backing store for ReferenceDataset rows. Per
+# spec-reference-data-ingest §1, browsers PUT chunks directly via GCS
+# resumable session URLs returned by ReferenceDataService.init_upload.
+resource "google_storage_bucket" "references" {
+  name          = "${local.bucket_prefix}-references-${var.org_slug}-${var.stack_uid}"
+  project       = var.project_id
+  location      = var.region
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+  versioning { enabled = true }
+  force_destroy = false
+
+  cors {
+    # POST allowed so the browser can initiate the resumable session URL
+    # via XHR even though the actual byte uploads use PUT.
+    origin          = ["*"] # tighten to bioAF frontend origins post-MVP
+    method          = ["PUT", "POST", "OPTIONS"]
+    response_header = ["Content-Type", "Content-Length", "Authorization", "x-goog-*"]
+    max_age_seconds = 3600
+  }
+
+  labels = {
+    managed_by = "bioaf"
+    purpose    = "references"
+  }
+}
+
 # DEPRECATED: Backups now go to the persistent backups bucket in the
 # foundation module (bioaf-backups-{project_id}). This bucket is kept for
 # backward compatibility with existing deployments but will be removed in
@@ -137,6 +165,7 @@ locals {
     raw            = google_storage_bucket.raw.name
     working        = google_storage_bucket.working.name
     results        = google_storage_bucket.results.name
+    references     = google_storage_bucket.references.name
     config_backups = google_storage_bucket.config_backups.name
   }
 }

--- a/backend/terraform/modules/storage/outputs.tf
+++ b/backend/terraform/modules/storage/outputs.tf
@@ -18,6 +18,11 @@ output "results_bucket_name" {
   value       = google_storage_bucket.results.name
 }
 
+output "references_bucket_name" {
+  description = "Name of the reference-data GCS bucket"
+  value       = google_storage_bucket.references.name
+}
+
 output "config_backups_bucket_name" {
   description = "Name of the config backups GCS bucket"
   value       = google_storage_bucket.config_backups.name

--- a/backend/tests/test_custom_pipeline_reference_param.py
+++ b/backend/tests/test_custom_pipeline_reference_param.py
@@ -1,0 +1,127 @@
+"""TDD: custom-pipeline `reference` parameter type — spec §5.
+
+The custom pipeline editor needs a new variable_type='reference' that, when
+launched, renders a searchable dropdown filtered by reference_category.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+
+from app.models.custom_pipeline import CustomPipeline
+from app.models.custom_pipeline_variable import CustomPipelineVariable
+from app.models.custom_pipeline_version import CustomPipelineVersion
+
+
+@pytest_asyncio.fixture
+async def admin_test(client, admin_user, admin_token, session):
+    """Bootstrap a custom pipeline + version row we can attach variables to."""
+    pipeline = CustomPipeline(
+        organization_id=admin_user.organization_id,
+        pipeline_key="ref-param-test",
+        name="Ref Param Test",
+        created_by_user_id=admin_user.id,
+    )
+    session.add(pipeline)
+    await session.flush()
+
+    # find an environment_version_id; just use any existing — tests can fake
+    # by inserting a minimal env_version row.
+    await session.execute(
+        text(
+            "INSERT INTO environments (id, organization_id, name, created_by_user_id, created_at) "
+            "VALUES (1, :oid, 'env', :uid, NOW()) ON CONFLICT DO NOTHING"
+        ),
+        {"oid": admin_user.organization_id, "uid": admin_user.id},
+    )
+    await session.execute(
+        text(
+            "INSERT INTO environment_versions "
+            "(id, environment_id, version_number, build_number, status, "
+            " definition_format, definition_content, created_by_user_id, created_at) "
+            "VALUES (1, 1, 1, 1, 'built', 'conda', '{}', :uid, NOW()) ON CONFLICT DO NOTHING"
+        ),
+        {"uid": admin_user.id},
+    )
+    await session.commit()
+
+    return pipeline
+
+
+@pytest.mark.asyncio
+async def test_custom_pipeline_variable_can_persist_reference_type(session, admin_test):
+    """Schema accepts variable_type='reference' with a reference_category."""
+    pipeline = admin_test
+
+    user_id = (await session.execute(text("SELECT id FROM users LIMIT 1"))).scalar_one()
+    version = CustomPipelineVersion(
+        custom_pipeline_id=pipeline.id,
+        version_number=1,
+        code_source_type="inline",
+        entrypoint_command="echo hi",
+        environment_version_id=1,
+        cpu_request="1",
+        memory_request="1Gi",
+        version_trigger="manual",
+        status="ready",
+        created_by_user_id=user_id,
+    )
+    session.add(version)
+    await session.flush()
+
+    var = CustomPipelineVariable(
+        custom_pipeline_version_id=version.id,
+        variable_name="genome_ref",
+        variable_type="reference",
+        reference_category="genome",
+        is_required=True,
+    )
+    session.add(var)
+    await session.flush()
+
+    result = await session.execute(
+        select(CustomPipelineVariable).where(CustomPipelineVariable.custom_pipeline_version_id == version.id)
+    )
+    fetched = result.scalar_one()
+    assert fetched.variable_type == "reference"
+    assert fetched.reference_category == "genome"
+
+
+def test_variable_definition_schema_accepts_reference_type():
+    """Pydantic schema must accept variable_type='reference' with category."""
+    from app.schemas.custom_pipeline import CustomPipelineVariableDefinition
+
+    payload = CustomPipelineVariableDefinition(
+        variable_name="genome_ref",
+        variable_type="reference",
+        reference_category="genome",
+        is_required=True,
+    )
+    assert payload.variable_type == "reference"
+    assert payload.reference_category == "genome"
+
+
+def test_variable_definition_rejects_reference_without_category():
+    """Reference type must specify a reference_category."""
+    from app.schemas.custom_pipeline import CustomPipelineVariableDefinition
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="reference_category"):
+        CustomPipelineVariableDefinition(
+            variable_name="genome_ref",
+            variable_type="reference",
+            is_required=True,
+        )
+
+
+def test_variable_definition_rejects_unknown_category():
+    """reference_category must be one of the known reference categories or 'any'."""
+    from app.schemas.custom_pipeline import CustomPipelineVariableDefinition
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CustomPipelineVariableDefinition(
+            variable_name="genome_ref",
+            variable_type="reference",
+            reference_category="not_a_real_category",
+        )

--- a/backend/tests/test_reference_by_name.py
+++ b/backend/tests/test_reference_by_name.py
@@ -1,0 +1,113 @@
+"""TDD: GET /api/references/by-name — returns all versions of a reference (spec §4)."""
+
+import pytest
+import pytest_asyncio
+
+from app.services.auth_service import AuthService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_byname@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def comp_bio_token(comp_bio_user) -> str:
+    return AuthService.create_token(
+        comp_bio_user.id,
+        comp_bio_user.email,
+        comp_bio_user.role_id,
+        comp_bio_user.organization_id,
+        role_name="comp_bio",
+    )
+
+
+REF_BASE = {
+    "name": "GRCh38 GENCODE",
+    "category": "genome",
+    "scope": "public",
+    "gcs_prefix": "genome/grch38/gencode/",
+    "files": [
+        {
+            "filename": "genome.fa",
+            "gcs_uri": "gs://bucket/genome/grch38/gencode/v44/genome.fa",
+            "size_bytes": 1000,
+            "md5_checksum": "a" * 32,
+            "file_type": "fasta",
+        }
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_by_name_returns_all_versions_descending(client, comp_bio_token):
+    # Create three versions
+    for v in ["v43", "v44", "v45"]:
+        await client.post(
+            "/api/references",
+            json={**REF_BASE, "version": v, "gcs_prefix": f"genome/grch38/gencode/{v}/"},
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+
+    response = await client.get(
+        "/api/references/by-name?name=GRCh38%20GENCODE&category=genome",
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total"] == 3
+    versions = [r["version"] for r in body["references"]]
+    assert versions == ["v45", "v44", "v43"]  # newest first
+
+
+@pytest.mark.asyncio
+async def test_by_name_filters_to_matching_category(client, comp_bio_token):
+    """Same name in two categories should only return rows for the requested category."""
+    await client.post(
+        "/api/references",
+        json={**REF_BASE, "version": "v1"},
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    await client.post(
+        "/api/references",
+        json={
+            **REF_BASE,
+            "category": "annotation",
+            "version": "v1-anno",
+            "gcs_prefix": "annotation/grch38/gencode/v1/",
+            "name": "GRCh38 GENCODE",
+        },
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+
+    response = await client.get(
+        "/api/references/by-name?name=GRCh38%20GENCODE&category=annotation",
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["references"][0]["category"] == "annotation"
+
+
+@pytest.mark.asyncio
+async def test_by_name_empty_when_no_match(client, comp_bio_token):
+    response = await client.get(
+        "/api/references/by-name?name=nonexistent&category=genome",
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"references": [], "total": 0}

--- a/backend/tests/test_reference_import_callback.py
+++ b/backend/tests/test_reference_import_callback.py
@@ -1,0 +1,158 @@
+"""TDD: POST /api/internal/references/{id}/import-progress — importer-container callback.
+
+Authenticated by `X-Internal-Token` matching settings.internal_token rather
+than a user JWT (the importer container has no user identity).
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.config import settings
+from app.services.auth_service import AuthService
+from app.services.reference_data_service import ReferenceDataService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_callback@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def comp_bio_token(comp_bio_user) -> str:
+    return AuthService.create_token(
+        comp_bio_user.id,
+        comp_bio_user.email,
+        comp_bio_user.role_id,
+        comp_bio_user.organization_id,
+        role_name="comp_bio",
+    )
+
+
+@pytest_asyncio.fixture
+async def configured(session, monkeypatch):
+    monkeypatch.setattr(settings, "internal_token", "test-internal-secret")
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value, updated_at) "
+            "VALUES ('references_bucket_name', 'bioaf-references-test', NOW()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+    )
+    await session.commit()
+
+
+def _stub_create_job(*, reference_id, **_):
+    return f"refimport-{reference_id}-stub"
+
+
+VALID_IMPORT = {
+    "name": "GENCODE",
+    "category": "annotation",
+    "scope": "internal",
+    "version": "v45",
+    "source_url": "https://ftp.example/file.gz",
+    "extract": "gzip",
+}
+
+
+@pytest.mark.asyncio
+async def test_callback_updates_progress(client, comp_bio_token, configured):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        init = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    ref_id = init.json()["reference_id"]
+
+    response = await client.post(
+        f"/api/internal/references/{ref_id}/import-progress",
+        json={
+            "status": "downloading",
+            "progress_pct": 33,
+            "bytes_downloaded": 333,
+            "total_bytes": 1000,
+        },
+        headers={"X-Internal-Token": "test-internal-secret"},
+    )
+    assert response.status_code == 200, response.text
+
+    # Status endpoint reflects the update
+    status = await client.get(
+        f"/api/references/{ref_id}/import-status",
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert status.json()["status"] == "downloading"
+    assert status.json()["progress_pct"] == 33
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_missing_token(client, comp_bio_token, configured):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        init = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    ref_id = init.json()["reference_id"]
+
+    response = await client.post(
+        f"/api/internal/references/{ref_id}/import-progress",
+        json={"status": "downloading"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_wrong_token(client, comp_bio_token, configured):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        init = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    ref_id = init.json()["reference_id"]
+
+    response = await client.post(
+        f"/api/internal/references/{ref_id}/import-progress",
+        json={"status": "downloading"},
+        headers={"X-Internal-Token": "wrong"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_callback_failed_status_marks_dataset_failed(client, comp_bio_token, configured, session):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        init = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    ref_id = init.json()["reference_id"]
+
+    response = await client.post(
+        f"/api/internal/references/{ref_id}/import-progress",
+        json={"status": "failed", "error_message": "404 from upstream"},
+        headers={"X-Internal-Token": "test-internal-secret"},
+    )
+    assert response.status_code == 200
+
+    result = await session.execute(text("SELECT status FROM reference_datasets WHERE id = :id"), {"id": ref_id})
+    assert result.scalar_one() == "failed"

--- a/backend/tests/test_reference_import_progress_model.py
+++ b/backend/tests/test_reference_import_progress_model.py
@@ -1,0 +1,45 @@
+"""TDD: ReferenceImportProgress model — tracks GKE-job-driven import state.
+
+Spec §3: progress writes go to a `reference_import_progress` table.
+"""
+
+import pytest
+from sqlalchemy import select
+
+
+@pytest.mark.asyncio
+async def test_reference_import_progress_row_can_be_created(session, admin_user):
+    """Smoke test: schema exists and accepts a row tied to a reference dataset."""
+    from app.models.reference_dataset import ReferenceDataset
+    from app.models.reference_import_progress import ReferenceImportProgress
+
+    ref = ReferenceDataset(
+        organization_id=admin_user.organization_id,
+        name="GENCODE Import Test",
+        category="annotation",
+        scope="internal",
+        version="v45",
+        gcs_prefix="annotation/gencode-import-test/v45/",
+        uploaded_by_user_id=admin_user.id,
+        status="uploading",
+    )
+    session.add(ref)
+    await session.flush()
+
+    progress = ReferenceImportProgress(
+        reference_id=ref.id,
+        status="pending",
+        import_job_id="refimport-1-abcd",
+        bytes_downloaded=0,
+        total_bytes=None,
+    )
+    session.add(progress)
+    await session.flush()
+
+    result = await session.execute(
+        select(ReferenceImportProgress).where(ReferenceImportProgress.reference_id == ref.id)
+    )
+    fetched = result.scalar_one()
+    assert fetched.status == "pending"
+    assert fetched.import_job_id == "refimport-1-abcd"
+    assert fetched.bytes_downloaded == 0

--- a/backend/tests/test_reference_import_routes.py
+++ b/backend/tests/test_reference_import_routes.py
@@ -1,0 +1,185 @@
+"""TDD: POST /api/references/import, GET /import-status, POST /import-cancel."""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.services.auth_service import AuthService
+from app.services.reference_data_service import ReferenceDataService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_importroute@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def comp_bio_token(comp_bio_user) -> str:
+    return AuthService.create_token(
+        comp_bio_user.id,
+        comp_bio_user.email,
+        comp_bio_user.role_id,
+        comp_bio_user.organization_id,
+        role_name="comp_bio",
+    )
+
+
+@pytest_asyncio.fixture
+async def bench_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("benchpass123")
+    user = User(
+        email="bench_importroute@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["bench"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def bench_token(bench_user) -> str:
+    return AuthService.create_token(
+        bench_user.id, bench_user.email, bench_user.role_id, bench_user.organization_id, role_name="bench"
+    )
+
+
+@pytest_asyncio.fixture
+async def configured_refs_bucket(session):
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value, updated_at) "
+            "VALUES ('references_bucket_name', 'bioaf-references-test', NOW()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+    )
+    await session.commit()
+
+
+def _stub_create_job(*, reference_id, **_):
+    return f"refimport-{reference_id}-stub"
+
+
+VALID_IMPORT = {
+    "name": "GENCODE",
+    "category": "annotation",
+    "scope": "internal",
+    "version": "v45",
+    "source_url": "https://ftp.example/gencode.v45.annotation.gtf.gz",
+    "extract": "gzip",
+}
+
+
+@pytest.mark.asyncio
+async def test_import_route_starts_job(client, comp_bio_token, configured_refs_bucket):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        response = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert "reference_id" in body
+    assert body["status"] == "pending"
+    assert body["import_job_id"].startswith("refimport-")
+
+
+@pytest.mark.asyncio
+async def test_import_route_rejects_bench(client, bench_token, configured_refs_bucket):
+    response = await client.post(
+        "/api/references/import",
+        json=VALID_IMPORT,
+        headers={"Authorization": f"Bearer {bench_token}"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_import_route_409_on_duplicate(client, comp_bio_token, configured_refs_bucket):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        first = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+        assert first.status_code == 200
+        second = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    assert second.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_import_status_route_returns_progress(client, comp_bio_token, configured_refs_bucket, session):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        init = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    ref_id = init.json()["reference_id"]
+
+    response = await client.get(
+        f"/api/references/{ref_id}/import-status",
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "pending"
+    assert body["reference_id"] == ref_id
+
+
+@pytest.mark.asyncio
+async def test_import_status_404_when_unknown(client, comp_bio_token, configured_refs_bucket):
+    response = await client.get(
+        "/api/references/999999/import-status",
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_import_cancel_route_purges(client, comp_bio_token, configured_refs_bucket, session):
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        init = await client.post(
+            "/api/references/import",
+            json=VALID_IMPORT,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    ref_id = init.json()["reference_id"]
+
+    with (
+        patch.object(ReferenceDataService, "_delete_import_job", return_value=None),
+        patch.object(ReferenceDataService, "_delete_blobs", return_value=None),
+    ):
+        response = await client.post(
+            f"/api/references/{ref_id}/import-cancel",
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    assert response.status_code == 204
+
+    result = await session.execute(text("SELECT id FROM reference_datasets WHERE id = :id"), {"id": ref_id})
+    assert result.scalar_one_or_none() is None

--- a/backend/tests/test_reference_import_service.py
+++ b/backend/tests/test_reference_import_service.py
@@ -1,0 +1,270 @@
+"""TDD: ReferenceDataService.start_import / import_status / import_cancel.
+
+Spec §3 import-from-URL flow. The service:
+- creates a ReferenceDataset row in status='uploading' (same lifecycle as
+  upload — finalize via the existing upload_complete path),
+- creates a ReferenceImportProgress row in status='pending',
+- launches a GKE job (stubbed in tests) and stores its name as import_job_id,
+- exposes status reads + a cancel that deletes the GKE job and aborts the
+  reference (purges GCS + deletes the row).
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.models.reference_dataset import ReferenceDataset
+from app.models.reference_import_progress import ReferenceImportProgress
+from app.schemas.reference_dataset import ReferenceImportRequest
+from app.services.auth_service import AuthService
+from app.services.reference_data_service import ReferenceDataService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_import@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def configured_refs_bucket(session):
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value, updated_at) "
+            "VALUES ('references_bucket_name', 'bioaf-references-test', NOW()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+    )
+    await session.commit()
+
+
+def _stub_create_job(*, reference_id, source_url, gcs_prefix, **kwargs):
+    """Drop-in for the live GKE job creator. Returns the job name."""
+    return f"refimport-{reference_id}-stub"
+
+
+@pytest.mark.asyncio
+async def test_start_import_creates_dataset_progress_and_job(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceImportRequest(
+        name="GENCODE",
+        category="annotation",
+        scope="public",
+        version="v45",
+        source_url="https://ftp.ebi.ac.uk/.../gencode.v45.annotation.gtf.gz",
+        extract="gzip",
+    )
+
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job) as mock_job:
+        dataset, job_id = await ReferenceDataService.start_import(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+    assert dataset.status == "uploading"
+    assert dataset.gcs_prefix.endswith("/")
+    assert job_id == f"refimport-{dataset.id}-stub"
+
+    # k8s job creation called once with expected args
+    mock_job.assert_called_once()
+    call_kwargs = mock_job.call_args.kwargs
+    assert call_kwargs["reference_id"] == dataset.id
+    assert call_kwargs["source_url"] == payload.source_url
+    assert call_kwargs["gcs_prefix"] == dataset.gcs_prefix
+
+    # progress row exists
+    progress = await session.get(ReferenceImportProgress, dataset.id)
+    assert progress is not None
+    assert progress.status == "pending"
+    assert progress.import_job_id == job_id
+
+    # audit log
+    audit = await session.execute(
+        text(
+            "SELECT * FROM audit_log WHERE entity_type='reference_dataset' "
+            "AND entity_id=:id AND action='import_started'"
+        ),
+        {"id": dataset.id},
+    )
+    assert audit.fetchone() is not None
+
+
+@pytest.mark.asyncio
+async def test_start_import_rejects_duplicate(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceImportRequest(
+        name="GENCODE",
+        category="annotation",
+        scope="public",
+        version="v45",
+        source_url="https://ftp.example/gencode.gtf.gz",
+        extract="gzip",
+    )
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        await ReferenceDataService.start_import(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+        with pytest.raises(ValueError, match="already exists"):
+            await ReferenceDataService.start_import(
+                session,
+                org_id=comp_bio_user.organization_id,
+                user_id=comp_bio_user.id,
+                request=payload,
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_import_status_returns_progress_row(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceImportRequest(
+        name="ScratchRef",
+        category="annotation",
+        scope="internal",
+        version="v1",
+        source_url="https://ftp.example/file.gz",
+        extract="none",
+    )
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        dataset, _ = await ReferenceDataService.start_import(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+    # Importer container would write progress; simulate it here:
+    progress = await session.get(ReferenceImportProgress, dataset.id)
+    progress.status = "downloading"
+    progress.progress_pct = 42
+    progress.bytes_downloaded = 100
+    progress.total_bytes = 1000
+    await session.commit()
+
+    status = await ReferenceDataService.get_import_status(
+        session, reference_id=dataset.id, org_id=comp_bio_user.organization_id
+    )
+    assert status.status == "downloading"
+    assert status.progress_pct == 42
+    assert status.bytes_downloaded == 100
+    assert status.total_bytes == 1000
+
+
+@pytest.mark.asyncio
+async def test_get_import_status_404_when_not_found(session, comp_bio_user):
+    with pytest.raises(ValueError, match="not found"):
+        await ReferenceDataService.get_import_status(
+            session, reference_id=999_999, org_id=comp_bio_user.organization_id
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancel_import_deletes_job_and_purges_reference(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceImportRequest(
+        name="CancelMe",
+        category="annotation",
+        scope="internal",
+        version="v1",
+        source_url="https://ftp.example/file.gz",
+        extract="none",
+    )
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        dataset, _ = await ReferenceDataService.start_import(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+    dataset_id = dataset.id
+
+    deleted_jobs: list[str] = []
+
+    def _capture_delete(job_id: str) -> None:
+        deleted_jobs.append(job_id)
+
+    with (
+        patch.object(ReferenceDataService, "_delete_import_job", side_effect=_capture_delete),
+        patch.object(ReferenceDataService, "_delete_blobs", return_value=None),
+    ):
+        await ReferenceDataService.cancel_import(
+            session, reference_id=dataset_id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+        )
+        await session.commit()
+
+    assert deleted_jobs == [f"refimport-{dataset_id}-stub"]
+    fresh = await session.get(ReferenceDataset, dataset_id)
+    assert fresh is None
+    progress = await session.get(ReferenceImportProgress, dataset_id)
+    assert progress is None  # cascade delete
+
+
+@pytest.mark.asyncio
+async def test_record_import_progress_updates_row(session, comp_bio_user, configured_refs_bucket):
+    """Internal callback path: the importer container POSTs progress updates."""
+    payload = ReferenceImportRequest(
+        name="ProgressMe",
+        category="annotation",
+        scope="internal",
+        version="v1",
+        source_url="https://ftp.example/file.gz",
+        extract="none",
+    )
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        dataset, _ = await ReferenceDataService.start_import(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+    await ReferenceDataService.record_import_progress(
+        session,
+        reference_id=dataset.id,
+        status="downloading",
+        progress_pct=25,
+        bytes_downloaded=250,
+        total_bytes=1000,
+    )
+    await session.commit()
+
+    progress = await session.get(ReferenceImportProgress, dataset.id)
+    assert progress.status == "downloading"
+    assert progress.progress_pct == 25
+    assert progress.bytes_downloaded == 250
+
+
+@pytest.mark.asyncio
+async def test_record_import_progress_failure_sets_dataset_failed(session, comp_bio_user, configured_refs_bucket):
+    """When the importer reports status='failed', the dataset row must also
+    flip to status='failed' so the existing UI surfaces it."""
+    payload = ReferenceImportRequest(
+        name="FailMe",
+        category="annotation",
+        scope="internal",
+        version="v1",
+        source_url="https://ftp.example/file.gz",
+        extract="none",
+    )
+    with patch.object(ReferenceDataService, "_create_import_job", side_effect=_stub_create_job):
+        dataset, _ = await ReferenceDataService.start_import(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+    await ReferenceDataService.record_import_progress(
+        session,
+        reference_id=dataset.id,
+        status="failed",
+        error_message="404 from upstream",
+    )
+    await session.commit()
+
+    fresh = await session.get(ReferenceDataset, dataset.id)
+    assert fresh.status == "failed"
+    assert "404" in (fresh.deprecation_note or "")

--- a/backend/tests/test_reference_upload_complete.py
+++ b/backend/tests/test_reference_upload_complete.py
@@ -1,0 +1,262 @@
+"""TDD: ReferenceDataService.upload_complete() and abort_upload() — spec §2.
+
+After the browser has PUT all bytes to GCS, `upload_complete` lists the bucket
+prefix, verifies each declared file arrived, reads the GCS-reported md5 hash
+and size, persists `reference_dataset_files` rows, builds the md5 manifest,
+and flips status:
+  - internal -> 'active'
+  - public   -> 'pending_approval' (initial public uploads require admin approval)
+
+`abort_upload` deletes any uploaded GCS objects and the dataset row.
+
+GCS calls are stubbed via monkeypatching `_create_resumable_session`,
+`_list_uploaded_blobs`, and `_delete_blobs`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+
+from app.models.reference_dataset import ReferenceDataset, ReferenceDatasetFile
+from app.schemas.reference_dataset import (
+    ReferenceUploadFileSpec,
+    ReferenceUploadInitRequest,
+)
+from app.services.auth_service import AuthService
+from app.services.reference_data_service import ReferenceDataService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_uploadcomplete@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def configured_refs_bucket(session):
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value, updated_at) "
+            "VALUES ('references_bucket_name', 'bioaf-references-test', NOW()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+    )
+    await session.commit()
+
+
+def _stub_session_url(bucket_name, blob_path, content_type, size_bytes, origin=None, credentials=None):
+    return f"https://storage.googleapis.com/stub/{blob_path}"
+
+
+class _StubBlob:
+    def __init__(self, name: str, size: int, md5: str):
+        self.name = name
+        self.size = size
+        self.md5_hash = md5
+
+
+async def _init(session, user, **overrides):
+    payload = ReferenceUploadInitRequest(
+        name=overrides.pop("name", "Custom Markers"),
+        category=overrides.pop("category", "markers"),
+        scope=overrides.pop("scope", "internal"),
+        version=overrides.pop("version", "v1"),
+        files=[
+            ReferenceUploadFileSpec(filename="markers.csv", size_bytes=4096),
+            ReferenceUploadFileSpec(filename="metadata.json", size_bytes=512),
+        ],
+    )
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        dataset, _ = await ReferenceDataService.init_upload(
+            session, org_id=user.organization_id, user_id=user.id, request=payload
+        )
+        await session.commit()
+    return dataset
+
+
+@pytest.mark.asyncio
+async def test_init_upload_persists_skeleton_file_rows(session, comp_bio_user, configured_refs_bucket):
+    """init_upload must persist a ReferenceDatasetFile row per declared file."""
+    dataset = await _init(session, comp_bio_user)
+
+    rows = await session.execute(
+        select(ReferenceDatasetFile).where(ReferenceDatasetFile.reference_dataset_id == dataset.id)
+    )
+    files = list(rows.scalars().all())
+    assert len(files) == 2
+    filenames = {f.filename for f in files}
+    assert filenames == {"markers.csv", "metadata.json"}
+    # md5 not yet known; size is the client-declared expected size
+    for f in files:
+        assert f.md5_checksum is None
+        assert f.gcs_uri.startswith("gs://bioaf-references-test/")
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_internal_flips_to_active(session, comp_bio_user, configured_refs_bucket):
+    dataset = await _init(session, comp_bio_user)
+
+    blobs = [
+        _StubBlob(name=f"{dataset.gcs_prefix}markers.csv", size=4096, md5="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        _StubBlob(name=f"{dataset.gcs_prefix}metadata.json", size=512, md5="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+    ]
+    with patch.object(ReferenceDataService, "_list_uploaded_blobs", return_value=blobs):
+        result = await ReferenceDataService.upload_complete(
+            session, reference_id=dataset.id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+        )
+        await session.commit()
+
+    assert result.status == "active"
+    assert result.total_size_bytes == 4096 + 512
+    assert result.md5_manifest_json is not None
+    assert result.md5_manifest_json["markers.csv"] == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    rows = await session.execute(
+        select(ReferenceDatasetFile).where(ReferenceDatasetFile.reference_dataset_id == dataset.id)
+    )
+    files = {f.filename: f for f in rows.scalars().all()}
+    assert files["markers.csv"].md5_checksum == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    assert files["markers.csv"].size_bytes == 4096
+
+    audit = await session.execute(
+        text(
+            "SELECT * FROM audit_log WHERE entity_type = 'reference_dataset' "
+            "AND entity_id = :id AND action = 'upload_completed'"
+        ),
+        {"id": dataset.id},
+    )
+    assert audit.fetchone() is not None
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_public_goes_pending_approval(session, comp_bio_user, configured_refs_bucket):
+    dataset = await _init(session, comp_bio_user, name="GENCODE", category="genome", scope="public", version="v45")
+
+    blobs = [
+        _StubBlob(name=f"{dataset.gcs_prefix}markers.csv", size=4096, md5="aaaa1111aaaa1111aaaa1111aaaa1111"),
+        _StubBlob(name=f"{dataset.gcs_prefix}metadata.json", size=512, md5="bbbb2222bbbb2222bbbb2222bbbb2222"),
+    ]
+    with patch.object(ReferenceDataService, "_list_uploaded_blobs", return_value=blobs):
+        result = await ReferenceDataService.upload_complete(
+            session, reference_id=dataset.id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+        )
+
+    assert result.status == "pending_approval"
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_missing_file_keeps_status_uploading(session, comp_bio_user, configured_refs_bucket):
+    dataset = await _init(session, comp_bio_user)
+
+    # Only one of the two declared files is present in GCS.
+    blobs = [
+        _StubBlob(name=f"{dataset.gcs_prefix}markers.csv", size=4096, md5="aa" * 16),
+    ]
+    with patch.object(ReferenceDataService, "_list_uploaded_blobs", return_value=blobs):
+        with pytest.raises(ValueError, match="metadata.json"):
+            await ReferenceDataService.upload_complete(
+                session, reference_id=dataset.id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+            )
+
+    # status must remain 'uploading' so the caller can retry once they finish PUTs.
+    fresh = await session.get(ReferenceDataset, dataset.id)
+    assert fresh.status == "uploading"
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_client_md5_mismatch_marks_failed(session, comp_bio_user, configured_refs_bucket):
+    """Advanced path: caller provided expected md5; mismatch => status=failed."""
+    payload = ReferenceUploadInitRequest(
+        name="Strict Markers",
+        category="markers",
+        scope="internal",
+        version="v1",
+        files=[
+            ReferenceUploadFileSpec(filename="markers.csv", size_bytes=4096, md5_checksum="cc" * 16),
+        ],
+    )
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        dataset, _ = await ReferenceDataService.init_upload(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+    # Bucket-reported md5 differs from the client-declared one
+    blobs = [_StubBlob(name=f"{dataset.gcs_prefix}markers.csv", size=4096, md5="dd" * 16)]
+    with (
+        patch.object(ReferenceDataService, "_list_uploaded_blobs", return_value=blobs),
+        patch.object(ReferenceDataService, "_delete_blobs", return_value=None),
+    ):
+        with pytest.raises(ValueError, match="md5 mismatch"):
+            await ReferenceDataService.upload_complete(
+                session, reference_id=dataset.id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+            )
+        await session.commit()
+
+    fresh = await session.get(ReferenceDataset, dataset.id)
+    assert fresh.status == "failed"
+    assert "md5 mismatch" in (fresh.deprecation_note or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_only_works_in_uploading_status(session, comp_bio_user, configured_refs_bucket):
+    dataset = await _init(session, comp_bio_user)
+    blobs = [
+        _StubBlob(name=f"{dataset.gcs_prefix}markers.csv", size=4096, md5="aa" * 16),
+        _StubBlob(name=f"{dataset.gcs_prefix}metadata.json", size=512, md5="bb" * 16),
+    ]
+    with patch.object(ReferenceDataService, "_list_uploaded_blobs", return_value=blobs):
+        await ReferenceDataService.upload_complete(
+            session, reference_id=dataset.id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+        )
+        await session.commit()
+
+        with pytest.raises(ValueError, match="already finalized|cannot finalize|status"):
+            await ReferenceDataService.upload_complete(
+                session, reference_id=dataset.id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+            )
+
+
+@pytest.mark.asyncio
+async def test_abort_upload_deletes_blobs_and_row(session, comp_bio_user, configured_refs_bucket):
+    dataset = await _init(session, comp_bio_user)
+    dataset_id = dataset.id
+
+    deleted_calls: list[tuple[str, str]] = []
+
+    def _capture_delete(bucket_name, prefix, credentials=None):
+        deleted_calls.append((bucket_name, prefix))
+
+    with patch.object(ReferenceDataService, "_delete_blobs", side_effect=_capture_delete):
+        await ReferenceDataService.abort_upload(
+            session, reference_id=dataset_id, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+        )
+        await session.commit()
+
+    assert deleted_calls == [("bioaf-references-test", dataset.gcs_prefix)]
+    fresh = await session.get(ReferenceDataset, dataset_id)
+    assert fresh is None
+
+
+@pytest.mark.asyncio
+async def test_abort_upload_idempotent_on_missing_row(session, comp_bio_user, configured_refs_bucket):
+    """Aborting a reference that doesn't exist should not error (idempotent per spec §2)."""
+    with patch.object(ReferenceDataService, "_delete_blobs", return_value=None):
+        # Should not raise even when row is gone
+        await ReferenceDataService.abort_upload(
+            session, reference_id=999_999, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id
+        )

--- a/backend/tests/test_reference_upload_complete_route.py
+++ b/backend/tests/test_reference_upload_complete_route.py
@@ -1,0 +1,198 @@
+"""TDD: POST /api/references/{id}/upload-complete and /abort routes — spec §2."""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.services.auth_service import AuthService
+from app.services.reference_data_service import ReferenceDataService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_uploadcomplete_route@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def comp_bio_token(comp_bio_user) -> str:
+    return AuthService.create_token(
+        comp_bio_user.id,
+        comp_bio_user.email,
+        comp_bio_user.role_id,
+        comp_bio_user.organization_id,
+        role_name="comp_bio",
+    )
+
+
+@pytest_asyncio.fixture
+async def bench_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("benchpass123")
+    user = User(
+        email="bench_uploadcomplete_route@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["bench"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def bench_token(bench_user) -> str:
+    return AuthService.create_token(
+        bench_user.id, bench_user.email, bench_user.role_id, bench_user.organization_id, role_name="bench"
+    )
+
+
+@pytest_asyncio.fixture
+async def configured_refs_bucket(session):
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value, updated_at) "
+            "VALUES ('references_bucket_name', 'bioaf-references-test', NOW()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+    )
+    await session.commit()
+
+
+def _stub_session_url(bucket_name, blob_path, content_type, size_bytes, origin=None, credentials=None):
+    return f"https://storage.googleapis.com/stub/{blob_path}"
+
+
+class _StubBlob:
+    def __init__(self, name: str, size: int, md5: str):
+        self.name = name
+        self.size = size
+        self.md5_hash = md5
+
+
+VALID_INIT = {
+    "name": "Custom Markers",
+    "category": "markers",
+    "scope": "internal",
+    "version": "v1",
+    "files": [
+        {"filename": "markers.csv", "size_bytes": 4096},
+        {"filename": "metadata.json", "size_bytes": 512},
+    ],
+}
+
+
+async def _post_init(client, token):
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        return await client.post(
+            "/api/references/upload-init",
+            json=VALID_INIT,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_route_finalizes(client, comp_bio_token, configured_refs_bucket):
+    init_resp = await _post_init(client, comp_bio_token)
+    assert init_resp.status_code == 200
+    ref_id = init_resp.json()["reference_id"]
+    prefix = init_resp.json()["gcs_prefix"]
+
+    blobs = [
+        _StubBlob(name=f"{prefix}markers.csv", size=4096, md5="aa" * 16),
+        _StubBlob(name=f"{prefix}metadata.json", size=512, md5="bb" * 16),
+    ]
+    with patch.object(ReferenceDataService, "_list_uploaded_blobs", return_value=blobs):
+        response = await client.post(
+            f"/api/references/{ref_id}/upload-complete",
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "active"
+    assert body["total_size_bytes"] == 4608
+    assert len(body["files"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_route_404_unknown(client, comp_bio_token, configured_refs_bucket):
+    response = await client.post(
+        "/api/references/99999/upload-complete",
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_route_400_when_files_missing(client, comp_bio_token, configured_refs_bucket):
+    init_resp = await _post_init(client, comp_bio_token)
+    ref_id = init_resp.json()["reference_id"]
+    prefix = init_resp.json()["gcs_prefix"]
+
+    blobs = [_StubBlob(name=f"{prefix}markers.csv", size=4096, md5="aa" * 16)]  # missing metadata.json
+    with patch.object(ReferenceDataService, "_list_uploaded_blobs", return_value=blobs):
+        response = await client.post(
+            f"/api/references/{ref_id}/upload-complete",
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    assert response.status_code == 400
+    assert "metadata.json" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_route_rejects_bench(client, comp_bio_token, bench_token, configured_refs_bucket):
+    init_resp = await _post_init(client, comp_bio_token)
+    ref_id = init_resp.json()["reference_id"]
+
+    response = await client.post(
+        f"/api/references/{ref_id}/upload-complete",
+        headers={"Authorization": f"Bearer {bench_token}"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_abort_route_deletes_reference(client, comp_bio_token, session, configured_refs_bucket):
+    init_resp = await _post_init(client, comp_bio_token)
+    ref_id = init_resp.json()["reference_id"]
+
+    with patch.object(ReferenceDataService, "_delete_blobs", return_value=None):
+        response = await client.post(
+            f"/api/references/{ref_id}/abort",
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+
+    assert response.status_code == 204
+
+    # Row gone
+    result = await session.execute(text("SELECT id FROM reference_datasets WHERE id = :id"), {"id": ref_id})
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_abort_route_idempotent_on_unknown(client, comp_bio_token, configured_refs_bucket):
+    """Aborting a missing reference returns 204 (idempotent per spec)."""
+    with patch.object(ReferenceDataService, "_delete_blobs", return_value=None):
+        response = await client.post(
+            "/api/references/99999/abort",
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    assert response.status_code == 204

--- a/backend/tests/test_reference_upload_init.py
+++ b/backend/tests/test_reference_upload_init.py
@@ -1,0 +1,194 @@
+"""TDD: ReferenceDataService.init_upload() — spec §2 Upload flow.
+
+The init_upload service method:
+- creates a ReferenceDataset row in status='uploading' (no files persisted yet)
+- requests a GCS resumable upload session for each declared file
+- returns the session URLs to the caller (browser will PUT directly to GCS)
+- writes an audit log entry
+- enforces (org_id, name, version) uniqueness up-front
+
+GCS calls are stubbed via monkeypatching `_create_resumable_session`.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.schemas.reference_dataset import (
+    ReferenceUploadFileSpec,
+    ReferenceUploadInitRequest,
+)
+from app.services.auth_service import AuthService
+from app.services.reference_data_service import ReferenceDataService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_uploadinit@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def configured_refs_bucket(session):
+    """Seed platform_config with a references bucket name."""
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value, updated_at) "
+            "VALUES ('references_bucket_name', 'bioaf-references-test', NOW()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+    )
+    await session.commit()
+    return "bioaf-references-test"
+
+
+def _stub_session_url(bucket_name, blob_path, content_type, size_bytes, origin=None, credentials=None):
+    """Drop-in replacement for the live GCS resumable session creator."""
+    return (
+        f"https://storage.googleapis.com/upload/storage/v1/b/{bucket_name}/o"
+        f"?uploadType=resumable&upload_id=stub-{blob_path.replace('/', '-')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_init_upload_creates_uploading_dataset(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceUploadInitRequest(
+        name="GRCh38 GENCODE",
+        category="genome",
+        scope="public",
+        version="v45",
+        source_url="https://www.gencodegenes.org/human/release_45.html",
+        files=[
+            ReferenceUploadFileSpec(filename="genome.fa", size_bytes=2_500_000_000),
+            ReferenceUploadFileSpec(filename="genes.gtf", size_bytes=500_000_000),
+        ],
+    )
+
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        dataset, uploads = await ReferenceDataService.init_upload(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+
+    assert dataset.id is not None
+    assert dataset.status == "uploading"
+    assert dataset.name == "GRCh38 GENCODE"
+    assert dataset.version == "v45"
+    assert dataset.uploaded_by_user_id == comp_bio_user.id
+    # gcs_prefix should namespace by category + slug(name) + slug(version) and end in /
+    assert dataset.gcs_prefix.endswith("/")
+    assert "v45" in dataset.gcs_prefix
+    assert "grch38-gencode" in dataset.gcs_prefix.lower()
+
+    assert len(uploads) == 2
+    filenames = {u["filename"] for u in uploads}
+    assert filenames == {"genome.fa", "genes.gtf"}
+    for u in uploads:
+        assert u["session_url"].startswith("https://storage.googleapis.com/")
+        # expires_at must be a datetime-or-isoformat string in the future
+        expires = u["expires_at"]
+        if isinstance(expires, str):
+            expires = datetime.fromisoformat(expires)
+        assert expires > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_init_upload_rejects_duplicate_name_version(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceUploadInitRequest(
+        name="GRCh38 GENCODE",
+        category="genome",
+        scope="public",
+        version="v45",
+        files=[ReferenceUploadFileSpec(filename="genome.fa", size_bytes=100)],
+    )
+
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        await ReferenceDataService.init_upload(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+        with pytest.raises(ValueError, match="already exists"):
+            await ReferenceDataService.init_upload(
+                session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+            )
+
+
+@pytest.mark.asyncio
+async def test_init_upload_writes_audit_log(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceUploadInitRequest(
+        name="Custom Markers",
+        category="markers",
+        scope="internal",
+        version="v1",
+        files=[ReferenceUploadFileSpec(filename="markers.csv", size_bytes=4096)],
+    )
+
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        dataset, _ = await ReferenceDataService.init_upload(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+        await session.commit()
+
+    result = await session.execute(
+        text(
+            "SELECT user_id, action FROM audit_log "
+            "WHERE entity_type = 'reference_dataset' "
+            "AND entity_id = :id AND action = 'upload_initiated'"
+        ),
+        {"id": dataset.id},
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.user_id == comp_bio_user.id
+
+
+@pytest.mark.asyncio
+async def test_init_upload_raises_when_bucket_not_configured(session, comp_bio_user):
+    """If platform_config has no references_bucket_name, the call must fail clearly."""
+    # Defensive: scrub the key in case prior tests inserted it.
+    await session.execute(text("DELETE FROM platform_config WHERE key = 'references_bucket_name'"))
+    await session.commit()
+
+    payload = ReferenceUploadInitRequest(
+        name="No Bucket",
+        category="other",
+        scope="internal",
+        version="v1",
+        files=[ReferenceUploadFileSpec(filename="x.txt", size_bytes=1)],
+    )
+
+    with pytest.raises(ValueError, match="not configured"):
+        await ReferenceDataService.init_upload(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )
+
+
+@pytest.mark.asyncio
+async def test_init_upload_requires_at_least_one_file(session, comp_bio_user, configured_refs_bucket):
+    payload = ReferenceUploadInitRequest(
+        name="Empty",
+        category="other",
+        scope="internal",
+        version="v1",
+        files=[],
+    )
+
+    with pytest.raises(ValueError, match="at least one file"):
+        await ReferenceDataService.init_upload(
+            session, org_id=comp_bio_user.organization_id, user_id=comp_bio_user.id, request=payload
+        )

--- a/backend/tests/test_reference_upload_init_route.py
+++ b/backend/tests/test_reference_upload_init_route.py
@@ -1,0 +1,179 @@
+"""TDD: POST /api/references/upload-init route — spec §2.
+
+Wraps ReferenceDataService.init_upload behind a FastAPI endpoint. Permission:
+`references:upload`. The browser uses the response to PUT bytes to GCS directly.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.services.auth_service import AuthService
+from app.services.reference_data_service import ReferenceDataService
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_uploadroute@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def comp_bio_token(comp_bio_user) -> str:
+    return AuthService.create_token(
+        comp_bio_user.id,
+        comp_bio_user.email,
+        comp_bio_user.role_id,
+        comp_bio_user.organization_id,
+        role_name="comp_bio",
+    )
+
+
+@pytest_asyncio.fixture
+async def bench_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("benchpass123")
+    user = User(
+        email="bench_uploadroute@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["bench"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def bench_token(bench_user) -> str:
+    return AuthService.create_token(
+        bench_user.id, bench_user.email, bench_user.role_id, bench_user.organization_id, role_name="bench"
+    )
+
+
+@pytest_asyncio.fixture
+async def configured_refs_bucket(session):
+    await session.execute(
+        text(
+            "INSERT INTO platform_config (key, value, updated_at) "
+            "VALUES ('references_bucket_name', 'bioaf-references-test', NOW()) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+        )
+    )
+    await session.commit()
+
+
+def _stub_session_url(bucket_name, blob_path, content_type, size_bytes, origin=None, credentials=None):
+    return (
+        f"https://storage.googleapis.com/upload/storage/v1/b/{bucket_name}/o"
+        f"?uploadType=resumable&upload_id=stub-{blob_path.replace('/', '-')}"
+    )
+
+
+VALID_PAYLOAD = {
+    "name": "GRCh38 GENCODE",
+    "category": "genome",
+    "scope": "public",
+    "version": "v45",
+    "source_url": "https://www.gencodegenes.org/human/release_45.html",
+    "files": [
+        {"filename": "genome.fa", "size_bytes": 2_500_000_000},
+        {"filename": "genes.gtf", "size_bytes": 500_000_000, "content_type": "text/plain"},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_upload_init_happy_path(client, comp_bio_token, configured_refs_bucket):
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        response = await client.post(
+            "/api/references/upload-init",
+            json=VALID_PAYLOAD,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "reference_id" in data
+    assert data["gcs_prefix"].endswith("/")
+    assert "v45" in data["gcs_prefix"]
+    assert len(data["uploads"]) == 2
+    filenames = {u["filename"] for u in data["uploads"]}
+    assert filenames == {"genome.fa", "genes.gtf"}
+    for slot in data["uploads"]:
+        assert slot["session_url"].startswith("https://storage.googleapis.com/")
+        assert "expires_at" in slot
+
+
+@pytest.mark.asyncio
+async def test_upload_init_rejects_bench(client, bench_token, configured_refs_bucket):
+    """bench role lacks references:upload."""
+    response = await client.post(
+        "/api/references/upload-init",
+        json=VALID_PAYLOAD,
+        headers={"Authorization": f"Bearer {bench_token}"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_upload_init_returns_409_on_duplicate(client, comp_bio_token, configured_refs_bucket):
+    with patch.object(ReferenceDataService, "_create_resumable_session", side_effect=_stub_session_url):
+        # first call ok
+        first = await client.post(
+            "/api/references/upload-init",
+            json=VALID_PAYLOAD,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+        assert first.status_code == 200
+
+        # second call (same name+version) -> 409
+        second = await client.post(
+            "/api/references/upload-init",
+            json=VALID_PAYLOAD,
+            headers={"Authorization": f"Bearer {comp_bio_token}"},
+        )
+    assert second.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_upload_init_503_when_bucket_missing(client, comp_bio_token, session):
+    """If references bucket isn't configured, return 503 with clear message."""
+    await session.execute(text("DELETE FROM platform_config WHERE key = 'references_bucket_name'"))
+    await session.commit()
+
+    response = await client.post(
+        "/api/references/upload-init",
+        json=VALID_PAYLOAD,
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 503
+    assert "not configured" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_init_400_on_empty_files(client, comp_bio_token, configured_refs_bucket):
+    payload = {**VALID_PAYLOAD, "files": []}
+    response = await client.post(
+        "/api/references/upload-init",
+        json=payload,
+        headers={"Authorization": f"Bearer {comp_bio_token}"},
+    )
+    assert response.status_code == 400

--- a/backend/tests/test_references_resource_permissions.py
+++ b/backend/tests/test_references_resource_permissions.py
@@ -1,0 +1,114 @@
+"""Tests for the new `references` resource in the permission catalog.
+
+The Reference Data Ingest spec (ADR-047) calls for a dedicated `references`
+resource with `view` and `upload` actions, replacing the prior reuse of
+`pipelines:view` / `pipelines:create`. This test pins the catalog and
+the per-role seeding so future drift is caught.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.role import RolePermission
+from app.services.auth_service import AuthService
+from app.services.bootstrap_roles import ALL_RESOURCES_ACTIONS
+
+
+def test_references_resource_in_catalog():
+    """`references` resource must expose at least view and upload actions."""
+    assert "references" in ALL_RESOURCES_ACTIONS
+    actions = ALL_RESOURCES_ACTIONS["references"]
+    assert "view" in actions
+    assert "upload" in actions
+
+
+@pytest_asyncio.fixture
+async def comp_bio_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("compbiopass123")
+    user = User(
+        email="compbio_refperm@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["comp_bio"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def bench_user(session, admin_user):
+    from app.models.user import User
+
+    password_hash = AuthService.hash_password("benchpass123")
+    user = User(
+        email="bench_refperm@test.com",
+        password_hash=password_hash,
+        role_id=admin_user._test_role_map["bench"],
+        organization_id=admin_user.organization_id,
+        status="active",
+    )
+    session.add(user)
+    await session.flush()
+    await session.commit()
+    return user
+
+
+async def _role_perms(session, role_id: int) -> set[tuple[str, str]]:
+    result = await session.execute(
+        select(RolePermission.resource, RolePermission.action).where(RolePermission.role_id == role_id)
+    )
+    return {(r, a) for r, a in result.all()}
+
+
+@pytest.mark.asyncio
+async def test_admin_role_seeded_with_references_permissions(session, admin_user):
+    """admin role: references:view and references:upload."""
+    role_id = admin_user._test_role_map["admin"]
+    perms = await _role_perms(session, role_id)
+    assert ("references", "view") in perms
+    assert ("references", "upload") in perms
+
+
+@pytest.mark.asyncio
+async def test_comp_bio_role_seeded_with_references_permissions(session, admin_user, comp_bio_user):
+    """comp_bio role: references:view and references:upload."""
+    role_id = admin_user._test_role_map["comp_bio"]
+    perms = await _role_perms(session, role_id)
+    assert ("references", "view") in perms
+    assert ("references", "upload") in perms
+
+
+@pytest.mark.asyncio
+async def test_bench_role_seeded_with_references_view(session, admin_user, bench_user):
+    """bench role: references:view only (no upload)."""
+    role_id = admin_user._test_role_map["bench"]
+    perms = await _role_perms(session, role_id)
+    assert ("references", "view") in perms
+    assert ("references", "upload") not in perms
+
+
+@pytest.mark.asyncio
+async def test_viewer_role_seeded_with_references_view(session, admin_user):
+    """viewer role: references:view only."""
+    role_id = admin_user._test_role_map["viewer"]
+    perms = await _role_perms(session, role_id)
+    assert ("references", "view") in perms
+    assert ("references", "upload") not in perms
+
+
+def test_reference_status_enum_includes_uploading_and_failed():
+    """Spec §2 introduces 'uploading' and 'failed' as new lifecycle statuses."""
+    from app.models.reference_dataset import REFERENCE_STATUSES
+
+    assert "uploading" in REFERENCE_STATUSES
+    assert "failed" in REFERENCE_STATUSES
+    # Existing statuses must still be present (additive only).
+    assert "active" in REFERENCE_STATUSES
+    assert "deprecated" in REFERENCE_STATUSES
+    assert "pending_approval" in REFERENCE_STATUSES

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.9.1",
+  "version": "0.10.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/data/references/[id]/page.test.tsx
+++ b/frontend/src/app/data/references/[id]/page.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import DataReferenceDetailPage from "./page";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ id: "1" }),
+}));
+
+jest.mock("@/components/layout/Sidebar", () => ({
+  Sidebar: () => <nav data-testid="sidebar" />,
+}));
+jest.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  isAuthenticated: () => true,
+  getCurrentUser: () => ({ role_name: "comp_bio", sub: "1", org_id: "1" }),
+}));
+
+import { api } from "@/lib/api";
+const mockGet = api.get as jest.Mock;
+
+const REF_DETAIL = {
+  id: 1,
+  organization_id: 1,
+  name: "GRCh38 GENCODE",
+  category: "genome",
+  scope: "public",
+  version: "v45",
+  source_url: null,
+  gcs_prefix: "genome/grch38-gencode/v45/",
+  total_size_bytes: 100,
+  file_count: 1,
+  status: "active",
+  deprecation_note: null,
+  superseded_by_id: null,
+  created_at: "2026-05-01T00:00:00Z",
+  files: [],
+  uploaded_by: { id: 1, name: "alice", email: "alice@test.com" },
+  approved_by: null,
+};
+
+beforeEach(() => {
+  mockPush.mockReset();
+  mockGet.mockReset();
+});
+
+describe("Reference Detail — versioning UX", () => {
+  it("Upload new version button navigates with locked name + category + scope", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.startsWith("/api/references/1")) return Promise.resolve(REF_DETAIL);
+      return Promise.resolve({ references: [], total: 0 });
+    });
+    render(<DataReferenceDetailPage />);
+    const btn = await screen.findByRole("button", { name: /upload new version/i });
+    fireEvent.click(btn);
+    expect(mockPush).toHaveBeenCalled();
+    const target = mockPush.mock.calls[0][0] as string;
+    expect(target).toContain("/data/references/new?");
+    expect(target).toContain("name=GRCh38+GENCODE");
+    expect(target).toContain("category=genome");
+    expect(target).toContain("scope=public");
+  });
+
+  it("Versions tab fetches /by-name and renders sibling versions", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.startsWith("/api/references/by-name")) {
+        return Promise.resolve({
+          total: 2,
+          references: [
+            REF_DETAIL,
+            {
+              ...REF_DETAIL,
+              id: 2,
+              version: "v44",
+              status: "deprecated",
+              deprecation_note: "old",
+            },
+          ],
+        });
+      }
+      if (url.startsWith("/api/references/1")) return Promise.resolve(REF_DETAIL);
+      return Promise.resolve({ references: [], total: 0 });
+    });
+
+    render(<DataReferenceDetailPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /versions/i }));
+
+    await waitFor(() => {
+      const calls = mockGet.mock.calls.map((c) => c[0]);
+      expect(calls.some((u: string) => u.includes("/api/references/by-name"))).toBe(true);
+    });
+
+    // Wait for the version-list table to render the deprecated v44 row
+    expect(await screen.findByText(/v44/)).toBeInTheDocument();
+    // Versions tab marks the current row with a "current" badge
+    expect(screen.getByText(/current/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/data/references/[id]/page.tsx
+++ b/frontend/src/app/data/references/[id]/page.tsx
@@ -23,7 +23,7 @@ function formatBytes(bytes: number | null): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
-type Tab = "files" | "impact" | "details";
+type Tab = "files" | "impact" | "details" | "versions";
 
 export default function DataReferenceDetailPage() {
   const router = useRouter();
@@ -47,6 +47,9 @@ export default function DataReferenceDetailPage() {
   const [activeRefs, setActiveRefs] = useState<ReferenceDataset[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
+  const [versions, setVersions] = useState<ReferenceDataset[] | null>(null);
+  const [versionsLoading, setVersionsLoading] = useState(false);
+
   useEffect(() => {
     if (!isAuthenticated()) {
       router.push("/login");
@@ -58,8 +61,28 @@ export default function DataReferenceDetailPage() {
 
   useEffect(() => {
     if (activeTab === "impact") loadImpact();
+    if (activeTab === "versions") loadVersions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab, id]);
+
+  async function loadVersions() {
+    if (!reference) return;
+    setVersionsLoading(true);
+    try {
+      const params = new URLSearchParams({
+        name: reference.name,
+        category: reference.category,
+      });
+      const data = await api.get<ReferenceDatasetListResponse>(
+        `/api/references/by-name?${params}`,
+      );
+      setVersions(data.references);
+    } catch {
+      setVersions([]);
+    } finally {
+      setVersionsLoading(false);
+    }
+  }
 
   async function loadReference() {
     try {
@@ -149,6 +172,7 @@ export default function DataReferenceDetailPage() {
 
   const tabs: { key: Tab; label: string }[] = [
     { key: "files", label: `Files (${reference.files.length})` },
+    { key: "versions", label: "Versions" },
     { key: "impact", label: "Impact" },
     { key: "details", label: "Details" },
   ];
@@ -172,13 +196,30 @@ export default function DataReferenceDetailPage() {
             <span className="capitalize">{reference.category}</span>
             <span>&middot;</span>
             <span className="capitalize">{reference.scope}</span>
-            {canDeprecate && reference.status === "active" && (
-              <button
-                onClick={openDeprecateModal}
-                className="ml-auto bg-red-50 text-red-700 border border-red-200 px-3 py-1.5 rounded-md text-sm hover:bg-red-100 transition-colors"
-              >
-                Deprecate
-              </button>
+            {canDeprecate && (
+              <div className="ml-auto flex gap-2">
+                <button
+                  onClick={() => {
+                    const params = new URLSearchParams({
+                      name: reference.name,
+                      category: reference.category,
+                      scope: reference.scope,
+                    });
+                    router.push(`/data/references/new?${params}`);
+                  }}
+                  className="bg-bioaf-50 text-bioaf-700 border border-bioaf-200 px-3 py-1.5 rounded-md text-sm hover:bg-bioaf-100 transition-colors"
+                >
+                  Upload new version
+                </button>
+                {reference.status === "active" && (
+                  <button
+                    onClick={openDeprecateModal}
+                    className="bg-red-50 text-red-700 border border-red-200 px-3 py-1.5 rounded-md text-sm hover:bg-red-100 transition-colors"
+                  >
+                    Deprecate
+                  </button>
+                )}
+              </div>
             )}
           </div>
 
@@ -270,6 +311,80 @@ export default function DataReferenceDetailPage() {
                   )}
                 </tbody>
               </table>
+            </div>
+          )}
+
+          {activeTab === "versions" && (
+            <div className="bg-white rounded-lg shadow overflow-hidden">
+              {versionsLoading && (
+                <div className="flex justify-center py-12">
+                  <LoadingSpinner size="lg" />
+                </div>
+              )}
+              {!versionsLoading && versions && versions.length > 0 && (
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Version</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200">
+                    {versions.map((v) => {
+                      const isCurrent = v.id === Number(id);
+                      return (
+                        <tr
+                          key={v.id}
+                          className={
+                            isCurrent
+                              ? "bg-bioaf-50"
+                              : v.status === "deprecated"
+                                ? "text-gray-400 hover:bg-gray-50"
+                                : "hover:bg-gray-50"
+                          }
+                        >
+                          <td className="px-6 py-4 text-sm font-medium">
+                            {isCurrent ? (
+                              <span>
+                                {v.version}{" "}
+                                <span className="ml-2 text-xs uppercase tracking-wide text-bioaf-600">
+                                  current
+                                </span>
+                              </span>
+                            ) : (
+                              <a
+                                href={`/data/references/${v.id}`}
+                                className="text-bioaf-700 hover:underline"
+                              >
+                                {v.version}
+                              </a>
+                            )}
+                          </td>
+                          <td className="px-6 py-4">
+                            <ReferenceStatusBadge status={v.status} />
+                          </td>
+                          <td className="px-6 py-4 text-sm text-gray-500">
+                            {new Date(v.created_at).toLocaleDateString()}
+                          </td>
+                          <td className="px-6 py-4 text-sm text-gray-500">
+                            {v.deprecation_note ?? "—"}
+                            {v.superseded_by_id && (
+                              <span> (superseded by #{v.superseded_by_id})</span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
+              {!versionsLoading && versions && versions.length === 0 && (
+                <div className="px-6 py-12 text-center text-gray-400">
+                  No other versions of this reference exist.
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/app/data/references/import/page.test.tsx
+++ b/frontend/src/app/data/references/import/page.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ImportReferencePage from "./page";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/components/layout/Sidebar", () => ({
+  Sidebar: () => <nav data-testid="sidebar" />,
+}));
+jest.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: () => ({ role_name: "comp_bio", sub: "1", org_id: "1" }),
+}));
+
+import { api } from "@/lib/api";
+
+const mockGet = api.get as jest.Mock;
+const mockPost = api.post as jest.Mock;
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+});
+
+describe("ImportReferencePage", () => {
+  it("renders the import form fields", () => {
+    render(<ImportReferencePage />);
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/version/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/source url/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/extract/i)).toBeInTheDocument();
+  });
+
+  it("submits to /api/references/import with form values", async () => {
+    mockPost.mockResolvedValueOnce({
+      reference_id: 7,
+      import_job_id: "refimport-7-stub",
+      status: "pending",
+    });
+    mockGet.mockResolvedValue({
+      reference_id: 7,
+      status: "downloading",
+      progress_pct: 10,
+      bytes_downloaded: 10,
+      total_bytes: 100,
+      error_message: null,
+      import_job_id: "refimport-7-stub",
+      updated_at: null,
+    });
+
+    render(<ImportReferencePage />);
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "GENCODE" } });
+    fireEvent.change(screen.getByLabelText(/version/i), { target: { value: "v45" } });
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: "annotation" } });
+    fireEvent.change(screen.getByLabelText(/scope/i), { target: { value: "internal" } });
+    fireEvent.change(screen.getByLabelText(/source url/i), {
+      target: { value: "https://ftp.example/file.gz" },
+    });
+    fireEvent.change(screen.getByLabelText(/extract/i), { target: { value: "gzip" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    expect(mockPost.mock.calls[0][0]).toBe("/api/references/import");
+    const body = mockPost.mock.calls[0][1];
+    expect(body.name).toBe("GENCODE");
+    expect(body.source_url).toBe("https://ftp.example/file.gz");
+    expect(body.extract).toBe("gzip");
+  });
+
+  it("shows server error when import-init fails", async () => {
+    mockPost.mockRejectedValueOnce(new Error("References bucket not configured"));
+
+    render(<ImportReferencePage />);
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "GENCODE" } });
+    fireEvent.change(screen.getByLabelText(/version/i), { target: { value: "v45" } });
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: "annotation" } });
+    fireEvent.change(screen.getByLabelText(/scope/i), { target: { value: "internal" } });
+    fireEvent.change(screen.getByLabelText(/source url/i), {
+      target: { value: "https://ftp.example/file.gz" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    expect(await screen.findByText(/bucket not configured/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/data/references/import/page.tsx
+++ b/frontend/src/app/data/references/import/page.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Sidebar } from "@/components/layout/Sidebar";
+import { Header } from "@/components/layout/Header";
+import { api } from "@/lib/api";
+import type {
+  ReferenceImportRequest,
+  ReferenceImportStartResponse,
+  ReferenceImportStatusResponse,
+} from "@/lib/types";
+
+const CATEGORIES = ["genome", "annotation", "index", "atlas", "markers", "other"];
+const SCOPES = ["public", "internal"];
+const EXTRACT_MODES: ReferenceImportRequest["extract"][] = ["none", "gzip", "tar", "tar.gz"];
+
+const TERMINAL_STATUSES = new Set(["active", "failed"]);
+const POLL_INTERVAL_MS = 5000;
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export default function ImportReferencePage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [version, setVersion] = useState("");
+  const [category, setCategory] = useState("annotation");
+  const [scope, setScope] = useState("internal");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [sourceMd5Url, setSourceMd5Url] = useState("");
+  const [extract, setExtract] = useState<ReferenceImportRequest["extract"]>("gzip");
+  const [description, setDescription] = useState("");
+
+  const [referenceId, setReferenceId] = useState<number | null>(null);
+  const [status, setStatus] = useState<ReferenceImportStatusResponse | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollHandle = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pollHandle.current) clearInterval(pollHandle.current);
+    };
+  }, []);
+
+  const startPolling = (id: number) => {
+    if (pollHandle.current) clearInterval(pollHandle.current);
+    const tick = async () => {
+      try {
+        const s = await api.get<ReferenceImportStatusResponse>(
+          `/api/references/${id}/import-status`,
+        );
+        setStatus(s);
+        if (TERMINAL_STATUSES.has(s.status)) {
+          if (pollHandle.current) clearInterval(pollHandle.current);
+          if (s.status === "active") {
+            router.push(`/data/references/${id}`);
+          }
+        }
+      } catch {
+        // keep polling on transient errors
+      }
+    };
+    void tick();
+    pollHandle.current = setInterval(tick, POLL_INTERVAL_MS);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!name || !version || !category || !scope || !sourceUrl) {
+      setError("Fill in all required fields.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const init = await api.post<ReferenceImportStartResponse>(
+        "/api/references/import",
+        {
+          name,
+          version,
+          category,
+          scope,
+          source_url: sourceUrl,
+          source_md5_url: sourceMd5Url || undefined,
+          extract,
+          description: description || undefined,
+        } satisfies ReferenceImportRequest,
+      );
+      setReferenceId(init.reference_id);
+      setStatus({
+        reference_id: init.reference_id,
+        status: init.status,
+        progress_pct: null,
+        bytes_downloaded: null,
+        total_bytes: null,
+        error_message: null,
+        import_job_id: init.import_job_id,
+        updated_at: null,
+      });
+      startPolling(init.reference_id);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Import failed";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (referenceId == null) return;
+    try {
+      await api.post(`/api/references/${referenceId}/import-cancel`);
+    } catch {
+      // best-effort cancel
+    }
+    if (pollHandle.current) clearInterval(pollHandle.current);
+    router.push("/data/references");
+  };
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <Header />
+        <main className="flex-1 overflow-y-auto p-6">
+          <h1 className="text-2xl font-bold mb-4">Import Reference from URL</h1>
+          <p className="text-sm text-gray-600 mb-6">
+            Pull a reference (FASTA, GTF, prebuilt index, ...) from a public URL via a
+            per-import job that runs to completion in the background. Large transfers
+            don&apos;t block this browser session.
+          </p>
+
+          {!referenceId && (
+            <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-6 space-y-4 max-w-3xl">
+              <div className="grid grid-cols-2 gap-4">
+                <label className="block">
+                  <span className="text-sm font-medium text-gray-700">Name *</span>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                    required
+                  />
+                </label>
+                <label className="block">
+                  <span className="text-sm font-medium text-gray-700">Version *</span>
+                  <input
+                    type="text"
+                    value={version}
+                    onChange={(e) => setVersion(e.target.value)}
+                    className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                    required
+                  />
+                </label>
+                <label className="block">
+                  <span className="text-sm font-medium text-gray-700">Category *</span>
+                  <select
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                    required
+                  >
+                    {CATEGORIES.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block">
+                  <span className="text-sm font-medium text-gray-700">Scope *</span>
+                  <select
+                    value={scope}
+                    onChange={(e) => setScope(e.target.value)}
+                    className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                    required
+                  >
+                    {SCOPES.map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Source URL *</span>
+                <input
+                  type="url"
+                  value={sourceUrl}
+                  onChange={(e) => setSourceUrl(e.target.value)}
+                  placeholder="https://ftp.ebi.ac.uk/.../gencode.v45.annotation.gtf.gz"
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  required
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Source MD5 URL (optional)</span>
+                <input
+                  type="url"
+                  value={sourceMd5Url}
+                  onChange={(e) => setSourceMd5Url(e.target.value)}
+                  placeholder="https://ftp.example/MD5SUMS"
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Extract</span>
+                <select
+                  value={extract}
+                  onChange={(e) => setExtract(e.target.value as ReferenceImportRequest["extract"])}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                >
+                  {EXTRACT_MODES.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Description (optional)</span>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={2}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                />
+              </label>
+
+              {error && (
+                <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+                  {error}
+                </div>
+              )}
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => router.push("/data/references")}
+                  disabled={submitting}
+                  className="px-4 py-2 border border-gray-300 rounded-md text-sm hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="bg-bioaf-600 text-white px-4 py-2 rounded-md text-sm hover:bg-bioaf-700 disabled:opacity-50"
+                >
+                  {submitting ? "Starting..." : "Start import"}
+                </button>
+              </div>
+            </form>
+          )}
+
+          {referenceId && status && (
+            <div className="bg-white rounded-lg shadow p-6 space-y-3 max-w-3xl">
+              <h2 className="text-lg font-semibold">Import in progress</h2>
+              <div className="text-sm">
+                Status: <span className="font-mono">{status.status}</span>
+                {status.progress_pct != null && <> — {status.progress_pct}%</>}
+              </div>
+              {status.total_bytes != null && (
+                <div className="text-sm text-gray-600">
+                  {formatBytes(status.bytes_downloaded)} / {formatBytes(status.total_bytes)}
+                </div>
+              )}
+              <div className="bg-gray-200 h-2 rounded overflow-hidden">
+                <div
+                  className="bg-bioaf-600 h-2 transition-all"
+                  style={{ width: `${status.progress_pct ?? 0}%` }}
+                />
+              </div>
+              {status.error_message && (
+                <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+                  {status.error_message}
+                </div>
+              )}
+              <div className="flex justify-end pt-2">
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="px-4 py-2 border border-red-300 text-red-700 rounded-md text-sm hover:bg-red-50"
+                >
+                  Cancel import
+                </button>
+              </div>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/data/references/new/page.test.tsx
+++ b/frontend/src/app/data/references/new/page.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import NewReferencePage from "./page";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/components/layout/Sidebar", () => ({
+  Sidebar: () => <nav data-testid="sidebar" />,
+}));
+jest.mock("@/components/layout/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: () => ({ role_name: "comp_bio", sub: "1", org_id: "1" }),
+}));
+
+jest.mock("@/lib/resumableUpload", () => ({
+  uploadFileResumable: jest.fn(async () => undefined),
+  pickChunkSize: () => 8 * 1024 * 1024,
+}));
+
+import { api } from "@/lib/api";
+import { uploadFileResumable } from "@/lib/resumableUpload";
+
+const mockPost = api.post as jest.Mock;
+const mockUpload = uploadFileResumable as jest.Mock;
+
+beforeEach(() => {
+  mockPost.mockReset();
+  mockUpload.mockReset().mockResolvedValue(undefined);
+});
+
+function makeFile(name: string, bytes: number): File {
+  return new File([new Uint8Array(bytes)], name, { type: "application/octet-stream" });
+}
+
+describe("NewReferencePage", () => {
+  it("renders the upload form fields", () => {
+    render(<NewReferencePage />);
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/version/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/category/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/scope/i)).toBeInTheDocument();
+  });
+
+  it("calls upload-init with the form values then PUTs each file then upload-complete", async () => {
+    mockPost
+      .mockResolvedValueOnce({
+        reference_id: 42,
+        gcs_prefix: "genome/grch38/v45/",
+        uploads: [
+          {
+            filename: "genome.fa",
+            session_url: "https://gcs.example/session/genome.fa",
+            expires_at: "2026-05-10T00:00:00Z",
+          },
+          {
+            filename: "genes.gtf",
+            session_url: "https://gcs.example/session/genes.gtf",
+            expires_at: "2026-05-10T00:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: 42,
+        organization_id: 1,
+        name: "GRCh38",
+        category: "genome",
+        scope: "public",
+        version: "v45",
+        gcs_prefix: "genome/grch38/v45/",
+        status: "pending_approval",
+        files: [],
+      });
+
+    render(<NewReferencePage />);
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "GRCh38" } });
+    fireEvent.change(screen.getByLabelText(/version/i), { target: { value: "v45" } });
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: "genome" } });
+    fireEvent.change(screen.getByLabelText(/scope/i), { target: { value: "public" } });
+
+    const fileInput = screen.getByLabelText(/files/i) as HTMLInputElement;
+    const f1 = makeFile("genome.fa", 1024);
+    const f2 = makeFile("genes.gtf", 2048);
+    fireEvent.change(fileInput, { target: { files: [f1, f2] } });
+
+    fireEvent.click(screen.getByRole("button", { name: /start upload/i }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+
+    expect(mockPost.mock.calls[0][0]).toBe("/api/references/upload-init");
+    const initBody = mockPost.mock.calls[0][1];
+    expect(initBody.name).toBe("GRCh38");
+    expect(initBody.version).toBe("v45");
+    expect(initBody.category).toBe("genome");
+    expect(initBody.scope).toBe("public");
+    expect(initBody.files).toHaveLength(2);
+    expect(initBody.files[0]).toMatchObject({ filename: "genome.fa", size_bytes: 1024 });
+
+    await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(2));
+    expect(mockUpload).toHaveBeenCalledWith(
+      "https://gcs.example/session/genome.fa",
+      f1,
+      expect.any(Object),
+    );
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith("/api/references/42/upload-complete"),
+    );
+  });
+
+  it("calls /abort on init failure cleanup", async () => {
+    mockPost
+      .mockResolvedValueOnce({
+        reference_id: 99,
+        gcs_prefix: "genome/x/v1/",
+        uploads: [
+          {
+            filename: "genome.fa",
+            session_url: "https://gcs.example/session/genome.fa",
+            expires_at: "2026-05-10T00:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({}); // /abort
+
+    mockUpload.mockRejectedValueOnce(new Error("network down"));
+
+    render(<NewReferencePage />);
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "X" } });
+    fireEvent.change(screen.getByLabelText(/version/i), { target: { value: "v1" } });
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: "genome" } });
+    fireEvent.change(screen.getByLabelText(/scope/i), { target: { value: "internal" } });
+
+    const fileInput = screen.getByLabelText(/files/i) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [makeFile("genome.fa", 1024)] } });
+
+    fireEvent.click(screen.getByRole("button", { name: /start upload/i }));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith("/api/references/99/abort"),
+    );
+    expect(await screen.findByText(/network down|upload failed/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/data/references/new/page.test.tsx
+++ b/frontend/src/app/data/references/new/page.test.tsx
@@ -3,6 +3,7 @@ import NewReferencePage from "./page";
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 jest.mock("@/components/layout/Sidebar", () => ({

--- a/frontend/src/app/data/references/new/page.tsx
+++ b/frontend/src/app/data/references/new/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Sidebar } from "@/components/layout/Sidebar";
+import { Header } from "@/components/layout/Header";
+import { api } from "@/lib/api";
+import { uploadFileResumable } from "@/lib/resumableUpload";
+import type {
+  ReferenceUploadInitRequest,
+  ReferenceUploadInitResponse,
+} from "@/lib/types";
+
+const CATEGORIES = ["genome", "annotation", "index", "atlas", "markers", "other"];
+const SCOPES = ["public", "internal"];
+
+interface FileProgress {
+  filename: string;
+  size: number;
+  uploaded: number;
+  status: "pending" | "uploading" | "done" | "error";
+  error?: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export default function NewReferencePage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [version, setVersion] = useState("");
+  const [category, setCategory] = useState("genome");
+  const [scope, setScope] = useState("internal");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [description, setDescription] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [progress, setProgress] = useState<FileProgress[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files ?? []);
+    setFiles(selected);
+    setProgress(
+      selected.map((f) => ({
+        filename: f.name,
+        size: f.size,
+        uploaded: 0,
+        status: "pending",
+      })),
+    );
+  };
+
+  const updateProgress = (filename: string, patch: Partial<FileProgress>) => {
+    setProgress((prev) =>
+      prev.map((p) => (p.filename === filename ? { ...p, ...patch } : p)),
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!name || !version || !category || !scope || files.length === 0) {
+      setError("Fill in all required fields and select at least one file.");
+      return;
+    }
+    setSubmitting(true);
+
+    const initBody: ReferenceUploadInitRequest = {
+      name,
+      version,
+      category,
+      scope,
+      source_url: sourceUrl || undefined,
+      description: description || undefined,
+      files: files.map((f) => ({
+        filename: f.name,
+        size_bytes: f.size,
+        content_type: f.type || undefined,
+      })),
+    };
+
+    let referenceId: number | null = null;
+    try {
+      const init = await api.post<ReferenceUploadInitResponse>(
+        "/api/references/upload-init",
+        initBody,
+      );
+      referenceId = init.reference_id;
+
+      const slotByFilename = new Map(init.uploads.map((u) => [u.filename, u]));
+      for (const file of files) {
+        const slot = slotByFilename.get(file.name);
+        if (!slot) {
+          throw new Error(`Server did not return a session URL for ${file.name}`);
+        }
+        updateProgress(file.name, { status: "uploading" });
+        await uploadFileResumable(slot.session_url, file, {
+          onProgress: (uploaded) => updateProgress(file.name, { uploaded }),
+        });
+        updateProgress(file.name, { status: "done", uploaded: file.size });
+      }
+
+      await api.post(`/api/references/${referenceId}/upload-complete`);
+      router.push(`/data/references/${referenceId}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Upload failed";
+      setError(message);
+      if (referenceId != null) {
+        try {
+          await api.post(`/api/references/${referenceId}/abort`);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <Header />
+        <main className="flex-1 overflow-y-auto p-6">
+          <h1 className="text-2xl font-bold mb-4">Add Reference Dataset</h1>
+          <p className="text-sm text-gray-600 mb-6">
+            Upload reference files (genome FASTA, annotation GTF, prebuilt indices, etc.)
+            directly to GCS via a resumable session — large files survive page reloads
+            and flaky connections.
+          </p>
+
+          <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-6 space-y-4 max-w-3xl">
+            <div className="grid grid-cols-2 gap-4">
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Name *</span>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  required
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Version *</span>
+                <input
+                  type="text"
+                  value={version}
+                  onChange={(e) => setVersion(e.target.value)}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  required
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Category *</span>
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  required
+                >
+                  {CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700">Scope *</span>
+                <select
+                  value={scope}
+                  onChange={(e) => setScope(e.target.value)}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  required
+                >
+                  {SCOPES.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Source URL (optional)</span>
+              <input
+                type="url"
+                value={sourceUrl}
+                onChange={(e) => setSourceUrl(e.target.value)}
+                placeholder="https://www.gencodegenes.org/..."
+                className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Description (optional)</span>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={2}
+                className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Files *</span>
+              <input
+                type="file"
+                multiple
+                onChange={handleFiles}
+                disabled={submitting}
+                className="mt-1 block w-full text-sm"
+              />
+            </label>
+
+            {progress.length > 0 && (
+              <div className="border-t pt-4 space-y-2">
+                {progress.map((p) => (
+                  <div key={p.filename} className="text-sm">
+                    <div className="flex justify-between">
+                      <span className="font-mono">{p.filename}</span>
+                      <span className="text-gray-500">
+                        {formatBytes(p.uploaded)} / {formatBytes(p.size)} —{" "}
+                        <span
+                          className={
+                            p.status === "done"
+                              ? "text-green-600"
+                              : p.status === "error"
+                                ? "text-red-600"
+                                : "text-gray-600"
+                          }
+                        >
+                          {p.status}
+                        </span>
+                      </span>
+                    </div>
+                    <div className="bg-gray-200 h-2 rounded mt-1 overflow-hidden">
+                      <div
+                        className="bg-bioaf-600 h-2 transition-all"
+                        style={{ width: `${p.size === 0 ? 0 : (p.uploaded / p.size) * 100}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {error && (
+              <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+                {error}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={() => router.push("/data/references")}
+                disabled={submitting}
+                className="px-4 py-2 border border-gray-300 rounded-md text-sm hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="bg-bioaf-600 text-white px-4 py-2 rounded-md text-sm hover:bg-bioaf-700 disabled:opacity-50"
+              >
+                {submitting ? "Uploading..." : "Start upload"}
+              </button>
+            </div>
+          </form>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/data/references/new/page.tsx
+++ b/frontend/src/app/data/references/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { api } from "@/lib/api";
@@ -31,10 +31,17 @@ function formatBytes(bytes: number): string {
 
 export default function NewReferencePage() {
   const router = useRouter();
-  const [name, setName] = useState("");
+  const search = useSearchParams();
+  // When invoked as 'Upload new version' from a reference detail page, the
+  // caller passes name/category/scope so we lock those fields and the user
+  // only fills in version + files.
+  const lockedName = search?.get("name") ?? "";
+  const lockedCategory = search?.get("category") ?? "";
+  const lockedScope = search?.get("scope") ?? "";
+  const [name, setName] = useState(lockedName);
   const [version, setVersion] = useState("");
-  const [category, setCategory] = useState("genome");
-  const [scope, setScope] = useState("internal");
+  const [category, setCategory] = useState(lockedCategory || "genome");
+  const [scope, setScope] = useState(lockedScope || "internal");
   const [sourceUrl, setSourceUrl] = useState("");
   const [description, setDescription] = useState("");
   const [files, setFiles] = useState<File[]>([]);
@@ -143,7 +150,8 @@ export default function NewReferencePage() {
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  readOnly={Boolean(lockedName)}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm read-only:bg-gray-50 read-only:text-gray-600"
                   required
                 />
               </label>
@@ -162,7 +170,8 @@ export default function NewReferencePage() {
                 <select
                   value={category}
                   onChange={(e) => setCategory(e.target.value)}
-                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+                  disabled={Boolean(lockedCategory)}
+                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 text-sm disabled:bg-gray-50 disabled:text-gray-600"
                   required
                 >
                   {CATEGORIES.map((c) => (

--- a/frontend/src/app/data/references/new/page.tsx
+++ b/frontend/src/app/data/references/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
@@ -30,6 +30,16 @@ function formatBytes(bytes: number): string {
 }
 
 export default function NewReferencePage() {
+  // useSearchParams forces client-side rendering and must be wrapped in a
+  // Suspense boundary for Next.js's prerender pass to skip this page cleanly.
+  return (
+    <Suspense fallback={null}>
+      <NewReferenceForm />
+    </Suspense>
+  );
+}
+
+function NewReferenceForm() {
   const router = useRouter();
   const search = useSearchParams();
   // When invoked as 'Upload new version' from a reference detail page, the

--- a/frontend/src/app/data/references/page.tsx
+++ b/frontend/src/app/data/references/page.tsx
@@ -21,10 +21,7 @@ function formatBytes(bytes: number | null): string {
 export default function DataReferencesPage() {
   const router = useRouter();
   const user = getCurrentUser();
-  // Add Reference upload UI is in flight (spec-reference-data-ingest §9 step 3).
-  // Until the /data/references/new route exists, keep the affordance hidden so
-  // we don't dead-end users on a 404.
-  const canAdd = false && (user?.role_name === "admin" || user?.role_name === "comp_bio");
+  const canAdd = user?.role_name === "admin" || user?.role_name === "comp_bio";
 
   const [references, setReferences] = useState<ReferenceDataset[]>([]);
   const [total, setTotal] = useState(0);
@@ -76,7 +73,7 @@ export default function DataReferencesPage() {
             <h1 className="text-2xl font-bold">Reference Data</h1>
             {canAdd && (
               <button
-                onClick={() => router.push("/references/new")}
+                onClick={() => router.push("/data/references/new")}
                 className="bg-bioaf-600 text-white px-4 py-2 rounded-md hover:bg-bioaf-700 transition-colors"
               >
                 Add Reference
@@ -146,7 +143,7 @@ export default function DataReferencesPage() {
               </p>
               {canAdd && (
                 <button
-                  onClick={() => router.push("/references/new")}
+                  onClick={() => router.push("/data/references/new")}
                   className="bg-bioaf-600 text-white px-4 py-2 rounded-md hover:bg-bioaf-700"
                 >
                   Add Reference

--- a/frontend/src/app/data/references/page.tsx
+++ b/frontend/src/app/data/references/page.tsx
@@ -72,12 +72,20 @@ export default function DataReferencesPage() {
           <div className="flex items-center justify-between mb-6">
             <h1 className="text-2xl font-bold">Reference Data</h1>
             {canAdd && (
-              <button
-                onClick={() => router.push("/data/references/new")}
-                className="bg-bioaf-600 text-white px-4 py-2 rounded-md hover:bg-bioaf-700 transition-colors"
-              >
-                Add Reference
-              </button>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => router.push("/data/references/import")}
+                  className="border border-bioaf-600 text-bioaf-700 px-4 py-2 rounded-md hover:bg-bioaf-50 transition-colors"
+                >
+                  Import from URL
+                </button>
+                <button
+                  onClick={() => router.push("/data/references/new")}
+                  className="bg-bioaf-600 text-white px-4 py-2 rounded-md hover:bg-bioaf-700 transition-colors"
+                >
+                  Add Reference
+                </button>
+              </div>
             )}
           </div>
 

--- a/frontend/src/app/data/references/page.tsx
+++ b/frontend/src/app/data/references/page.tsx
@@ -21,7 +21,10 @@ function formatBytes(bytes: number | null): string {
 export default function DataReferencesPage() {
   const router = useRouter();
   const user = getCurrentUser();
-  const canAdd = user?.role_name === "admin" || user?.role_name === "comp_bio";
+  // Add Reference upload UI is in flight (spec-reference-data-ingest §9 step 3).
+  // Until the /data/references/new route exists, keep the affordance hidden so
+  // we don't dead-end users on a 404.
+  const canAdd = false && (user?.role_name === "admin" || user?.role_name === "comp_bio");
 
   const [references, setReferences] = useState<ReferenceDataset[]>([]);
   const [total, setTotal] = useState(0);

--- a/frontend/src/app/pipelines/custom/[id]/page.tsx
+++ b/frontend/src/app/pipelines/custom/[id]/page.tsx
@@ -42,9 +42,20 @@ function emptyVariableDraft(): VariableDraft {
     variable_name: "",
     default_value: "",
     variable_type: "string",
+    reference_category: null,
     is_required: false,
   };
 }
+
+const REFERENCE_CATEGORY_OPTIONS = [
+  "any",
+  "genome",
+  "annotation",
+  "index",
+  "atlas",
+  "markers",
+  "other",
+] as const;
 
 function changeLabel(
   current: CustomPipelineVersion,
@@ -216,6 +227,7 @@ export default function CustomPipelineDetailPage() {
         variable_name: v.variable_name,
         default_value: v.default_value,
         variable_type: v.variable_type,
+        reference_category: v.reference_category ?? null,
         is_required: v.is_required,
       })),
       qc_template: latest.qc_template ?? "",
@@ -390,6 +402,8 @@ export default function CustomPipelineDetailPage() {
         variable_name: v.variable_name,
         default_value: v.default_value || null,
         variable_type: v.variable_type,
+        reference_category:
+          v.variable_type === "reference" ? (v.reference_category ?? null) : null,
         is_required: v.is_required,
       })),
       qc_template: versionForm.qc_template.trim() || null,
@@ -1030,6 +1044,13 @@ function NewVersionForm({
                 onChange={(e) =>
                   updateVariable(idx, {
                     variable_type: e.target.value as VariableDraft["variable_type"],
+                    // When switching to reference, default to 'any' so the
+                    // schema-required field is non-empty; clear it on switch
+                    // back to a primitive type.
+                    reference_category:
+                      e.target.value === "reference"
+                        ? (v.reference_category ?? "any")
+                        : null,
                   })
                 }
                 className="border rounded px-2 py-1.5 text-sm bg-white"
@@ -1037,13 +1058,33 @@ function NewVersionForm({
                 <option value="string">string</option>
                 <option value="number">number</option>
                 <option value="boolean">boolean</option>
+                <option value="reference">reference</option>
               </select>
-              <input
-                value={v.default_value ?? ""}
-                onChange={(e) => updateVariable(idx, { default_value: e.target.value })}
-                placeholder="Default value"
-                className="border rounded px-2 py-1.5 text-sm"
-              />
+              {v.variable_type === "reference" ? (
+                <select
+                  value={v.reference_category ?? "any"}
+                  onChange={(e) =>
+                    updateVariable(idx, {
+                      reference_category: e.target.value as VariableDraft["reference_category"],
+                    })
+                  }
+                  className="border rounded px-2 py-1.5 text-sm bg-white"
+                  aria-label="Reference category"
+                >
+                  {REFERENCE_CATEGORY_OPTIONS.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  value={v.default_value ?? ""}
+                  onChange={(e) => updateVariable(idx, { default_value: e.target.value })}
+                  placeholder="Default value"
+                  className="border rounded px-2 py-1.5 text-sm"
+                />
+              )}
               <label className="flex items-center gap-1 text-xs text-gray-600 px-1">
                 <input
                   type="checkbox"

--- a/frontend/src/app/pipelines/runs/[id]/page.tsx
+++ b/frontend/src/app/pipelines/runs/[id]/page.tsx
@@ -739,6 +739,7 @@ export default function PipelineRunDetailPage() {
                   <tr>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Version</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Notes</th>
                   </tr>
@@ -746,8 +747,16 @@ export default function PipelineRunDetailPage() {
                 <tbody className="divide-y divide-gray-200">
                   {references.map((ref) => (
                     <tr key={ref.id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 text-sm font-medium">{ref.name}</td>
+                      <td className="px-4 py-3 text-sm font-medium">
+                        <a
+                          href={`/data/references/${ref.id}`}
+                          className="text-bioaf-700 hover:underline"
+                        >
+                          {ref.name}
+                        </a>
+                      </td>
                       <td className="px-4 py-3 text-sm">{ref.version}</td>
+                      <td className="px-4 py-3 text-sm capitalize text-gray-700">{ref.category}</td>
                       <td className="px-4 py-3">
                         <ReferenceStatusBadge status={ref.status} />
                       </td>

--- a/frontend/src/components/pipelines/CustomPipelineLaunchDialog.tsx
+++ b/frontend/src/components/pipelines/CustomPipelineLaunchDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "@/lib/api";
 import { FileTreeSelector } from "@/components/notebooks/FileTreeSelector";
+import { ReferencePicker } from "@/components/references/ReferencePicker";
 import type {
   CustomPipelineDetail,
   CustomPipelineVariable,
@@ -508,6 +509,12 @@ function VariableInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           className="w-full border rounded px-3 py-2 text-sm font-mono"
+        />
+      ) : variable.variable_type === "reference" ? (
+        <ReferencePicker
+          category={variable.reference_category ?? "any"}
+          value={value}
+          onChange={onChange}
         />
       ) : (
         <input

--- a/frontend/src/components/references/ReferencePicker.test.tsx
+++ b/frontend/src/components/references/ReferencePicker.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { ReferencePicker } from "./ReferencePicker";
+
+jest.mock("@/lib/api", () => ({
+  api: { get: jest.fn() },
+}));
+
+import { api } from "@/lib/api";
+const mockGet = api.get as jest.Mock;
+
+beforeEach(() => mockGet.mockReset());
+
+describe("ReferencePicker", () => {
+  it("queries /api/references with the right category and renders active rows", async () => {
+    mockGet.mockResolvedValueOnce({
+      total: 2,
+      references: [
+        {
+          id: 1,
+          organization_id: 1,
+          name: "GRCh38",
+          category: "genome",
+          scope: "public",
+          version: "v45",
+          source_url: null,
+          gcs_prefix: "genome/grch38/v45/",
+          total_size_bytes: null,
+          file_count: 1,
+          status: "active",
+          deprecation_note: null,
+          superseded_by_id: null,
+          created_at: "2026-05-01T00:00:00Z",
+        },
+        {
+          id: 2,
+          organization_id: 1,
+          name: "GRCh38",
+          category: "genome",
+          scope: "public",
+          version: "v44",
+          source_url: null,
+          gcs_prefix: "genome/grch38/v44/",
+          total_size_bytes: null,
+          file_count: 1,
+          status: "deprecated",
+          deprecation_note: "old",
+          superseded_by_id: 1,
+          created_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+    });
+
+    const onChange = jest.fn();
+    render(<ReferencePicker category="genome" value="" onChange={onChange} />);
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith("/api/references?category=genome"));
+
+    // active version visible by default
+    expect(await screen.findByText(/GRCh38 \(v45\)/)).toBeInTheDocument();
+    // deprecated version is hidden until the toggle is checked
+    expect(screen.queryByText(/v44.*deprecated/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/include deprecated/i));
+    expect(await screen.findByText(/v44.*deprecated/)).toBeInTheDocument();
+  });
+
+  it("emits the dataset path when a row is selected", async () => {
+    mockGet.mockResolvedValueOnce({
+      total: 1,
+      references: [
+        {
+          id: 1,
+          organization_id: 1,
+          name: "GENCODE",
+          category: "annotation",
+          scope: "public",
+          version: "v45",
+          source_url: null,
+          gcs_prefix: "annotation/gencode/v45/",
+          total_size_bytes: null,
+          file_count: 1,
+          status: "active",
+          deprecation_note: null,
+          superseded_by_id: null,
+          created_at: "2026-05-01T00:00:00Z",
+        },
+      ],
+    });
+
+    const onChange = jest.fn();
+    render(<ReferencePicker category="annotation" value="" onChange={onChange} />);
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    fireEvent.change(screen.getByRole("combobox", { name: "" }), {
+      target: { value: "/data/references/annotation/gencode/v45/" },
+    });
+    expect(onChange).toHaveBeenCalledWith("/data/references/annotation/gencode/v45/");
+  });
+
+  it("requests all categories when category='any'", async () => {
+    mockGet.mockResolvedValueOnce({ total: 0, references: [] });
+    render(<ReferencePicker category="any" value="" onChange={() => {}} />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith("/api/references"));
+  });
+});

--- a/frontend/src/components/references/ReferencePicker.tsx
+++ b/frontend/src/components/references/ReferencePicker.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import type { ReferenceDataset, ReferenceDatasetListResponse } from "@/lib/types";
+
+/**
+ * Searchable dropdown of active reference datasets, scoped to a category
+ * (or 'any'). Stores the dataset's *path* (gcs_prefix mounted under
+ * /data/references/) so the existing pipeline_run_service auto-linker
+ * picks it up at run time without further wiring.
+ */
+export function ReferencePicker({
+  category,
+  value,
+  onChange,
+}: {
+  category: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const [refs, setRefs] = useState<ReferenceDataset[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [includeDeprecated, setIncludeDeprecated] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (category && category !== "any") params.set("category", category);
+    api
+      .get<ReferenceDatasetListResponse>(
+        `/api/references${params.toString() ? `?${params}` : ""}`,
+      )
+      .then((data) => setRefs(data.references))
+      .catch(() => setRefs([]))
+      .finally(() => setLoading(false));
+  }, [category]);
+
+  const visible = useMemo(
+    () =>
+      refs.filter((r) =>
+        includeDeprecated ? true : r.status === "active" || r.status === "pending_approval",
+      ),
+    [refs, includeDeprecated],
+  );
+
+  const pathFor = (r: ReferenceDataset) => `/data/references/${r.gcs_prefix}`;
+
+  return (
+    <div className="space-y-1">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full border rounded px-3 py-2 text-sm font-mono bg-white"
+        disabled={loading}
+      >
+        <option value="">— Select a reference —</option>
+        {visible.map((r) => (
+          <option
+            key={r.id}
+            value={pathFor(r)}
+            disabled={r.status === "deprecated"}
+          >
+            {r.name} ({r.version})
+            {r.status !== "active" ? ` — ${r.status}` : ""}
+          </option>
+        ))}
+      </select>
+      <label className="inline-flex items-center gap-1.5 text-xs text-gray-500">
+        <input
+          type="checkbox"
+          checked={includeDeprecated}
+          onChange={(e) => setIncludeDeprecated(e.target.checked)}
+          className="rounded"
+        />
+        Include deprecated versions
+      </label>
+      {loading && <p className="text-xs text-gray-400">Loading references...</p>}
+      {!loading && visible.length === 0 && (
+        <p className="text-xs text-gray-500">
+          No active references in category &ldquo;{category}&rdquo;.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/resumableUpload.test.ts
+++ b/frontend/src/lib/resumableUpload.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the chunked PUT loop against a GCS resumable session URL.
+ *
+ * Spec §2 (browser upload, chunked PUT with resume):
+ * - PUT each chunk with `Content-Range: bytes {start}-{end-1}/{total}`.
+ * - On 308 Resume Incomplete, parse the `Range: bytes=0-N` header to learn
+ *   the last byte the server saw and continue from N+1.
+ * - On 200/201 the upload is complete.
+ * - Chunk size: 8 MiB default; 64 MiB for files > 1 GiB.
+ */
+import { uploadFileResumable, pickChunkSize } from "./resumableUpload";
+
+function mockBlob(size: number, name = "test.bin"): File {
+  const arr = new Uint8Array(size);
+  return new File([arr], name, { type: "application/octet-stream" });
+}
+
+function fakeResponse(
+  status: number,
+  headers: Record<string, string> = {},
+  statusText = "",
+): Response {
+  return {
+    status,
+    statusText,
+    headers: {
+      get: (name: string) => headers[name] ?? null,
+    },
+  } as unknown as Response;
+}
+
+describe("pickChunkSize", () => {
+  it("returns 8 MiB for files <= 1 GiB", () => {
+    expect(pickChunkSize(1024)).toBe(8 * 1024 * 1024);
+    expect(pickChunkSize(1024 * 1024 * 1024)).toBe(8 * 1024 * 1024);
+  });
+  it("returns 64 MiB for files > 1 GiB", () => {
+    expect(pickChunkSize(2 * 1024 * 1024 * 1024)).toBe(64 * 1024 * 1024);
+  });
+});
+
+describe("uploadFileResumable", () => {
+  let originalFetch: typeof global.fetch;
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("PUTs a single chunk for a small file and resolves on 200", async () => {
+    const file = mockBlob(1024);
+    const calls: { range: string | null; bodySize: number }[] = [];
+
+    global.fetch = jest.fn(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      const range = headers["Content-Range"] ?? null;
+      const bodyBytes = init?.body instanceof Blob ? init.body.size : 0;
+      calls.push({ range, bodySize: bodyBytes });
+      return fakeResponse(200);
+    }) as jest.Mock;
+
+    await uploadFileResumable("https://gcs.example/session", file);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].range).toBe("bytes 0-1023/1024");
+    expect(calls[0].bodySize).toBe(1024);
+  });
+
+  it("chunks a large file across multiple PUTs, advancing on 308 with Range header", async () => {
+    const total = 20 * 1024; // 20 KB
+    const chunkSize = 8 * 1024; // 8 KB
+    const file = mockBlob(total);
+
+    const ranges: string[] = [];
+    let call = 0;
+    global.fetch = jest.fn(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      ranges.push(headers["Content-Range"]);
+      call++;
+      // First two chunks: 308 with Range advancing to last byte received
+      if (call < 3) {
+        const lastByte = call * chunkSize - 1;
+        return fakeResponse(308, { Range: `bytes=0-${lastByte}` });
+      }
+      return fakeResponse(200);
+    }) as jest.Mock;
+
+    const progress: number[] = [];
+    await uploadFileResumable("https://gcs.example/session", file, {
+      chunkSize,
+      onProgress: (uploaded) => progress.push(uploaded),
+    });
+
+    expect(ranges).toEqual([
+      `bytes 0-${chunkSize - 1}/${total}`,
+      `bytes ${chunkSize}-${chunkSize * 2 - 1}/${total}`,
+      `bytes ${chunkSize * 2}-${total - 1}/${total}`,
+    ]);
+    expect(progress[progress.length - 1]).toBe(total);
+  });
+
+  it("respects abort signal and stops issuing further chunks", async () => {
+    const file = mockBlob(20 * 1024);
+    const ctrl = new AbortController();
+    let chunkCount = 0;
+    global.fetch = jest.fn(async (_url, init) => {
+      chunkCount++;
+      if (chunkCount === 1) {
+        ctrl.abort();
+        return fakeResponse(308, { Range: "bytes=0-8191" });
+      }
+      return fakeResponse(200);
+    }) as jest.Mock;
+
+    await expect(
+      uploadFileResumable("https://gcs.example/session", file, {
+        chunkSize: 8 * 1024,
+        signal: ctrl.signal,
+      }),
+    ).rejects.toThrow(/aborted/i);
+    expect(chunkCount).toBe(1);
+  });
+
+  it("throws if GCS returns a 4xx/5xx", async () => {
+    const file = mockBlob(1024);
+    global.fetch = jest.fn(async () => fakeResponse(403, {}, "Forbidden")) as jest.Mock;
+
+    await expect(uploadFileResumable("https://gcs.example/session", file)).rejects.toThrow(
+      /403/,
+    );
+  });
+});

--- a/frontend/src/lib/resumableUpload.ts
+++ b/frontend/src/lib/resumableUpload.ts
@@ -1,0 +1,75 @@
+/**
+ * Browser-side chunked PUT against a GCS resumable upload session URL.
+ *
+ * The session URL is created server-side by ReferenceDataService.init_upload
+ * (spec §2). The browser then PUTs the bytes directly — no bioAF auth on the
+ * upload path, just GCS's own session token embedded in the URL.
+ *
+ * Resume protocol: GCS returns 308 with `Range: bytes=0-N` to tell us the
+ * highest byte it has accepted. We continue from N+1.
+ */
+
+const ONE_GIB = 1024 * 1024 * 1024;
+const DEFAULT_CHUNK = 8 * 1024 * 1024;
+const LARGE_FILE_CHUNK = 64 * 1024 * 1024;
+
+export function pickChunkSize(totalBytes: number): number {
+  return totalBytes > ONE_GIB ? LARGE_FILE_CHUNK : DEFAULT_CHUNK;
+}
+
+export interface ResumableUploadOptions {
+  chunkSize?: number;
+  signal?: AbortSignal;
+  onProgress?: (bytesUploaded: number, totalBytes: number) => void;
+}
+
+export async function uploadFileResumable(
+  sessionUrl: string,
+  file: File,
+  opts: ResumableUploadOptions = {},
+): Promise<void> {
+  const total = file.size;
+  const chunkSize = opts.chunkSize ?? pickChunkSize(total);
+  let start = 0;
+
+  while (start < total) {
+    if (opts.signal?.aborted) {
+      throw new Error("Upload aborted");
+    }
+    const end = Math.min(start + chunkSize, total);
+    const chunk = file.slice(start, end);
+    const response = await fetch(sessionUrl, {
+      method: "PUT",
+      headers: {
+        "Content-Range": `bytes ${start}-${end - 1}/${total}`,
+      },
+      body: chunk,
+      signal: opts.signal,
+    });
+
+    if (response.status === 200 || response.status === 201) {
+      opts.onProgress?.(total, total);
+      return;
+    }
+    if (response.status === 308) {
+      const rangeHeader = response.headers.get("Range");
+      if (rangeHeader) {
+        // GCS returns "bytes=0-N" — last byte received
+        const match = rangeHeader.match(/bytes=\d+-(\d+)/);
+        if (match) {
+          const lastByte = parseInt(match[1], 10);
+          start = lastByte + 1;
+          opts.onProgress?.(start, total);
+          continue;
+        }
+      }
+      // No Range header: assume the full chunk we just sent landed
+      start = end;
+      opts.onProgress?.(start, total);
+      continue;
+    }
+    throw new Error(
+      `Resumable upload failed: ${response.status} ${response.statusText}`,
+    );
+  }
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1532,6 +1532,36 @@ export interface ReferenceUploadInitResponse {
   uploads: ReferenceUploadSlot[];
 }
 
+export interface ReferenceImportRequest {
+  name: string;
+  category: string;
+  scope: string;
+  version: string;
+  source_url: string;
+  source_md5_url?: string;
+  auth_header?: string;
+  extract: "none" | "gzip" | "tar" | "tar.gz";
+  expected_files?: string[];
+  description?: string;
+}
+
+export interface ReferenceImportStartResponse {
+  reference_id: number;
+  import_job_id: string;
+  status: string;
+}
+
+export interface ReferenceImportStatusResponse {
+  reference_id: number;
+  status: string;
+  progress_pct: number | null;
+  bytes_downloaded: number | null;
+  total_bytes: number | null;
+  error_message: string | null;
+  import_job_id: string | null;
+  updated_at: string | null;
+}
+
 export interface GeoValidationField {
   geo_column: string;
   status: "complete" | "populated_unvalidated" | "missing_required" | "missing_recommended";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -813,7 +813,15 @@ export interface PipelineAddRequest {
 // Custom Pipelines
 
 export type CustomPipelineCodeSource = "github_repo" | "code_blob" | "inline";
-export type CustomPipelineVariableType = "string" | "number" | "boolean";
+export type CustomPipelineVariableType = "string" | "number" | "boolean" | "reference";
+export type ReferenceParameterCategory =
+  | "genome"
+  | "annotation"
+  | "index"
+  | "atlas"
+  | "markers"
+  | "other"
+  | "any";
 export type CustomPipelineVersionStatus = "active" | "deprecated";
 export type CustomPipelineVersionTrigger = "user" | "environment_cascade";
 
@@ -822,6 +830,7 @@ export interface CustomPipelineVariable {
   variable_name: string;
   default_value: string | null;
   variable_type: CustomPipelineVariableType;
+  reference_category?: ReferenceParameterCategory | null;
   is_required: boolean;
 }
 
@@ -829,6 +838,7 @@ export interface CustomPipelineVariableDefinition {
   variable_name: string;
   default_value: string | null;
   variable_type: CustomPipelineVariableType;
+  reference_category?: ReferenceParameterCategory | null;
   is_required: boolean;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1503,6 +1503,35 @@ export interface ImpactSummary {
   pipeline_runs: ImpactPipelineRun[];
 }
 
+export interface ReferenceUploadFileSpec {
+  filename: string;
+  size_bytes: number;
+  content_type?: string;
+  md5_checksum?: string;
+}
+
+export interface ReferenceUploadInitRequest {
+  name: string;
+  category: string;
+  scope: string;
+  version: string;
+  source_url?: string;
+  description?: string;
+  files: ReferenceUploadFileSpec[];
+}
+
+export interface ReferenceUploadSlot {
+  filename: string;
+  session_url: string;
+  expires_at: string;
+}
+
+export interface ReferenceUploadInitResponse {
+  reference_id: number;
+  gcs_prefix: string;
+  uploads: ReferenceUploadSlot[];
+}
+
 export interface GeoValidationField {
   geo_column: string;
   status: "complete" | "populated_unvalidated" | "missing_required" | "missing_recommended";

--- a/frontend/tests/pages/pipeline-runs.test.tsx
+++ b/frontend/tests/pages/pipeline-runs.test.tsx
@@ -95,6 +95,50 @@ const mockRunWithK8s = {
   samples: [],
 };
 
+describe("Pipeline Run Detail - References Used", () => {
+  test("renders linked references with name, version, and category", async () => {
+    const refs = [
+      {
+        id: 7,
+        organization_id: 1,
+        name: "GRCh38 GENCODE",
+        category: "genome",
+        scope: "public",
+        version: "v45",
+        source_url: null,
+        gcs_prefix: "genome/grch38-gencode/v45/",
+        total_size_bytes: null,
+        file_count: 2,
+        status: "active",
+        deprecation_note: null,
+        superseded_by_id: null,
+        created_at: "2026-05-01T00:00:00Z",
+      },
+    ];
+    mockApiGet.mockImplementation((url: string) => {
+      if (url.includes("/api/pipeline-runs/42/references")) {
+        return Promise.resolve(refs);
+      }
+      return Promise.resolve(mockRunWithK8s);
+    });
+
+    const PipelineRunDetailPage =
+      require("@/app/pipelines/runs/[id]/page").default;
+    render(<PipelineRunDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("References Used")).toBeInTheDocument();
+    });
+    expect(screen.getByText("GRCh38 GENCODE")).toBeInTheDocument();
+    expect(screen.getByText("v45")).toBeInTheDocument();
+    // Category column rendered (capitalized via CSS, raw "genome" in DOM)
+    expect(screen.getByText("genome")).toBeInTheDocument();
+    // Name links to detail page
+    const link = screen.getByRole("link", { name: "GRCh38 GENCODE" });
+    expect(link).toHaveAttribute("href", "/data/references/7");
+  });
+});
+
 describe("Pipeline Run Detail - K8s Fields (Test 28)", () => {
   test("shows k8s_job_name when present", async () => {
     // Mock API calls


### PR DESCRIPTION
## Summary

Implements [spec-reference-data-ingest.md](documentation/spec-reference-data-ingest.md) end-to-end (ADR-017 / ADR-047). The reference-dataset registry already existed; this PR adds everything around getting bytes into it and using them in pipelines.

- **Upload flow** — drag-drop multi-file page at `/data/references/new`. Bytes go directly to GCS via resumable session URLs; 8 MiB chunks default, 64 MiB for files > 1 GiB; uploads survive page reloads via the 308-Range resume protocol
- **Import-from-URL flow** — page at `/data/references/import` launches a per-import GKE Job that streams a public URL (GENCODE, 10x, ...) into GCS with `none`/`gzip`/`tar`/`tar.gz` extraction. Status polled every 5s
- **Versioning UX** — Versions tab on the detail page lists every `(name, category)` sibling; "Upload new version" button pre-fills locked name + category + scope
- **Reference parameter type** — custom pipelines can declare `variable_type='reference'` with a `reference_category`; launch-time renders a searchable dropdown that stores the dataset's `/data/references/{prefix}` path so the existing auto-linker picks it up unchanged
- **Run detail** — the References Used table gains a Category column and a link back to each reference

### New endpoints

`POST /api/references/upload-init`, `POST /{id}/upload-complete`, `POST /{id}/abort`, `POST /api/references/import`, `GET /{id}/import-status`, `POST /{id}/import-cancel`, `GET /api/references/by-name?name=&category=`, `POST /api/internal/references/{id}/import-progress` (X-Internal-Token auth).

### Roles & DB (additive only)

- New `references` resource with `view`/`upload` actions; migration 071 backfills existing system roles (admin/comp_bio: both; bench/viewer: view)
- Migration 072: `reference_import_progress` table
- Migration 073: `custom_pipeline_variables.reference_category` column
- `REFERENCE_STATUSES` extended with `uploading` and `failed`

### Infrastructure

Terraform `storage` module gains a `bioaf-references-{org}-{stack}` GCS bucket (versioning + CORS for browser PUT/POST); the storage stack-deploy hook plants its name in `platform_config` as `references_bucket_name`. New env var `BIOAF_INTERNAL_TOKEN` for the importer-callback secret.

### Caveats

- Importer container image (`bioaf-reference-importer:latest`) is referenced from `_create_import_job` but the actual container code/Dockerfile is a separate deliverable
- New notification event types (spec §6) not added; existing `REFERENCE_DEPRECATED` is reused
- `BIOAF_INTERNAL_TOKEN` has no production wiring yet; deploy scripts will need to plant a rotated secret before the importer can call back

## Test plan

- [x] Backend: `pytest tests/test_reference*.py tests/test_custom_pipeline_reference_param.py` — 77 tests passing
- [x] Frontend: `jest src/lib/resumableUpload.test.ts src/app/data/references/ src/components/references/ tests/pages/pipeline-runs.test.tsx` — 22 tests passing
- [x] `ruff format --check`, `ruff check`, `mypy --ignore-missing-imports` — all clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — succeeds (Suspense boundary added around useSearchParams on /data/references/new)
- [ ] Apply migrations 071–073 against staging and verify backfill seeds `references:*` permissions correctly
- [ ] Deploy storage terraform; confirm `references_bucket_name` lands in `platform_config`
- [ ] Smoke: upload a small (10 MB) reference through the UI; cancel mid-upload; resume; finalize; launch a custom pipeline that uses a `reference` parameter and confirm the auto-linker creates the `pipeline_run_references` row
- [ ] Smoke: import GENCODE v45 GTF (~50 MB gz) via /import once the importer container image is published