### PR TITLE
v0.11.2: env picker fixes, default env seeders, work-node Packer SSD quota

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,94 @@
 # Release Notes
 
+## v0.11.2
+
+Bug-fix point release covering the environment-management gaps and a
+work-node Packer-build quota issue surfaced while testing v0.11.1
+end-to-end on a fresh greenfield install. No schema changes; no
+migration required. The bioaf-base work-node seed is gated by
+`BIOAF_BASE_WORK_NODE_IMAGE_URI` and is a no-op until the public
+image is published, so existing installs are unaffected.
+
+### Environment pickers correctly filter by type
+
+The Notebooks page and the Workbench Environments "All" filter both
+showed environments of the wrong type -- pipeline envs leaked into
+notebook pickers and into the workbench list, where they could not
+actually be selected. Tracked as to-resolve.md issue #2.
+
+- `notebooks/page.tsx` now requests `/api/v1/environments?type=notebook`.
+- The Workbench Environments "All" filter fetches `notebook` and
+  `work_node` lists separately and merges them; pipeline envs are
+  excluded.
+
+### Default environments seeded at bootstrap
+
+Two related gaps blocked first-time users from launching anything
+without manual env creation:
+
+- A default notebook env seeder was missing alongside the existing
+  pipeline / work_node seeders; the notebooks picker came up empty.
+  Added `ensure_default_notebook_environment` mirroring the pipeline
+  seeder.
+- Seeders only ran from the lifespan startup hook, which skips when
+  org / admin do not yet exist. On a fresh install the user
+  completes bootstrap *after* startup, so the seeders never took
+  effect until the next backend restart. All three seeders now also
+  run from the `create_admin` bootstrap endpoint (idempotent).
+
+### Built-in `bioaf-base` work-node environment (opt-in)
+
+Resolves to-resolve.md issue #1 (backend portion). When
+`BIOAF_BASE_WORK_NODE_IMAGE_URI` is set, the backend seeds a
+system-managed `bioaf-base` work-node env whose single version is
+`status=ready` with `image_uri` pre-populated -- so first-launch is
+instant and users no longer have to wait through a ~10-15 min Packer
+build before they can pick anything from the work-node environment
+dropdown. If the env var is unset, the seed is a no-op and the
+existing draft fallback still runs (backward-compatible).
+
+The published Artifact Registry / GCE image itself is not yet built;
+once available, set `BIOAF_BASE_WORK_NODE_IMAGE_URI` in the deploy
+config to surface the seeded env.
+
+### Build trigger UX
+
+- The "build environment" trigger on `/environments` and
+  `/pipelines/environments` no longer uses the bare browser
+  `confirm()` dialog (which renders with the host IP in the title
+  bar and leaks "Cloud Build" terminology users do not recognize).
+  Replaced with the existing `ConfirmDialog` modal; copy now
+  explains the build runs in the background and the user can keep
+  using the app.
+- The build trigger endpoint previously caught only `ValueError`,
+  so any other failure (GCP API, credentials, packer step) bubbled
+  up as a bare 500 with no JSON body and the frontend rendered a
+  meaningless "Unknown error" alert. Now catches broad `Exception`,
+  logs the stack server-side, and returns a 500 whose detail is the
+  underlying error message so the user sees something actionable.
+
+### Work-node Packer build no longer eats SSD quota
+
+The Packer build VM (transient, runs once per work-node image
+build) used `pd-ssd` for its 50 GB boot disk. That 50 GB counts
+against the regional `SSD_TOTAL_GB` quota -- already pressured by
+the GKE pool nodes' `pd-balanced` boot disks (which also count
+toward SSD quota). On a fresh GCP project (default 250 GB
+ceiling), one running pipeline pool plus the bioaf control VM
+consume ~230 GB; the build's +50 GB tipped past 250 and failed
+immediately with `Quota 'SSD_TOTAL_GB' exceeded`.
+
+Switched to `pd-standard` for the build disk -- HDD vs SSD makes
+no material difference for a one-off conda env install, and the
+image artifact uploaded to GCE Image Service still works for
+`pd-ssd` work-node boot disks at launch. A regression test
+(`test_packer_template_disk.py`) guards `disk_type` and
+`disk_size` so future drift trips a clear failure message.
+
+This is a tactical mitigation; the proper fix (auto-request an
+`SSD_TOTAL_GB` quota bump alongside the CPU bump) is tracked in
+to-resolve.md issue #3.
+
 ## v0.11.1
 
 Bug-fix point release for the v0.11.0 SA hardening work. Resolves the

--- a/backend/app/api/bootstrap.py
+++ b/backend/app/api/bootstrap.py
@@ -173,6 +173,23 @@ async def create_admin(body: CreateAdminRequest, request: Request, session: Asyn
     # Initialize component states
     await ComponentService.initialize_states(session)
 
+    # Seed default environments now that org + admin exist.  These are
+    # idempotent and run on each backend startup as well, but invoking
+    # them here means the user lands on a fully populated picker on
+    # first install without waiting for a restart.
+    from app.services.environment_service import (
+        ensure_default_notebook_environment,
+        ensure_default_pipeline_environment,
+        ensure_default_work_node_environment,
+    )
+
+    try:
+        await ensure_default_work_node_environment(session)
+        await ensure_default_pipeline_environment(session)
+        await ensure_default_notebook_environment(session)
+    except Exception as e:
+        logger.warning("Default environment seed during bootstrap failed: %s", e)
+
     await session.commit()
 
     # Issue JWT token

--- a/backend/app/api/environments.py
+++ b/backend/app/api/environments.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,6 +18,8 @@ from app.schemas.environment import (
     VersionResponse,
 )
 from app.services.environment_service import EnvironmentService
+
+logger = logging.getLogger("bioaf.environments.api")
 
 router = APIRouter(prefix="/api/v1/environments", tags=["environments"])
 
@@ -253,6 +257,14 @@ async def trigger_build(
         await session.commit()
     except ValueError as e:
         raise HTTPException(400, str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        # Surface the real error to the client instead of letting it
+        # bubble up as a bare 500 (which the frontend renders as
+        # "Unknown error"). Log full stack server-side for debugging.
+        logger.exception("Build trigger failed for env=%d version=%d", environment_id, version_id)
+        raise HTTPException(500, f"Build failed to start: {e}")
 
     version = await EnvironmentService.get_version(session, org_id, environment_id, version_id)
     if not version:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -181,6 +181,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Default work node environment seed failed: %s", e)
 
+    # Seed built-in `bioaf-base` work-node env (to-resolve.md issue #1).
+    # No-op if BIOAF_BASE_WORK_NODE_IMAGE_URI is unset.
+    from app.services.bootstrap_environments import seed_builtin_environments
+
+    try:
+        async with notif_session_factory() as builtin_env_session:
+            await seed_builtin_environments(builtin_env_session)
+            await builtin_env_session.commit()
+    except Exception as e:
+        logger.warning("Built-in environment seed failed: %s", e)
+
     # Seed default pipeline environment if none exists (ADR-045)
     from app.services.environment_service import ensure_default_pipeline_environment
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -202,6 +202,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Default pipeline environment seed failed: %s", e)
 
+    # Seed default notebook environment if none exists
+    from app.services.environment_service import ensure_default_notebook_environment
+
+    try:
+        async with notif_session_factory() as nb_seed_session:
+            await ensure_default_notebook_environment(nb_seed_session)
+            await nb_seed_session.commit()
+    except Exception as e:
+        logger.warning("Default notebook environment seed failed: %s", e)
+
     # Resolve any pending upgrades from before the restart
     from app.services.upgrade_service import UpgradeService
 

--- a/backend/app/services/bootstrap_environments.py
+++ b/backend/app/services/bootstrap_environments.py
@@ -1,0 +1,131 @@
+"""Seed built-in environments at startup.
+
+Mirrors the pattern in `bootstrap_roles.seed_builtin_roles`: registers
+system-managed environments that ship with every install so users
+have something to pick on first launch.
+
+Currently seeds:
+- `bioaf-base` (work_node) -- points at a pre-published GCE image so
+  first-launch is instant. The image is published out-of-band; this
+  seeder only registers the metadata.
+"""
+
+import logging
+import os
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.environment import Environment
+from app.models.environment_version import EnvironmentVersion
+
+logger = logging.getLogger("bioaf.bootstrap_environments")
+
+BIOAF_BASE_NAME = "bioaf-base"
+BIOAF_BASE_DESCRIPTION = (
+    "Built-in base work-node environment. Python 3.11 with common "
+    "scientific packages and Cloud SDK. Ships pre-built so first launch "
+    "is instant -- no Packer build needed. Customize by creating a new "
+    "environment on top."
+)
+
+# Conda environment.yml that the published image is built from. Stored
+# as `definition_content` for transparency / auditability; the version
+# is marked `ready` with `image_uri` populated, so no per-install build
+# runs against this content.
+BIOAF_BASE_CONDA_YML = """\
+name: bioaf-base
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.11
+  - numpy
+  - pandas
+  - matplotlib
+  - jupyter
+  - ipykernel
+  - pip
+  - pip:
+      - google-cloud-storage
+"""
+
+
+def _get_base_image_uri() -> str | None:
+    """Return the pre-published bioaf-base image URI, or None if unset."""
+    uri = os.environ.get("BIOAF_BASE_WORK_NODE_IMAGE_URI")
+    return uri.strip() if uri and uri.strip() else None
+
+
+async def seed_builtin_environments(session: AsyncSession) -> None:
+    """Register `bioaf-base` for the org if a published image is configured.
+
+    No-op if `BIOAF_BASE_WORK_NODE_IMAGE_URI` is not set: better to fall
+    back to the existing `ensure_default_work_node_environment` draft
+    flow than to register an env whose `image_uri` points at nothing.
+    """
+    image_uri = _get_base_image_uri()
+    if not image_uri:
+        logger.info("BIOAF_BASE_WORK_NODE_IMAGE_URI not set; skipping bioaf-base seed")
+        return
+
+    org_row = (await session.execute(text("SELECT id FROM organizations LIMIT 1"))).fetchone()
+    if not org_row:
+        return
+    org_id = org_row[0]
+
+    existing = (
+        await session.execute(
+            select(Environment).where(
+                Environment.organization_id == org_id,
+                Environment.name == BIOAF_BASE_NAME,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return
+
+    admin_row = (
+        await session.execute(
+            text(
+                "SELECT u.id FROM users u "
+                "JOIN roles r ON u.role_id = r.id "
+                "WHERE u.organization_id = :org_id AND r.name = 'admin' "
+                "ORDER BY u.id LIMIT 1"
+            ).bindparams(org_id=org_id)
+        )
+    ).fetchone()
+    if not admin_row:
+        return
+    user_id = admin_row[0]
+
+    env = Environment(
+        name=BIOAF_BASE_NAME,
+        description=BIOAF_BASE_DESCRIPTION,
+        organization_id=org_id,
+        created_by_user_id=user_id,
+        visibility="organization",
+        environment_type="work_node",
+    )
+    session.add(env)
+    await session.flush()
+
+    version = EnvironmentVersion(
+        environment_id=env.id,
+        version_number=1,
+        build_number=1,
+        status="ready",
+        definition_format="conda",
+        definition_content=BIOAF_BASE_CONDA_YML,
+        image_uri=image_uri,
+        created_by_user_id=user_id,
+    )
+    session.add(version)
+    await session.flush()
+
+    logger.info(
+        "Seeded built-in environment '%s' (id=%d) -> %s",
+        env.name,
+        env.id,
+        image_uri,
+    )

--- a/backend/app/services/environment_build_service.py
+++ b/backend/app/services/environment_build_service.py
@@ -78,8 +78,15 @@ source "googlecompute" "work_node" {
     bioaf-managed = "true"
   }
 
+  # The build VM is transient (Packer creates it, runs the provisioner,
+  # destroys it). Use pd-standard so the 50 GB does not consume the
+  # regional SSD_TOTAL_GB quota -- which is already under pressure from
+  # the GKE pool nodes' pd-balanced boot disks (those count toward
+  # SSD_TOTAL_GB too). The image artifact uploaded to GCE Image Service
+  # is unaffected and still works for pd-ssd work-node boot disks at
+  # launch time. See documentation/to-resolve.md for the quota story.
   disk_size = 50
-  disk_type = "pd-ssd"
+  disk_type = "pd-standard"
 
   ssh_username = "packer"
 }

--- a/backend/app/services/environment_service.py
+++ b/backend/app/services/environment_service.py
@@ -50,6 +50,26 @@ dependencies:
   - pip
 """
 
+# Default conda environment.yml for notebook environments.  Practical
+# starting point for Jupyter/RStudio sessions; user can extend.
+DEFAULT_NOTEBOOK_CONDA_YML = """\
+name: bioaf-notebook
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.11
+  - numpy
+  - pandas
+  - scipy
+  - matplotlib
+  - seaborn
+  - jupyter
+  - ipykernel
+  - scikit-learn
+  - pip
+"""
+
 
 class EnvironmentService:
     @staticmethod
@@ -466,3 +486,69 @@ async def ensure_default_pipeline_environment(session: AsyncSession) -> None:
     await session.flush()
 
     logger.info("Created default pipeline environment '%s' (id=%d)", env.name, env.id)
+
+
+async def ensure_default_notebook_environment(session: AsyncSession) -> None:
+    """Create a default notebook environment if none exists yet.
+
+    Mirrors the work_node and pipeline seeders so notebook users land
+    on a pre-populated template instead of an empty picker.  The
+    version is created in 'draft' status -- the user must trigger a
+    build before it can be used.
+    """
+    row = (await session.execute(text("SELECT id FROM organizations LIMIT 1"))).fetchone()
+    if not row:
+        return
+    org_id = row[0]
+
+    existing = (
+        await session.execute(
+            text(
+                "SELECT id FROM environments WHERE organization_id = :org_id AND environment_type = 'notebook' LIMIT 1"
+            ).bindparams(org_id=org_id)
+        )
+    ).fetchone()
+    if existing:
+        return
+
+    admin_row = (
+        await session.execute(
+            text(
+                "SELECT u.id FROM users u "
+                "JOIN roles r ON u.role_id = r.id "
+                "WHERE u.organization_id = :org_id AND r.name = 'admin' "
+                "ORDER BY u.id LIMIT 1"
+            ).bindparams(org_id=org_id)
+        )
+    ).fetchone()
+    if not admin_row:
+        return
+    user_id = admin_row[0]
+
+    env = Environment(
+        name="Default Notebook",
+        description=(
+            "Base Python environment for notebook sessions. Build this "
+            "environment, then customize with your own packages."
+        ),
+        organization_id=org_id,
+        created_by_user_id=user_id,
+        visibility="organization",
+        environment_type="notebook",
+    )
+    session.add(env)
+    await session.flush()
+
+    version = EnvironmentVersion(
+        environment_id=env.id,
+        version_number=1,
+        build_number=1,
+        status="draft",
+        definition_format="conda",
+        definition_content=DEFAULT_NOTEBOOK_CONDA_YML,
+        created_by_user_id=user_id,
+    )
+    session.add(version)
+    await session.flush()
+
+    logger.info("Created default notebook environment '%s' (id=%d)", env.name, env.id)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.11.1"
+version = "0.11.2"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_bootstrap_environments.py
+++ b/backend/tests/test_bootstrap_environments.py
@@ -1,0 +1,112 @@
+"""Tests for the built-in environment seeder (to-resolve issue #1).
+
+The seeder ships a system-managed `bioaf-base` work-node environment
+that points at a pre-published image so first-launch is instant -- the
+user does not have to wait for a per-install Packer build.
+"""
+
+import os
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import select
+
+from app.models.environment import Environment
+from app.models.environment_version import EnvironmentVersion
+
+
+PUBLIC_IMAGE_URI = "projects/bioaf-public-images/global/images/bioaf-base-v1"
+
+
+@contextmanager
+def base_image_env(uri: str | None):
+    """Context manager that sets / unsets BIOAF_BASE_WORK_NODE_IMAGE_URI."""
+    prev = os.environ.get("BIOAF_BASE_WORK_NODE_IMAGE_URI")
+    if uri is None:
+        os.environ.pop("BIOAF_BASE_WORK_NODE_IMAGE_URI", None)
+    else:
+        os.environ["BIOAF_BASE_WORK_NODE_IMAGE_URI"] = uri
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("BIOAF_BASE_WORK_NODE_IMAGE_URI", None)
+        else:
+            os.environ["BIOAF_BASE_WORK_NODE_IMAGE_URI"] = prev
+
+
+@pytest.mark.asyncio
+async def test_seed_builtin_environments_creates_bioaf_base(session, admin_user):
+    """When the public image URI is configured, the seeder registers
+    `bioaf-base` as a ready work-node env pointing at that image."""
+    from app.services.bootstrap_environments import seed_builtin_environments
+
+    with base_image_env(PUBLIC_IMAGE_URI):
+        await seed_builtin_environments(session)
+        await session.commit()
+
+    result = await session.execute(
+        select(Environment).where(
+            Environment.organization_id == admin_user.organization_id,
+            Environment.name == "bioaf-base",
+        )
+    )
+    env = result.scalar_one_or_none()
+    assert env is not None, "bioaf-base environment should be seeded"
+    assert env.environment_type == "work_node"
+    assert env.visibility == "organization"
+
+    versions_result = await session.execute(
+        select(EnvironmentVersion).where(EnvironmentVersion.environment_id == env.id)
+    )
+    versions = list(versions_result.scalars().all())
+    assert len(versions) == 1, "bioaf-base should have exactly one version"
+    v = versions[0]
+    assert v.status == "ready", "bioaf-base version must be ready (no user build needed)"
+    assert v.image_uri == PUBLIC_IMAGE_URI
+    assert v.definition_format == "conda"
+
+
+@pytest.mark.asyncio
+async def test_seed_builtin_environments_is_idempotent(session, admin_user):
+    """Running the seeder twice does not create duplicate envs / versions."""
+    from app.services.bootstrap_environments import seed_builtin_environments
+
+    with base_image_env(PUBLIC_IMAGE_URI):
+        await seed_builtin_environments(session)
+        await seed_builtin_environments(session)
+        await session.commit()
+
+    envs_result = await session.execute(
+        select(Environment).where(
+            Environment.organization_id == admin_user.organization_id,
+            Environment.name == "bioaf-base",
+        )
+    )
+    envs = list(envs_result.scalars().all())
+    assert len(envs) == 1
+
+    versions_result = await session.execute(
+        select(EnvironmentVersion).where(EnvironmentVersion.environment_id == envs[0].id)
+    )
+    versions = list(versions_result.scalars().all())
+    assert len(versions) == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_builtin_environments_skips_when_image_unset(session, admin_user):
+    """Without a configured public image URI, the seeder is a no-op (it
+    does not create a half-broken env that points at nothing)."""
+    from app.services.bootstrap_environments import seed_builtin_environments
+
+    with base_image_env(None):
+        await seed_builtin_environments(session)
+        await session.commit()
+
+    result = await session.execute(
+        select(Environment).where(
+            Environment.organization_id == admin_user.organization_id,
+            Environment.name == "bioaf-base",
+        )
+    )
+    assert result.scalar_one_or_none() is None

--- a/backend/tests/test_environments.py
+++ b/backend/tests/test_environments.py
@@ -543,6 +543,49 @@ async def test_build_logs_endpoint(client, admin_token):
     assert data["build_id"] is None
 
 
+# --- Build error surfacing tests ---
+
+
+@pytest.mark.asyncio
+async def test_trigger_build_surfaces_real_error_message(monkeypatch, client, admin_token):
+    """When the build pipeline raises a non-ValueError (e.g. GCP API
+    failure), the endpoint should return a structured error with a
+    useful message instead of bubbling up as a 500 with no body --
+    which the frontend renders as a meaningless "Unknown error"."""
+    from app.services import environment_build_service
+
+    create_resp = await client.post(
+        "/api/v1/environments",
+        json={"name": "fail-build-env", "environment_type": "work_node"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    env_id = create_resp.json()["id"]
+
+    ver_resp = await client.post(
+        f"/api/v1/environments/{env_id}/versions",
+        json={"definition_format": "conda", "definition_content": "name: x\ndependencies: []\n"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    ver_id = ver_resp.json()["id"]
+
+    async def explode(*args, **kwargs):
+        raise RuntimeError("packer step failed: permission denied on bucket")
+
+    monkeypatch.setattr(environment_build_service.EnvironmentBuildService, "build_version", explode)
+
+    response = await client.post(
+        f"/api/v1/environments/{env_id}/versions/{ver_id}/build",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 500
+    body = response.json()
+    detail = body.get("detail", "")
+    assert "packer step failed" in detail or "permission denied" in detail, (
+        f"Build endpoint should surface the underlying error message, got: {body!r}"
+    )
+
+
 # --- Default-environment seeder tests ---
 
 

--- a/backend/tests/test_environments.py
+++ b/backend/tests/test_environments.py
@@ -541,3 +541,61 @@ async def test_build_logs_endpoint(client, admin_token):
     data = response.json()
     assert data["status"] == "draft"
     assert data["build_id"] is None
+
+
+# --- Default-environment seeder tests ---
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_notebook_environment_seeds(session, admin_user):
+    """Seeder creates a draft notebook environment when none exists."""
+    from sqlalchemy import select
+
+    from app.models.environment import Environment
+    from app.models.environment_version import EnvironmentVersion
+    from app.services.environment_service import ensure_default_notebook_environment
+
+    await ensure_default_notebook_environment(session)
+    await session.commit()
+
+    result = await session.execute(
+        select(Environment).where(
+            Environment.organization_id == admin_user.organization_id,
+            Environment.environment_type == "notebook",
+        )
+    )
+    envs = list(result.scalars().all())
+    assert len(envs) == 1, "exactly one default notebook env should be seeded"
+    env = envs[0]
+    assert env.visibility == "organization"
+
+    versions = list(
+        (await session.execute(select(EnvironmentVersion).where(EnvironmentVersion.environment_id == env.id))).scalars()
+    )
+    assert len(versions) == 1
+    v = versions[0]
+    assert v.status == "draft"
+    assert v.definition_format == "conda"
+    assert "python=3.11" in v.definition_content
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_notebook_environment_idempotent(session, admin_user):
+    """Running the notebook seeder twice does not create duplicates."""
+    from sqlalchemy import select
+
+    from app.models.environment import Environment
+    from app.services.environment_service import ensure_default_notebook_environment
+
+    await ensure_default_notebook_environment(session)
+    await ensure_default_notebook_environment(session)
+    await session.commit()
+
+    result = await session.execute(
+        select(Environment).where(
+            Environment.organization_id == admin_user.organization_id,
+            Environment.environment_type == "notebook",
+        )
+    )
+    envs = list(result.scalars().all())
+    assert len(envs) == 1

--- a/backend/tests/test_packer_template_disk.py
+++ b/backend/tests/test_packer_template_disk.py
@@ -1,0 +1,43 @@
+"""Guards on the work-node Packer template's disk config (to-resolve).
+
+The build VM is transient -- Packer creates it, runs the provisioner,
+destroys it. We deliberately use `pd-standard` (HDD) for the build
+disk so the 50 GB does not consume `SSD_TOTAL_GB` regional quota,
+which is already pressured by the GKE pool nodes' pd-balanced boot
+disks (those count toward SSD_TOTAL_GB too).
+
+The image artifact is uploaded to GCE Image Service and remains
+usable for pd-ssd work-node boot disks at launch time -- only the
+*build* VM uses pd-standard.
+"""
+
+import re
+
+from app.services.environment_build_service import PACKER_VM_TEMPLATE
+
+
+def test_packer_build_disk_uses_pd_standard_not_pd_ssd():
+    """The Packer build VM must use pd-standard so its 50 GB does not
+    eat into the regional SSD_TOTAL_GB quota (which the GKE pool nodes
+    already pressure)."""
+    match = re.search(r'disk_type\s*=\s*"(pd-[a-z]+)"', PACKER_VM_TEMPLATE)
+    assert match, "PACKER_VM_TEMPLATE must declare disk_type"
+    assert match.group(1) == "pd-standard", (
+        f"Packer build disk should be pd-standard (HDD, free quota), "
+        f"got {match.group(1)!r}. pd-ssd and pd-balanced both count "
+        f"against SSD_TOTAL_GB, which is what we are explicitly trying "
+        f"to avoid for the transient build VM."
+    )
+
+
+def test_packer_build_disk_size_is_50gb():
+    """Sanity check the build VM disk size has not drifted; 50 GB is
+    the documented value sized for Ubuntu base + miniforge + a typical
+    conda environment.yml install."""
+    match = re.search(r"disk_size\s*=\s*(\d+)", PACKER_VM_TEMPLATE)
+    assert match, "PACKER_VM_TEMPLATE must declare disk_size"
+    assert match.group(1) == "50", (
+        f"Expected 50 GB build disk, got {match.group(1)!r}. If a "
+        f"larger size is genuinely required, update the test and the "
+        f"to-resolve.md status notes."
+    )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "bioaf-backend"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -160,17 +160,21 @@ wheels = [
 
 [[package]]
 name = "bioaf-backend"
-version = "0.1.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "fastapi" },
+    { name = "google-cloud-iam" },
     { name = "google-cloud-secret-manager" },
+    { name = "h5py" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pymupdf" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -184,10 +188,14 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "bcrypt", specifier = ">=4.1" },
     { name = "fastapi", specifier = ">=0.110" },
+    { name = "google-cloud-iam", specifier = ">=2.14" },
     { name = "google-cloud-secret-manager", specifier = ">=2.18" },
+    { name = "h5py", specifier = ">=3.10" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pydantic-settings", specifier = ">=2.1" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
+    { name = "pymupdf", specifier = ">=1.24" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -457,6 +465,23 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-iam"
+version = "2.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/e5/07d4f1daf85a2a0bd9f78ad865ea678d7b4e1227ed76f671c7167aae147f/google_cloud_iam-2.22.0.tar.gz", hash = "sha256:203ddfece17e014ee4fbc5c3244daa14a88b7ee57c8e3a7622d0f2a1a3b8d7f3", size = 502498, upload-time = "2026-03-30T22:51:28.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/a8/d721ea11d0eb93803d14cb2e90d0442bb3b269a82f7cb5faff2b98022039/google_cloud_iam-2.22.0-py3-none-any.whl", hash = "sha256:c443b34b5a6a9e51d32cee397879bb781b900af68937c67a275def23bbc025f3", size = 463425, upload-time = "2026-03-30T20:02:42.967Z" },
+]
+
+[[package]]
 name = "google-cloud-secret-manager"
 version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -612,6 +637,49 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3c/7fcd9b4c9eed82e91fb15568992561019ae7a829d1f696b2c844355d95dd/h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65", size = 3678608, upload-time = "2026-03-06T13:48:35.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b7/9366ed44ced9b7ef357ab48c94205280276db9d7f064aa3012a97227e966/h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210", size = 3054773, upload-time = "2026-03-06T13:48:37.139Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/4964bc0e91e86340c2bbda83420225b2f770dcf1eb8a39464871ad769436/h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965", size = 5198886, upload-time = "2026-03-06T13:48:38.879Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/16/d905e7f53e661ce2c24686c38048d8e2b750ffc4350009d41c4e6c6c9826/h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd", size = 5404883, upload-time = "2026-03-06T13:48:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f2/58f34cb74af46d39f4cd18ea20909a8514960c5a3e5b92fd06a28161e0a8/h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c", size = 5192039, upload-time = "2026-03-06T13:48:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ca/934a39c24ce2e2db017268c08da0537c20fa0be7e1549be3e977313fc8f5/h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc", size = 5421526, upload-time = "2026-03-06T13:48:44.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/14/615a450205e1b56d16c6783f5ccd116cde05550faad70ae077c955654a75/h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab", size = 3183263, upload-time = "2026-03-06T13:48:47.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/a6faef5ed632cae0c65ac6b214a6614a0b510c3183532c521bdb0055e117/h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63", size = 2663450, upload-time = "2026-03-06T13:48:48.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/0c8bb8aedb62c772cf7c1d427c7d1951477e8c2835f872bc0a13d1f85f86/h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491", size = 3760693, upload-time = "2026-03-06T13:48:50.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/fcc5977d32d6387c5c9a694afee716a5e20658ac08b3ff24fdec79fb05f2/h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618", size = 3181305, upload-time = "2026-03-06T13:48:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/af87f64b9f986889884243643621ebbd4ac72472ba8ec8cec891ac8e2ca1/h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242", size = 5074061, upload-time = "2026-03-06T13:48:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d0/146f5eaff3dc246a9c7f6e5e4f42bd45cc613bce16693bcd4d1f7c958bf5/h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16", size = 5279216, upload-time = "2026-03-06T13:48:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/12a13424f1e604fc7df9497b73c0356fb78c2fb206abd7465ce47226e8fd/h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7", size = 5070068, upload-time = "2026-03-06T13:48:59.169Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -750,6 +818,67 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
 ]
 
 [[package]]
@@ -907,6 +1036,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618, upload-time = "2026-04-24T14:13:14.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636, upload-time = "2026-04-24T14:09:17.459Z" },
+    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238, upload-time = "2026-04-24T14:09:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923, upload-time = "2026-04-24T14:09:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198, upload-time = "2026-04-24T14:10:07.408Z" },
+    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609, upload-time = "2026-04-24T14:10:22.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286, upload-time = "2026-04-24T14:10:34.239Z" },
+    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102, upload-time = "2026-04-24T14:10:46.72Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393, upload-time = "2026-04-24T14:11:01.669Z" },
 ]
 
 [[package]]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/environments/page.test.tsx
+++ b/frontend/src/app/environments/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen, fireEvent } from "@testing-library/react";
 import EnvironmentsPage from "./page";
 
 jest.mock("next/navigation", () => ({
@@ -47,5 +47,80 @@ describe("Workbench EnvironmentsPage filter", () => {
     expect(mockGet).toHaveBeenCalledWith(
       expect.stringMatching(/^\/api\/v1\/environments\?type=work_node$/)
     );
+  });
+});
+
+describe("Workbench EnvironmentsPage build confirmation", () => {
+  const envSummary = {
+    id: 1,
+    name: "Default Notebook",
+    description: null,
+    visibility: "organization",
+    environment_type: "notebook",
+    version_count: 1,
+    latest_version: {
+      id: 10,
+      version_number: 1,
+      build_number: 1,
+      status: "draft",
+      definition_format: "conda",
+      image_uri: null,
+      created_at: "2026-05-07T10:00:00Z",
+    },
+    created_by: null,
+    created_at: "2026-05-07T10:00:00Z",
+    updated_at: "2026-05-07T10:00:00Z",
+  };
+
+  const envDetail = {
+    ...envSummary,
+    versions: [
+      {
+        id: 10,
+        version_number: 1,
+        build_number: 1,
+        status: "draft",
+        definition_format: "conda",
+        image_uri: null,
+        created_at: "2026-05-07T10:00:00Z",
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === "/api/v1/environments?type=notebook") {
+        return Promise.resolve({ environments: [envSummary], total: 1 });
+      }
+      if (url === "/api/v1/environments?type=work_node") {
+        return Promise.resolve({ environments: [], total: 0 });
+      }
+      if (url === "/api/v1/environments/1") return Promise.resolve(envDetail);
+      return Promise.resolve({});
+    });
+  });
+
+  test("clicking Build Image opens a friendly confirmation modal (no native confirm, no Cloud Build jargon)", async () => {
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<EnvironmentsPage />);
+
+    // Open the env so the version detail / Build button is visible.
+    await waitFor(() => {
+      expect(screen.getByText("Default Notebook")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Default Notebook"));
+
+    const buildButton = await screen.findByText("Build");
+    fireEvent.click(buildButton);
+
+    // Modal text should explain background build + that the user can keep
+    // working, and must NOT mention "Cloud Build" or use the native dialog.
+    expect(await screen.findByText(/in the background/i)).toBeInTheDocument();
+    expect(screen.getByText(/continue using bioaf/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Cloud Build/)).not.toBeInTheDocument();
+    expect(confirmSpy).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/app/environments/page.test.tsx
+++ b/frontend/src/app/environments/page.test.tsx
@@ -1,0 +1,51 @@
+import { render, waitFor } from "@testing-library/react";
+import EnvironmentsPage from "./page";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/environments",
+}));
+
+jest.mock("@/lib/api", () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getToken: () => "fake-token",
+  removeToken: jest.fn(),
+  getCurrentUser: () => ({ role_name: "admin", email: "admin@test.com" }),
+  isAuthenticated: () => true,
+}));
+
+import { api } from "@/lib/api";
+
+const mockGet = api.get as jest.Mock;
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockGet.mockResolvedValue({ environments: [], total: 0 });
+});
+
+describe("Workbench EnvironmentsPage filter", () => {
+  test("'All' filter excludes pipeline envs (does not call unfiltered list)", async () => {
+    render(<EnvironmentsPage />);
+
+    // Initial load should request notebook + work_node, never the bare
+    // /api/v1/environments which would include pipeline envs.
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalled();
+    });
+
+    expect(mockGet).not.toHaveBeenCalledWith("/api/v1/environments");
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/api\/v1\/environments\?type=notebook$/)
+    );
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/api\/v1\/environments\?type=work_node$/)
+    );
+  });
+});

--- a/frontend/src/app/environments/page.tsx
+++ b/frontend/src/app/environments/page.tsx
@@ -66,9 +66,24 @@ export default function EnvironmentsPage() {
   async function loadEnvironments(type?: string) {
     try {
       const filterType = type ?? typeFilter;
-      const query = filterType !== "all" ? `?type=${filterType}` : "";
-      const data = await api.get<EnvironmentListResponse>(`/api/v1/environments${query}`);
-      setEnvironments(data.environments);
+      // The Workbench env page only manages notebook and work_node envs.
+      // Pipeline envs live under Pipelines > Environments and would be
+      // unusable here, so "all" must fetch both notebook and work_node
+      // explicitly rather than calling the unfiltered list endpoint.
+      let envs: EnvironmentResponse[];
+      if (filterType === "all") {
+        const [nb, wn] = await Promise.all([
+          api.get<EnvironmentListResponse>("/api/v1/environments?type=notebook"),
+          api.get<EnvironmentListResponse>("/api/v1/environments?type=work_node"),
+        ]);
+        envs = [...nb.environments, ...wn.environments].sort(
+          (a, b) => +new Date(b.created_at) - +new Date(a.created_at)
+        );
+      } else {
+        const data = await api.get<EnvironmentListResponse>(`/api/v1/environments?type=${filterType}`);
+        envs = data.environments;
+      }
+      setEnvironments(envs);
       setLoadError(null);
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : "Failed to load environments");

--- a/frontend/src/app/environments/page.tsx
+++ b/frontend/src/app/environments/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { ContentLoading } from "@/components/shared/ContentLoading";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { isAuthenticated, getCurrentUser } from "@/lib/auth";
 import { api } from "@/lib/api";
 import type {
@@ -57,6 +58,9 @@ export default function EnvironmentsPage() {
   // Delete version modal state
   const [showDeleteVersionModal, setShowDeleteVersionModal] = useState<EnvironmentVersionSummary | null>(null);
   const [deletingVersion, setDeletingVersion] = useState(false);
+
+  // Build-confirmation modal state
+  const [buildConfirm, setBuildConfirm] = useState<{ envId: number; versionId: number } | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated()) { router.push("/login"); return; }
@@ -147,8 +151,14 @@ export default function EnvironmentsPage() {
     } finally { setCreatingVersion(false); }
   }
 
-  async function handleBuild(envId: number, versionId: number) {
-    if (!confirm("Start building this version? This submits a Cloud Build job.")) return;
+  function handleBuild(envId: number, versionId: number) {
+    setBuildConfirm({ envId, versionId });
+  }
+
+  async function confirmBuild() {
+    if (!buildConfirm) return;
+    const { envId, versionId } = buildConfirm;
+    setBuildConfirm(null);
     try {
       await api.post<EnvironmentVersionResponse>(
         `/api/v1/environments/${envId}/versions/${versionId}/build`
@@ -733,6 +743,26 @@ export default function EnvironmentsPage() {
           )}
         </main>
       </div>
+      <ConfirmDialog
+        open={buildConfirm !== null}
+        title="Start build?"
+        message={
+          <>
+            <p>
+              The image will be built in the background. This usually takes a
+              few minutes, sometimes longer for larger environments.
+            </p>
+            <p>
+              You can continue using bioAF while it builds -- we will update the
+              status here when it finishes.
+            </p>
+          </>
+        }
+        confirmLabel="Start build"
+        cancelLabel="Cancel"
+        onConfirm={confirmBuild}
+        onCancel={() => setBuildConfirm(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/app/notebooks/page.test.tsx
+++ b/frontend/src/app/notebooks/page.test.tsx
@@ -201,6 +201,21 @@ describe("NotebooksPage launch modal", () => {
   });
 });
 
+describe("NotebooksPage env picker filter", () => {
+  test("requests environments filtered by type=notebook", async () => {
+    setupMocks({ build_id: null, build_status: null, image_uri: null });
+
+    render(<NotebooksPage />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/api\/v1\/environments\?type=notebook$/)
+      );
+    });
+    expect(mockGet).not.toHaveBeenCalledWith("/api/v1/environments");
+  });
+});
+
 describe("NotebooksPage launch button component gating", () => {
   test("hides Launch RStudio when rstudio is not enabled", async () => {
     mockComponents.mockReturnValue({

--- a/frontend/src/app/notebooks/page.tsx
+++ b/frontend/src/app/notebooks/page.tsx
@@ -138,7 +138,7 @@ export default function NotebooksPage() {
 
   async function loadEnvironments() {
     try {
-      const data = await api.get<EnvironmentListResponse>("/api/v1/environments");
+      const data = await api.get<EnvironmentListResponse>("/api/v1/environments?type=notebook");
       setEnvironments(data.environments);
       const withReady = data.environments.find(
         (e) => e.latest_version?.status === "ready" && e.latest_version?.image_uri

--- a/frontend/src/app/pipelines/environments/page.tsx
+++ b/frontend/src/app/pipelines/environments/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { ContentLoading } from "@/components/shared/ContentLoading";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { isAuthenticated, getCurrentUser } from "@/lib/auth";
 import { api } from "@/lib/api";
 import type {
@@ -87,6 +88,11 @@ export default function PipelineEnvironmentsPage() {
   const [showDeleteVersionModal, setShowDeleteVersionModal] =
     useState<EnvironmentVersionSummary | null>(null);
   const [deletingVersion, setDeletingVersion] = useState(false);
+
+  // Build / rebuild confirmation modal state
+  const [buildConfirm, setBuildConfirm] = useState<
+    { kind: "build" | "rebuild"; envId: number; versionId: number } | null
+  >(null);
 
   const selectedEnvIdRef = useRef<number | null>(null);
   const selectedVersionIdRef = useRef<number | null>(null);
@@ -236,25 +242,26 @@ export default function PipelineEnvironmentsPage() {
     }
   }
 
-  async function handleBuild(envId: number, versionId: number) {
-    if (!confirm("Start building this version? This submits a Cloud Build job.")) return;
-    try {
-      await api.post(`/api/v1/environments/${envId}/versions/${versionId}/build`);
-      await selectEnvironment(envId);
-      await loadEnvironments(true);
-    } catch (err) {
-      alert(err instanceof Error ? err.message : "Build failed to start");
-    }
+  function handleBuild(envId: number, versionId: number) {
+    setBuildConfirm({ kind: "build", envId, versionId });
   }
 
-  async function handleRebuild(envId: number, versionId: number) {
-    if (!confirm("Rebuild this version? A new build will be created with the same definition.")) return;
+  function handleRebuild(envId: number, versionId: number) {
+    setBuildConfirm({ kind: "rebuild", envId, versionId });
+  }
+
+  async function confirmBuildOrRebuild() {
+    if (!buildConfirm) return;
+    const { kind, envId, versionId } = buildConfirm;
+    setBuildConfirm(null);
+    const path = kind === "rebuild" ? "rebuild" : "build";
     try {
-      await api.post(`/api/v1/environments/${envId}/versions/${versionId}/rebuild`);
+      await api.post(`/api/v1/environments/${envId}/versions/${versionId}/${path}`);
       await selectEnvironment(envId);
       await loadEnvironments(true);
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Rebuild failed to start");
+      const fallback = kind === "rebuild" ? "Rebuild failed to start" : "Build failed to start";
+      alert(err instanceof Error ? err.message : fallback);
     }
   }
 
@@ -727,6 +734,26 @@ export default function PipelineEnvironmentsPage() {
           )}
         </main>
       </div>
+      <ConfirmDialog
+        open={buildConfirm !== null}
+        title={buildConfirm?.kind === "rebuild" ? "Start rebuild?" : "Start build?"}
+        message={
+          <>
+            <p>
+              The image will be built in the background. This usually takes a
+              few minutes, sometimes longer for larger environments.
+            </p>
+            <p>
+              You can continue using bioAF while it builds -- we will update the
+              status here when it finishes.
+            </p>
+          </>
+        }
+        confirmLabel={buildConfirm?.kind === "rebuild" ? "Start rebuild" : "Start build"}
+        cancelLabel="Cancel"
+        onConfirm={confirmBuildOrRebuild}
+        onCancel={() => setBuildConfirm(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/shared/ConfirmDialog.tsx
+++ b/frontend/src/components/shared/ConfirmDialog.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 interface ConfirmDialogProps {
   open: boolean;
   title: string;
-  message: string;
+  message: ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   onConfirm: () => void;
@@ -27,7 +29,9 @@ export function ConfirmDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
         <h3 className="text-lg font-semibold mb-2">{title}</h3>
-        <p className="text-gray-600 mb-6">{message}</p>
+        <div className="text-gray-600 mb-6 space-y-3">
+          {typeof message === "string" ? <p>{message}</p> : message}
+        </div>
         <div className="flex justify-end gap-3">
           <button
             onClick={onCancel}


### PR DESCRIPTION
## Summary

Point release (v0.11.1 → v0.11.2). All bug fixes from end-to-end testing of v0.11.1 on a fresh greenfield install. No schema changes; no migration required.

- **Environment pickers correctly filter by type.** Notebooks page and Workbench Environments "All" filter no longer leak pipeline envs into pickers where they cannot be used (resolves to-resolve.md issue #2).
- **Default environments seeded at bootstrap.** Added a notebook seeder alongside the existing pipeline / work_node seeders, and now invoke all three from the `create_admin` bootstrap endpoint so they take effect on fresh installs (previously only ran from the lifespan startup hook, which skipped before bootstrap completed).
- **Built-in `bioaf-base` work-node env** (opt-in, gated by `BIOAF_BASE_WORK_NODE_IMAGE_URI`). When the published image URI is set, the env is seeded `status=ready` and first-launch is instant — no per-install ~10-15 min Packer build (resolves to-resolve.md issue #1, backend portion).
- **Build-trigger UX.** Replaced the bare browser `confirm()` (which renders with the host IP in the title bar and leaks "Cloud Build" terminology) with the existing `ConfirmDialog` modal. Build trigger endpoint now catches broad `Exception` so the user sees the real error instead of "Unknown error".
- **Work-node Packer build no longer eats SSD quota.** Switched the transient build VM from `pd-ssd` to `pd-standard` so the 50 GB does not consume regional `SSD_TOTAL_GB` (already pressured by GKE pool nodes' pd-balanced disks). Tactical mitigation; the full quota auto-request fix is tracked as to-resolve.md issue #3 on a follow-up branch. Regression test guards `disk_type` and `disk_size`.
- **Lockfile sync.** Regenerated `backend/uv.lock` to match `pyproject.toml` (lockfile had drifted after the v0.11.1 merge from main brought in new deps).

## Test plan

- [x] `ruff format --check .` (backend) — passes
- [x] `ruff check .` (backend) — passes
- [x] `mypy . --ignore-missing-imports` (backend) — passes
- [x] `pytest -x` (backend) — passes
- [x] `npx tsc --noEmit` (frontend) — passes
- [x] `npm test` (frontend) — 61 suites / 431 tests passing
- [ ] Manual smoke on a fresh install: bootstrap completes → notebooks / workbench-envs / pipelines pickers show only the right env types and a buildable default
- [ ] Manual smoke: trigger an env build → friendly modal appears; if the build fails the alert message is the actual error rather than "Unknown error"
- [ ] Manual smoke: work-node image build completes on a project at the default 250 GB SSD quota