### PR TITLE
v0.11.3: install-gcp.sh auto-quota-request + shell test refresh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,94 @@
 # Release Notes
 
+## v0.11.3
+
+Point release that automates the GCP quota-increase requests bioAF
+needs at install time, plus a small refresh of the shell test suite
+that had drifted away from the current `bioaf` and `install.sh`
+contracts. No schema changes; no migration required.
+
+### Auto-quota-request in `install-gcp.sh`
+
+Resolves the last open item from to-resolve.md issue #3 (CPUS) and
+its 2026-05-07 expansion (SSD / DISKS). Fresh GCP projects ship with
+quotas too tight for bioAF to schedule even one pipeline pod
+(12 vCPUs, 250 GB regional SSD). On v0.11.2 and earlier, the user
+had to discover this via `Pending` pods and `QUOTA_EXCEEDED` autoscaler
+events, then go to the console to file an increase manually.
+
+`install-gcp.sh` now adds a "Step 5b: GCP Quota Auto-Request" right
+after region selection. It checks each of the three quotas bioAF
+needs and, for any that are below target, files a `QuotaPreference`
+through the Cloud Quotas API:
+
+- `CPUS-ALL-REGIONS-per-project` &rarr; 64
+- `SSD-TOTAL-GB-per-project-region` &rarr; 1024
+- `DISKS-TOTAL-GB-per-project-region` &rarr; 2048
+
+On a paid billing account the API auto-approves these in seconds and
+the installer reports "granted automatically." On a free-trial
+billing account the request goes to human review (1-2 business days)
+and the installer surfaces a clear "Google needs to review and
+approve this -- this is normal" message before continuing. The
+install never aborts on a quota request; if a request was actually
+denied, the affected pipeline run will surface the underlying
+`QUOTA_EXCEEDED` reason in its log.
+
+The logic lives in `installer/quota.sh` (sourced by `install-gcp.sh`
+from a local clone, or fetched over HTTPS when the script is
+`curl|bash`'d). Cloud Quotas API errors are surfaced verbatim, so a
+4xx response shows the API's `code`/`status`/`message` rather than
+just an opaque "request failed."
+
+### Stale `bats` shell tests refreshed
+
+`tests/shell/test_bioaf.bats` and `tests/shell/test_install.bats`
+hadn't been touched since the original installer commit, but the
+underlying scripts had moved on across many releases. Three tests
+were checking for behavior that no longer exists:
+
+- `bioaf help` expected `create-admin`, but admin creation moved to
+  the web wizard; the test now checks the actually-current commands.
+- `install.sh check-prereqs` expected exit 0 on any host with docker
+  and git, but `install.sh` now refuses to run on macOS / Windows by
+  design (it is meant for the GCP Linux VM); the test now skips on
+  non-Linux hosts.
+- `install.sh generate-env` was tested as a "refuse to overwrite"
+  gate, but the current contract is "regenerate the file but
+  preserve known values (POSTGRES_PASSWORD, SECRET_KEY) unless
+  `--force` is passed"; the test now pins that contract.
+
+No production code changed -- this section is test-only cleanup.
+
+### Bug fix: install-gcp.sh exited silently on a Cloud Quotas 4xx
+
+The first version of the auto-quota-request flow (built earlier on
+this branch) used `curl -fsSL` and propagated curl's non-zero exit
+through the `pref_id=$(bioaf_quota_request_increase ...)` assignment
+in the orchestrator. Under `set -euo pipefail` (which `install-gcp.sh`
+uses) that aborted the entire installer mid-flow with no user-visible
+error, right after printing "Requesting an automatic quota increase
+from Google..." Two regression tests now pin this down; the helper
+always returns 0 and signals failure via empty stdout, matching the
+convention `bioaf_quota_poll` already used.
+
+### Bug fix: missing `contactEmail` rejected every QuotaPreference
+
+After the silent-abort fix surfaced the underlying API error, fresh
+projects revealed a second issue: the Cloud Quotas API requires a
+`contactEmail` field on every `QuotaPreference` body ("Contact email
+must be set in order to increase quota value") and the helper was
+not sending it. Long-lived projects can quietly accept submissions
+without it because of contacts retained from prior console activity,
+which masked the requirement during early testing.
+
+The orchestrator now resolves the gcloud-active account once
+(`gcloud config get-value account` -- same identity as the bearer
+token, so Google can email the right human if review or denial
+happens) and threads it into the body. `(unset)` is treated as empty
+so installs without a configured account degrade cleanly rather than
+sending a literal `(unset)` string as the contact.
+
 ## v0.11.2
 
 Bug-fix point release covering the environment-management gaps and a

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.11.2"
+version = "0.11.3"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "bioaf-backend"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/install-gcp.sh
+++ b/install-gcp.sh
@@ -92,6 +92,7 @@ REQUIRED_APIS=(
     "secretmanager.googleapis.com"
     "serviceusage.googleapis.com"
     "logging.googleapis.com"
+    "cloudquotas.googleapis.com"
 )
 
 # SA hardening (see documentation/sa-hardening/03-consolidated-plan.md):
@@ -387,6 +388,46 @@ read -ra REGION_ZONES <<< "$(zones_for_region "$REGION")"
 ZONE="${REGION_ZONES[0]}"
 
 green "  Using region: $REGION"
+
+# ---------------------------------------------------------------------------
+# Step 5b: Auto-request GCP quota increases
+#
+# Fresh GCP projects ship with very tight default quotas (12 vCPUs and
+# 250 GB regional SSD). Even one bioAF pipeline pod cannot be scheduled
+# under those defaults. The Cloud Quotas API accepts programmatic
+# QuotaPreference submissions and -- on paid billing accounts -- auto-
+# approves typical bumps in seconds. On free-trial billing accounts the
+# request goes to human review (1-2 business days).
+#
+# This step asks for the bumps bioAF needs and tells the user what is
+# happening at each phase. The install does not abort if a request is
+# denied or stuck pending: pipeline launches that depend on the quota
+# will surface the underlying QUOTA_EXCEEDED reason in the run logs.
+# ---------------------------------------------------------------------------
+echo ""
+bold "Step 5b: GCP Quota Auto-Request"
+
+# Source installer/quota.sh from a local clone if present (clone-then-run
+# install) or fetch it over HTTPS pinned to main (curl|bash install).
+QUOTA_HELPER_LOCAL="$(dirname "${BASH_SOURCE[0]:-$0}")/installer/quota.sh"
+QUOTA_HELPER_URL="https://raw.githubusercontent.com/not-that-guy-again/bioAF/main/installer/quota.sh"
+if [ -f "$QUOTA_HELPER_LOCAL" ]; then
+    # shellcheck source=installer/quota.sh
+    source "$QUOTA_HELPER_LOCAL"
+else
+    quota_helper_payload="$(curl -fsSL "$QUOTA_HELPER_URL" 2>/dev/null || true)"
+    if [ -z "$quota_helper_payload" ]; then
+        yellow "  Could not load the quota helper. Skipping auto-quota-request."
+        yellow "  If pipeline runs hit QUOTA_EXCEEDED later, request increases in"
+        yellow "  the Cloud Console: IAM & Admin -> Quotas."
+    else
+        eval "$quota_helper_payload"
+    fi
+fi
+
+if declare -F bioaf_quota_ensure_all >/dev/null 2>&1; then
+    bioaf_quota_ensure_all "$PROJECT_ID" "$REGION"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 6: Create firewall rule

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -131,3 +131,40 @@ name = data.get("name") or ""
 print(name.rsplit("/", 1)[-1] if name else "")
 ' <<<"$resp"
 }
+
+# Check the current state of a previously-submitted QuotaPreference.
+#   $1 project        GCP project id
+#   $2 pref_id        preference id returned by bioaf_quota_request_increase
+# Prints exactly one of:
+#   approved -- grantedValue matches preferredValue, change is live
+#   pending  -- reconciling, or awaiting Google review
+#   error    -- curl/parse failure (caller may retry)
+bioaf_quota_poll() {
+    local project="$1" pref_id="$2"
+    local token
+    token=$(gcloud auth print-access-token 2>/dev/null) || { echo error; return 0; }
+    local url="https://cloudquotas.googleapis.com/v1/projects/${project}/locations/global/quotaPreferences/${pref_id}"
+    local resp
+    resp=$(curl -fsSL \
+        -H "Authorization: Bearer ${token}" \
+        "$url" 2>/dev/null) || { echo error; return 0; }
+    local py
+    py=$(_bioaf_quota_python)
+    if [ -z "$py" ]; then echo error; return 0; fi
+    "$py" -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read() or "{}")
+except Exception:
+    print("error"); sys.exit(0)
+qc = data.get("quotaConfig") or {}
+preferred = qc.get("preferredValue")
+granted = qc.get("grantedValue")
+if preferred is not None and granted is not None and str(granted) == str(preferred):
+    print("approved"); sys.exit(0)
+# Otherwise: either reconciling or sitting in human review queue. Both are
+# "pending" from the installers point of view -- we surface a single
+# "Google needs to approve this, this is normal" message to the user.
+print("pending")
+' <<<"$resp"
+}

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -90,14 +90,17 @@ _bioaf_quota_pref_id() {
 #   $3 project        GCP project id
 #   $4 preferred_value (integer string)
 #   $5 region (opt)   for regional quotas; omit for project-scoped
-# Prints the preference id (the last path segment of `name`) on success,
-# empty string on failure.
+# Prints the preference id (the last path segment of `name`) on success.
+# Always returns 0 -- a failure is signalled via empty stdout, so callers
+# under `set -euo pipefail` can use $(...) safely. The orchestrator uses
+# this empty-stdout convention to print the friendly "Could not submit"
+# message instead of letting set -e abort the whole installer.
 bioaf_quota_request_increase() {
     local service="$1" quota_id="$2" project="$3" preferred="$4" region="${5:-}"
     local pref_id
     pref_id=$(_bioaf_quota_pref_id "$quota_id")
     local token
-    token=$(gcloud auth print-access-token 2>/dev/null) || return 1
+    token=$(gcloud auth print-access-token 2>/dev/null) || return 0
     local body
     if [ -n "$region" ]; then
         body=$(printf '{"service":"%s","quotaId":"%s","quotaConfig":{"preferredValue":"%s"},"dimensions":{"region":"%s"}}' \
@@ -112,7 +115,7 @@ bioaf_quota_request_increase() {
         -H "Authorization: Bearer ${token}" \
         -H "Content-Type: application/json" \
         --data "$body" \
-        "$url" 2>/dev/null) || return 1
+        "$url" 2>/dev/null) || return 0
     local py
     py=$(_bioaf_quota_python)
     if [ -z "$py" ]; then

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -23,3 +23,49 @@ bioaf_quota_targets() {
     printf 'compute.googleapis.com\tSSD-TOTAL-GB-per-project-region\tregion\t1024\n'
     printf 'compute.googleapis.com\tDISKS-TOTAL-GB-per-project-region\tregion\t2048\n'
 }
+
+# Resolve a python interpreter (gcloud bundles one; macOS ships python3).
+# Fails closed -- callers should treat empty stdout as "unknown".
+_bioaf_quota_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        echo python3
+    elif command -v python >/dev/null 2>&1; then
+        echo python
+    fi
+}
+
+# Read the current effective limit for a quota.
+#   $1 service        e.g. compute.googleapis.com
+#   $2 quota_id       e.g. CPUS-ALL-REGIONS-per-project
+#   $3 project        GCP project id
+#   $4 region (opt)   for regional quotas; omit for project-scoped
+# Prints the limit as an integer string, or "0" if the quota cannot be
+# read or the requested region is not present.
+bioaf_quota_get_current() {
+    local service="$1" quota_id="$2" project="$3" region="${4:-}"
+    local out
+    out=$(gcloud alpha quotas info describe "$quota_id" \
+            --service="$service" \
+            --project="$project" \
+            --format=json 2>/dev/null) || { echo 0; return 0; }
+    local py
+    py=$(_bioaf_quota_python)
+    if [ -z "$py" ]; then echo 0; return 0; fi
+    REGION="$region" "$py" -c '
+import json, os, sys
+try:
+    data = json.loads(sys.stdin.read() or "{}")
+except Exception:
+    print("0"); sys.exit(0)
+region = os.environ.get("REGION", "")
+for entry in (data.get("dimensionsInfos") or []):
+    dims = entry.get("dimensions") or {}
+    if region:
+        if dims.get("region") == region:
+            print((entry.get("details") or {}).get("value", "0")); sys.exit(0)
+    else:
+        if not dims:
+            print((entry.get("details") or {}).get("value", "0")); sys.exit(0)
+print("0")
+' <<<"$out"
+}

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# bioAF GCP quota auto-request helper.
+#
+# Sourced by install-gcp.sh. Owns the logic for checking and requesting
+# Cloud Quotas API increases for the metrics bioAF needs at install time:
+#
+#   - CPUS-ALL-REGIONS-per-project       (64)   compute pool headroom
+#   - SSD-TOTAL-GB-per-project-region    (1024) GKE pd-balanced + pd-ssd
+#   - DISKS-TOTAL-GB-per-project-region  (2048) Packer build & HDD work nodes
+#
+# Designed to be testable in isolation: every external call (gcloud, curl)
+# goes through the user's PATH so test stubs can intercept it. There is no
+# global state; callers pass project / region in.
+# ---------------------------------------------------------------------------
+
+# Emit one row per desired quota:
+#   <service>\t<quotaId>\t<scope>\t<preferredValue>
+# Scope is "project" for project-level metrics and "region" for those that
+# are dimensioned by region.
+bioaf_quota_targets() {
+    printf 'compute.googleapis.com\tCPUS-ALL-REGIONS-per-project\tproject\t64\n'
+    printf 'compute.googleapis.com\tSSD-TOTAL-GB-per-project-region\tregion\t1024\n'
+    printf 'compute.googleapis.com\tDISKS-TOTAL-GB-per-project-region\tregion\t2048\n'
+}

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -69,3 +69,65 @@ for entry in (data.get("dimensionsInfos") or []):
 print("0")
 ' <<<"$out"
 }
+
+# Generate a stable-but-unique QuotaPreference id. The Cloud Quotas API
+# requires it to be lowercase alphanumeric + hyphens, max 63 chars. We
+# combine a `bioaf` prefix, the lowercased quota id, and a short epoch
+# suffix so re-running the installer creates a fresh preference instead of
+# colliding with a previous run.
+_bioaf_quota_pref_id() {
+    local quota_id="$1"
+    local lower
+    lower=$(printf '%s' "$quota_id" | tr '[:upper:]_' '[:lower:]-' | tr -cd 'a-z0-9-')
+    # Trim to leave room for prefix + suffix (63 char limit).
+    lower="${lower:0:40}"
+    printf 'bioaf-%s-%s' "$lower" "$(date +%s)"
+}
+
+# Submit a QuotaPreference to bump a quota.
+#   $1 service        e.g. compute.googleapis.com
+#   $2 quota_id       e.g. CPUS-ALL-REGIONS-per-project
+#   $3 project        GCP project id
+#   $4 preferred_value (integer string)
+#   $5 region (opt)   for regional quotas; omit for project-scoped
+# Prints the preference id (the last path segment of `name`) on success,
+# empty string on failure.
+bioaf_quota_request_increase() {
+    local service="$1" quota_id="$2" project="$3" preferred="$4" region="${5:-}"
+    local pref_id
+    pref_id=$(_bioaf_quota_pref_id "$quota_id")
+    local token
+    token=$(gcloud auth print-access-token 2>/dev/null) || return 1
+    local body
+    if [ -n "$region" ]; then
+        body=$(printf '{"service":"%s","quotaId":"%s","quotaConfig":{"preferredValue":"%s"},"dimensions":{"region":"%s"}}' \
+            "$service" "$quota_id" "$preferred" "$region")
+    else
+        body=$(printf '{"service":"%s","quotaId":"%s","quotaConfig":{"preferredValue":"%s"}}' \
+            "$service" "$quota_id" "$preferred")
+    fi
+    local url="https://cloudquotas.googleapis.com/v1/projects/${project}/locations/global/quotaPreferences?quotaPreferenceId=${pref_id}"
+    local resp
+    resp=$(curl -fsSL -X POST \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        --data "$body" \
+        "$url" 2>/dev/null) || return 1
+    local py
+    py=$(_bioaf_quota_python)
+    if [ -z "$py" ]; then
+        # Without python we fall back to the id we generated -- the API uses
+        # exactly that as the last segment of `name`.
+        printf '%s\n' "$pref_id"
+        return 0
+    fi
+    "$py" -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read() or "{}")
+except Exception:
+    print(""); sys.exit(0)
+name = data.get("name") or ""
+print(name.rsplit("/", 1)[-1] if name else "")
+' <<<"$resp"
+}

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -168,3 +168,75 @@ if preferred is not None and granted is not None and str(granted) == str(preferr
 print("pending")
 ' <<<"$resp"
 }
+
+# Walk every desired quota; for each one that is below its target, request
+# an increase and poll briefly for an automatic approval. Notifies the user
+# at every step. Never aborts on a single-quota failure -- the install
+# should still complete; pipeline launches will surface the exact reason
+# later if the quota was actually denied.
+#
+# Inputs:
+#   $1 project        GCP project id
+#   $2 region         GCE region used by bioAF (regional quotas only)
+# Knobs (env):
+#   BIOAF_QUOTA_POLL_INTERVAL  seconds between polls   (default 3)
+#   BIOAF_QUOTA_POLL_TIMEOUT   max wait per quota      (default 30)
+bioaf_quota_ensure_all() {
+    local project="$1" region="$2"
+    local interval="${BIOAF_QUOTA_POLL_INTERVAL:-3}"
+    local timeout="${BIOAF_QUOTA_POLL_TIMEOUT:-30}"
+
+    echo ""
+    echo "  Checking GCP quotas needed by bioAF (CPUs and disk)..."
+    echo ""
+
+    local row
+    while IFS=$'\t' read -r service quota_id scope preferred; do
+        local r=""
+        [ "$scope" = "region" ] && r="$region"
+        local current
+        current=$(bioaf_quota_get_current "$service" "$quota_id" "$project" "$r")
+        # Treat non-numeric as 0 so we always proceed to ask.
+        case "$current" in (''|*[!0-9]*) current=0 ;; esac
+        if [ "$current" -ge "$preferred" ]; then
+            echo "  ${quota_id}: current limit ${current} already meets target ${preferred}. Skipping."
+            continue
+        fi
+        echo ""
+        echo "  ${quota_id}: current ${current}, target ${preferred}."
+        echo "  Requesting an automatic quota increase from Google..."
+        local pref_id
+        pref_id=$(bioaf_quota_request_increase "$service" "$quota_id" "$project" "$preferred" "$r")
+        if [ -z "$pref_id" ]; then
+            echo "  Could not submit the quota request. Continuing without auto-bump --"
+            echo "  if the limit blocks pipeline runs later, you can request the bump"
+            echo "  in the Cloud Console: IAM & Admin -> Quotas."
+            continue
+        fi
+        echo "  Submitted (preference id: ${pref_id}). Waiting up to ${timeout}s for"
+        echo "  automatic approval..."
+        local elapsed=0
+        local status="pending"
+        while [ "$elapsed" -lt "$timeout" ]; do
+            status=$(bioaf_quota_poll "$project" "$pref_id")
+            [ "$status" = "approved" ] && break
+            sleep "$interval"
+            elapsed=$((elapsed + interval))
+        done
+        case "$status" in
+            approved)
+                echo "  ${quota_id}: granted automatically (now ${preferred})."
+                ;;
+            *)
+                echo "  ${quota_id}: not auto-approved within ${timeout}s."
+                echo "  Google needs to review and approve this quota increase."
+                echo "  This is normal -- approval typically takes 1-2 business days."
+                echo "  bioAF install will continue. Pipeline launches that depend on"
+                echo "  this quota will fail until approval; the run log will surface"
+                echo "  the underlying QUOTA_EXCEEDED reason when that happens."
+                ;;
+        esac
+    done < <(bioaf_quota_targets)
+
+    echo ""
+}

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -90,25 +90,34 @@ _bioaf_quota_pref_id() {
 #   $3 project        GCP project id
 #   $4 preferred_value (integer string)
 #   $5 region (opt)   for regional quotas; omit for project-scoped
+#   $6 contact_email (opt) Cloud Quotas requires this on every QuotaPreference
+#                          submission ("Contact email must be set in order to
+#                          increase quota value"); pass empty string to omit
+#                          when not available, but expect the API to reject.
 # Prints the preference id (the last path segment of `name`) on success.
 # Always returns 0 -- a failure is signalled via empty stdout, so callers
 # under `set -euo pipefail` can use $(...) safely. The orchestrator uses
 # this empty-stdout convention to print the friendly "Could not submit"
 # message instead of letting set -e abort the whole installer.
 bioaf_quota_request_increase() {
-    local service="$1" quota_id="$2" project="$3" preferred="$4" region="${5:-}"
+    local service="$1" quota_id="$2" project="$3" preferred="$4"
+    local region="${5:-}" contact_email="${6:-}"
     local pref_id
     pref_id=$(_bioaf_quota_pref_id "$quota_id")
     local token
     token=$(gcloud auth print-access-token 2>/dev/null) || return 0
-    local body
+    # Build the JSON body piece by piece. Region and contactEmail are both
+    # optional fields; we drop them entirely (rather than emit empty values)
+    # when not provided, since the API has different validation rules per
+    # field shape.
+    local body='{"service":"'"$service"'","quotaId":"'"$quota_id"'","quotaConfig":{"preferredValue":"'"$preferred"'"}'
     if [ -n "$region" ]; then
-        body=$(printf '{"service":"%s","quotaId":"%s","quotaConfig":{"preferredValue":"%s"},"dimensions":{"region":"%s"}}' \
-            "$service" "$quota_id" "$preferred" "$region")
-    else
-        body=$(printf '{"service":"%s","quotaId":"%s","quotaConfig":{"preferredValue":"%s"}}' \
-            "$service" "$quota_id" "$preferred")
+        body+=',"dimensions":{"region":"'"$region"'"}'
     fi
+    if [ -n "$contact_email" ]; then
+        body+=',"contactEmail":"'"$contact_email"'"'
+    fi
+    body+='}'
     local url="https://cloudquotas.googleapis.com/v1/projects/${project}/locations/global/quotaPreferences?quotaPreferenceId=${pref_id}"
     # Drop -f so 4xx responses give us the error JSON body instead of an
     # opaque curl exit. We parse the body below: if it has top-level "error"
@@ -208,6 +217,17 @@ bioaf_quota_ensure_all() {
     local interval="${BIOAF_QUOTA_POLL_INTERVAL:-3}"
     local timeout="${BIOAF_QUOTA_POLL_TIMEOUT:-30}"
 
+    # Cloud Quotas API requires a contactEmail on every QuotaPreference
+    # submission. Use the gcloud-active account: same identity as the bearer
+    # token, so Google can email the right human if the request hits review
+    # or gets denied. "(unset)" is gclouds sentinel for "no account
+    # configured" -- treat it as empty.
+    local contact_email
+    contact_email=$(gcloud config get-value account 2>/dev/null || true)
+    if [ "$contact_email" = "(unset)" ]; then
+        contact_email=""
+    fi
+
     echo ""
     echo "  Checking GCP quotas needed by bioAF (CPUs and disk)..."
     echo ""
@@ -227,7 +247,7 @@ bioaf_quota_ensure_all() {
         echo "  ${quota_id}: current ${current}, target ${preferred}."
         echo "  Requesting an automatic quota increase from Google..."
         local pref_id
-        pref_id=$(bioaf_quota_request_increase "$service" "$quota_id" "$project" "$preferred" "$r")
+        pref_id=$(bioaf_quota_request_increase "$service" "$quota_id" "$project" "$preferred" "$r" "$contact_email")
         if [ -z "$pref_id" ]; then
             echo "  Could not submit the quota request. Continuing without auto-bump --"
             echo "  if the limit blocks pipeline runs later, you can request the bump"

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -190,7 +190,6 @@ bioaf_quota_ensure_all() {
     echo "  Checking GCP quotas needed by bioAF (CPUs and disk)..."
     echo ""
 
-    local row
     while IFS=$'\t' read -r service quota_id scope preferred; do
         local r=""
         [ "$scope" = "region" ] && r="$region"

--- a/installer/quota.sh
+++ b/installer/quota.sh
@@ -110,8 +110,12 @@ bioaf_quota_request_increase() {
             "$service" "$quota_id" "$preferred")
     fi
     local url="https://cloudquotas.googleapis.com/v1/projects/${project}/locations/global/quotaPreferences?quotaPreferenceId=${pref_id}"
+    # Drop -f so 4xx responses give us the error JSON body instead of an
+    # opaque curl exit. We parse the body below: if it has top-level "error"
+    # we surface the API message on stderr; if it has "name", we treat it as
+    # a successful preference creation.
     local resp
-    resp=$(curl -fsSL -X POST \
+    resp=$(curl -sSL -X POST \
         -H "Authorization: Bearer ${token}" \
         -H "Content-Type: application/json" \
         --data "$body" \
@@ -119,17 +123,32 @@ bioaf_quota_request_increase() {
     local py
     py=$(_bioaf_quota_python)
     if [ -z "$py" ]; then
-        # Without python we fall back to the id we generated -- the API uses
-        # exactly that as the last segment of `name`.
-        printf '%s\n' "$pref_id"
+        # Without python we cant reliably distinguish error bodies from
+        # success bodies. Conservatively echo nothing -- caller will print
+        # the friendly "Could not submit" branch.
         return 0
     fi
     "$py" -c '
 import json, sys
+raw = sys.stdin.read() or ""
 try:
-    data = json.loads(sys.stdin.read() or "{}")
+    data = json.loads(raw)
 except Exception:
-    print(""); sys.exit(0)
+    if raw.strip():
+        sys.stderr.write("  Quota API returned an unparseable response.\n")
+    print("")
+    sys.exit(0)
+err = data.get("error") if isinstance(data, dict) else None
+if err:
+    msg = err.get("message") or str(err)
+    code = err.get("code")
+    status = err.get("status")
+    prefix = "  Quota API error"
+    if code or status:
+        prefix += " ({}{}{})".format(code or "", " " if code and status else "", status or "")
+    sys.stderr.write(prefix + ": " + msg + "\n")
+    print("")
+    sys.exit(0)
 name = data.get("name") or ""
 print(name.rsplit("/", 1)[-1] if name else "")
 ' <<<"$resp"

--- a/tests/shell/test_bioaf.bats
+++ b/tests/shell/test_bioaf.bats
@@ -23,6 +23,7 @@ BIOAF_SCRIPT="$BATS_TEST_DIRNAME/../../bioaf"
     [[ "$output" == *"status"* ]]
     [[ "$output" == *"logs"* ]]
     [[ "$output" == *"migrate"* ]]
+    [[ "$output" == *"migrate-down"* ]]
     [[ "$output" == *"backup"* ]]
     [[ "$output" == *"update"* ]]
     [[ "$output" == *"reset-db"* ]]
@@ -30,7 +31,7 @@ BIOAF_SCRIPT="$BATS_TEST_DIRNAME/../../bioaf"
     [[ "$output" == *"shell"* ]]
     [[ "$output" == *"dbshell"* ]]
     [[ "$output" == *"seed"* ]]
-    [[ "$output" == *"create-admin"* ]]
+    [[ "$output" == *"register-outputs"* ]]
 }
 
 @test "bioaf unknown command exits nonzero" {

--- a/tests/shell/test_install.bats
+++ b/tests/shell/test_install.bats
@@ -46,7 +46,12 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "install.sh check-prereqs succeeds when docker and git are present" {
-    # This test only passes if the test runner has docker + git installed
+    # install.sh refuses to run on non-Linux hosts (macOS / Windows) by
+    # design -- it is meant to be executed on the GCP VM, not on the
+    # operator's laptop. Skip this contract test on those hosts.
+    if [ "$(uname -s)" != "Linux" ]; then
+        skip "install.sh requires Linux ($(uname -s) detected)"
+    fi
     if ! command -v docker &>/dev/null; then
         skip "docker not installed on test runner"
     fi
@@ -58,9 +63,10 @@ teardown() {
 }
 
 @test "install.sh check-prereqs fails when a required tool is missing" {
-    # Create a restricted PATH with no docker
+    # Create a restricted PATH with no docker. On non-Linux hosts the
+    # OS-guard fires first and we still expect a non-zero exit, just for
+    # a different reason -- both are valid "fail" outcomes for this test.
     run env PATH="/usr/bin" bash "$INSTALL_SCRIPT" check-prereqs
-    # Should fail because docker won't be found on the restricted PATH
     [ "$status" -ne 0 ] || [[ "$output" == *"docker"* ]]
 }
 
@@ -106,23 +112,40 @@ teardown() {
     [ -n "$secret" ]
 }
 
-@test "generate-env does not overwrite existing .env" {
+@test "generate-env preserves existing POSTGRES_PASSWORD and SECRET_KEY across re-runs" {
     cd "$BIOAF_ROOT"
-    echo "EXISTING=true" > "$BIOAF_ROOT/docker/.env"
+    cat > "$BIOAF_ROOT/docker/.env" <<'EOF'
+POSTGRES_USER=bioaf
+POSTGRES_PASSWORD=preserve_this_password_abc123
+POSTGRES_DB=bioaf
+DATABASE_URL=postgresql+asyncpg://bioaf:preserve_this_password_abc123@db:5432/bioaf
+SECRET_KEY=preserve_this_secret_key_xyz789
+BIOAF_ENVIRONMENT=production
+EOF
     run bash install.sh generate-env --non-interactive
     [ "$status" -eq 0 ]
-    [[ "$output" == *"already exists"* ]]
-    # Original content preserved
-    grep -q "EXISTING=true" "$BIOAF_ROOT/docker/.env"
+    # Existing secrets must survive a re-run -- regenerating them silently
+    # would orphan the database volume and break login sessions.
+    grep -q "^POSTGRES_PASSWORD=preserve_this_password_abc123$" "$BIOAF_ROOT/docker/.env"
+    grep -q "^SECRET_KEY=preserve_this_secret_key_xyz789$" "$BIOAF_ROOT/docker/.env"
 }
 
-@test "generate-env --force overwrites existing .env" {
+@test "generate-env --force regenerates secrets even when they already exist" {
     cd "$BIOAF_ROOT"
-    echo "EXISTING=true" > "$BIOAF_ROOT/docker/.env"
+    cat > "$BIOAF_ROOT/docker/.env" <<'EOF'
+POSTGRES_USER=bioaf
+POSTGRES_PASSWORD=will_be_regenerated
+POSTGRES_DB=bioaf
+DATABASE_URL=postgresql+asyncpg://bioaf:will_be_regenerated@db:5432/bioaf
+SECRET_KEY=will_also_be_regenerated
+BIOAF_ENVIRONMENT=production
+EOF
     run bash install.sh generate-env --non-interactive --force
     [ "$status" -eq 0 ]
-    # Should have new generated content, not the old line
-    ! grep -q "EXISTING=true" "$BIOAF_ROOT/docker/.env"
+    # --force is the explicit "yes, please rotate" path; the old values
+    # must be gone.
+    ! grep -q "will_be_regenerated" "$BIOAF_ROOT/docker/.env"
+    ! grep -q "will_also_be_regenerated" "$BIOAF_ROOT/docker/.env"
 }
 
 @test "generated .env does not contain NEXT_PUBLIC_API_URL" {

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -22,18 +22,22 @@ setup() {
     cat > "$STUBS_DIR/gcloud" <<'STUB'
 #!/usr/bin/env bash
 printf 'gcloud %s\n' "$*" >> "$CALL_LOG"
-case "$1 $2" in
-    "auth print-access-token")
+case "$1 $2 $3" in
+    "auth print-access-token "*)
         echo "ya29.fake-token"
         ;;
-    "alpha quotas")
-        # `gcloud alpha quotas info describe ... --format=...`
-        if [ -f "$FIXTURE_DIR/quota_info_$4.json" ]; then
-            cat "$FIXTURE_DIR/quota_info_$4.json"
-            exit 0
+    "alpha quotas info")
+        # `gcloud alpha quotas info describe <quota_id> --service=... --project=... --format=json`
+        # The 4th positional arg is the quota id when subcommand is "describe".
+        if [ "$3" = "info" ] && [ "$4" = "describe" ]; then
+            qid="$5"
+            if [ -f "$FIXTURE_DIR/quota_info_${qid}.json" ]; then
+                cat "$FIXTURE_DIR/quota_info_${qid}.json"
+                exit 0
+            fi
+            # Default: empty dimensionsInfos so callers parse 0.
+            echo '{"dimensionsInfos":[]}'
         fi
-        # Default: emit a benign empty quota response so callers parse 0.
-        echo '{"effectiveLimit":"0"}'
         ;;
     *) ;;
 esac
@@ -87,4 +91,58 @@ teardown() {
     run bash -c "source '$QUOTA_HELPER'; bioaf_quota_targets | wc -l"
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | tr -d ' ')" = "3" ]
+}
+
+# ---------------------------------------------------------------------------
+# bioaf_quota_get_current
+# ---------------------------------------------------------------------------
+
+@test "get_current returns the value for a project-scoped quota" {
+    cat > "$FIXTURE_DIR/quota_info_CPUS-ALL-REGIONS-per-project.json" <<'JSON'
+{
+  "name": "projects/x/locations/global/services/compute.googleapis.com/quotaInfos/CPUS-ALL-REGIONS-per-project",
+  "dimensionsInfos": [
+    { "dimensions": {}, "details": { "value": "12" } }
+  ]
+}
+JSON
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_get_current compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj"
+    [ "$status" -eq 0 ]
+    [ "$output" = "12" ]
+}
+
+@test "get_current returns the value for the matching region of a regional quota" {
+    cat > "$FIXTURE_DIR/quota_info_SSD-TOTAL-GB-per-project-region.json" <<'JSON'
+{
+  "name": "projects/x/locations/global/services/compute.googleapis.com/quotaInfos/SSD-TOTAL-GB-per-project-region",
+  "dimensionsInfos": [
+    { "dimensions": {"region": "us-east1"}, "details": { "value": "500" } },
+    { "dimensions": {"region": "us-central1"}, "details": { "value": "250" } },
+    { "dimensions": {"region": "europe-west1"}, "details": { "value": "750" } }
+  ]
+}
+JSON
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_get_current compute.googleapis.com SSD-TOTAL-GB-per-project-region my-proj us-central1"
+    [ "$status" -eq 0 ]
+    [ "$output" = "250" ]
+}
+
+@test "get_current returns 0 when the quota info has no matching region entry" {
+    cat > "$FIXTURE_DIR/quota_info_SSD-TOTAL-GB-per-project-region.json" <<'JSON'
+{ "dimensionsInfos": [
+    { "dimensions": {"region": "europe-west1"}, "details": { "value": "999" } }
+] }
+JSON
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_get_current compute.googleapis.com SSD-TOTAL-GB-per-project-region my-proj us-central1"
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+@test "get_current invokes gcloud with the expected arguments" {
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_get_current compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj"
+    [ "$status" -eq 0 ]
+    grep -q "alpha quotas info describe CPUS-ALL-REGIONS-per-project" "$CALL_LOG"
+    grep -q -- "--service=compute.googleapis.com" "$CALL_LOG"
+    grep -q -- "--project=my-proj" "$CALL_LOG"
+    grep -q -- "--format=json" "$CALL_LOG"
 }

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -75,7 +75,7 @@ done
 if [ -n "${CURL_FIXTURE:-}" ] && [ -f "$FIXTURE_DIR/$CURL_FIXTURE" ]; then
     cat "$FIXTURE_DIR/$CURL_FIXTURE"
 fi
-exit 0
+exit "${CURL_EXIT:-0}"
 STUB
     chmod +x "$STUBS_DIR/curl"
 
@@ -223,4 +223,57 @@ JSON
     run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj 64"
     [ "$status" -eq 0 ]
     grep -q "Authorization: Bearer ya29.fake-token" "$CALL_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# bioaf_quota_poll
+# ---------------------------------------------------------------------------
+
+@test "poll returns approved when grantedValue equals preferredValue" {
+    cat > "$FIXTURE_DIR/poll_approved.json" <<'JSON'
+{
+  "name": "projects/123/locations/global/quotaPreferences/bioaf-cpus-q",
+  "quotaConfig": { "preferredValue": "64", "grantedValue": "64" },
+  "reconciling": false
+}
+JSON
+    export CURL_FIXTURE=poll_approved.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_poll my-proj bioaf-cpus-q"
+    [ "$status" -eq 0 ]
+    [ "$output" = "approved" ]
+    grep -q "cloudquotas.googleapis.com/v1/projects/my-proj/locations/global/quotaPreferences/bioaf-cpus-q" "$CALL_LOG"
+}
+
+@test "poll returns pending when reconciling is true" {
+    cat > "$FIXTURE_DIR/poll_pending.json" <<'JSON'
+{
+  "name": "projects/123/locations/global/quotaPreferences/bioaf-cpus-q",
+  "quotaConfig": { "preferredValue": "64" },
+  "reconciling": true
+}
+JSON
+    export CURL_FIXTURE=poll_pending.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_poll my-proj bioaf-cpus-q"
+    [ "$status" -eq 0 ]
+    [ "$output" = "pending" ]
+}
+
+@test "poll returns pending when neither approved nor reconciling (awaiting review)" {
+    cat > "$FIXTURE_DIR/poll_review.json" <<'JSON'
+{
+  "name": "projects/123/locations/global/quotaPreferences/bioaf-cpus-q",
+  "quotaConfig": { "preferredValue": "64" }
+}
+JSON
+    export CURL_FIXTURE=poll_review.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_poll my-proj bioaf-cpus-q"
+    [ "$status" -eq 0 ]
+    [ "$output" = "pending" ]
+}
+
+@test "poll returns error when curl fails" {
+    export CURL_EXIT=22
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_poll my-proj bioaf-cpus-q"
+    [ "$status" -eq 0 ]
+    [ "$output" = "error" ]
 }

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -45,11 +45,33 @@ exit 0
 STUB
     chmod +x "$STUBS_DIR/gcloud"
 
-    # curl stub: logs the invocation and serves a fixture body keyed by a
-    # marker the test sets via $CURL_FIXTURE.
+    # curl stub: logs each arg on its own line so tests can grep for body
+    # substrings, and serves a fixture body keyed by $CURL_FIXTURE. If a
+    # `--data @<path>` arg is present, the file contents are appended to the
+    # call log so the test can assert on the request body.
     cat > "$STUBS_DIR/curl" <<'STUB'
 #!/usr/bin/env bash
-printf 'curl %s\n' "$*" >> "$CALL_LOG"
+echo "curl-call:" >> "$CALL_LOG"
+prev=""
+for a in "$@"; do
+    printf 'arg: %s\n' "$a" >> "$CALL_LOG"
+    case "$prev" in
+        --data|-d|--data-binary|--data-raw)
+            if [[ "$a" == @* ]]; then
+                body_path="${a#@}"
+                if [ -f "$body_path" ]; then
+                    echo "body-from-file:" >> "$CALL_LOG"
+                    cat "$body_path" >> "$CALL_LOG"
+                    echo >> "$CALL_LOG"
+                fi
+            else
+                echo "body:" >> "$CALL_LOG"
+                printf '%s\n' "$a" >> "$CALL_LOG"
+            fi
+            ;;
+    esac
+    prev="$a"
+done
 if [ -n "${CURL_FIXTURE:-}" ] && [ -f "$FIXTURE_DIR/$CURL_FIXTURE" ]; then
     cat "$FIXTURE_DIR/$CURL_FIXTURE"
 fi
@@ -145,4 +167,60 @@ JSON
     grep -q -- "--service=compute.googleapis.com" "$CALL_LOG"
     grep -q -- "--project=my-proj" "$CALL_LOG"
     grep -q -- "--format=json" "$CALL_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# bioaf_quota_request_increase
+# ---------------------------------------------------------------------------
+
+@test "request_increase POSTs a quota preference and returns the preference id (project-scoped)" {
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{
+  "name": "projects/123/locations/global/quotaPreferences/bioaf-cpus-abc123",
+  "quotaConfig": { "preferredValue": "64" },
+  "reconciling": true
+}
+JSON
+    export CURL_FIXTURE=post_resp.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj 64"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"bioaf-cpus-abc123"* ]]
+    # URL includes the right project and endpoint
+    grep -q "cloudquotas.googleapis.com/v1/projects/my-proj/locations/global/quotaPreferences" "$CALL_LOG"
+    # Body asserts
+    grep -q '"service":"compute.googleapis.com"' "$CALL_LOG"
+    grep -q '"quotaId":"CPUS-ALL-REGIONS-per-project"' "$CALL_LOG"
+    grep -q '"preferredValue":"64"' "$CALL_LOG"
+}
+
+@test "request_increase includes region dimension for regional quotas" {
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-ssd-zzz" }
+JSON
+    export CURL_FIXTURE=post_resp.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com SSD-TOTAL-GB-per-project-region my-proj 1024 us-central1"
+    [ "$status" -eq 0 ]
+    grep -q '"dimensions":{"region":"us-central1"}' "$CALL_LOG"
+    grep -q '"preferredValue":"1024"' "$CALL_LOG"
+}
+
+@test "request_increase omits dimensions block for project-scoped quotas" {
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-cpus-q" }
+JSON
+    export CURL_FIXTURE=post_resp.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj 64"
+    [ "$status" -eq 0 ]
+    # The body should NOT contain a dimensions key when no region is given.
+    ! grep -q '"dimensions"' "$CALL_LOG"
+}
+
+@test "request_increase sends an Authorization bearer header" {
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-cpus-q" }
+JSON
+    export CURL_FIXTURE=post_resp.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj 64"
+    [ "$status" -eq 0 ]
+    grep -q "Authorization: Bearer ya29.fake-token" "$CALL_LOG"
 }

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -364,6 +364,36 @@ JSON
     grep -q "alpha quotas info describe DISKS-TOTAL-GB-per-project-region" "$CALL_LOG"
 }
 
+# Regression: install-gcp.sh runs under `set -euo pipefail`, so any helper
+# that returns nonzero on a failure path will propagate through the
+# `pref_id=$(bioaf_quota_request_increase ...)` assignment and abort the
+# whole installer. The friendly "Could not submit" branch in ensure_all
+# would never be reached. Bug observed in the wild on a fresh project
+# where curl POST hit a 4xx; install exited silently after the
+# "Requesting an automatic quota increase from Google..." line.
+@test "ensure_all does not abort under set -e when curl POST fails" {
+    _stage_quota_limits 12 100 200
+    export CURL_EXIT=22  # curl exits 22 on any HTTP >=400 with -f
+    run bash -c "
+        set -euo pipefail
+        source '$QUOTA_HELPER'
+        BIOAF_QUOTA_POLL_INTERVAL=1 BIOAF_QUOTA_POLL_TIMEOUT=1 \
+            bioaf_quota_ensure_all my-proj us-central1
+        echo 'INSTALLER_CONTINUED'
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"INSTALLER_CONTINUED"* ]]
+    [[ "$output" == *"Could not submit"* ]]
+}
+
+@test "request_increase returns 0 with empty stdout when the POST fails" {
+    export CURL_EXIT=22
+    run bash -c "set -euo pipefail; source '$QUOTA_HELPER'; pref_id=\$(bioaf_quota_request_increase compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj 64); echo \"pref_id=[\$pref_id]\"; echo OK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pref_id=[]"* ]]
+    [[ "$output" == *"OK"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # install-gcp.sh wiring -- static checks that the integration is in place.
 # These do not execute install-gcp.sh end-to-end (which would require gcloud

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -363,3 +363,35 @@ JSON
     grep -q "alpha quotas info describe SSD-TOTAL-GB-per-project-region" "$CALL_LOG"
     grep -q "alpha quotas info describe DISKS-TOTAL-GB-per-project-region" "$CALL_LOG"
 }
+
+# ---------------------------------------------------------------------------
+# install-gcp.sh wiring -- static checks that the integration is in place.
+# These do not execute install-gcp.sh end-to-end (which would require gcloud
+# auth and a real GCP project); they catch regressions where someone deletes
+# or moves the quota wiring without updating tests.
+# ---------------------------------------------------------------------------
+
+INSTALL_GCP="$BATS_TEST_DIRNAME/../../install-gcp.sh"
+
+@test "install-gcp.sh syntax is valid" {
+    [ -f "$INSTALL_GCP" ]
+    run bash -n "$INSTALL_GCP"
+    [ "$status" -eq 0 ]
+}
+
+@test "install-gcp.sh sources installer/quota.sh" {
+    # The source line may use a variable for the path; check that both the
+    # literal path string and a `source` invocation are present.
+    grep -q "installer/quota.sh" "$INSTALL_GCP"
+    grep -E -q '^[[:space:]]*(source|\.)[[:space:]]' "$INSTALL_GCP"
+}
+
+@test "install-gcp.sh invokes bioaf_quota_ensure_all" {
+    grep -q "bioaf_quota_ensure_all" "$INSTALL_GCP"
+}
+
+@test "install-gcp.sh enables the cloudquotas API" {
+    # cloudquotas.googleapis.com must appear in the REQUIRED_APIS list so it
+    # is enabled before bioaf_quota_ensure_all runs.
+    grep -q "cloudquotas.googleapis.com" "$INSTALL_GCP"
+}

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -46,16 +46,20 @@ STUB
     chmod +x "$STUBS_DIR/gcloud"
 
     # curl stub: logs each arg on its own line so tests can grep for body
-    # substrings, and serves a fixture body keyed by $CURL_FIXTURE. If a
-    # `--data @<path>` arg is present, the file contents are appended to the
-    # call log so the test can assert on the request body.
+    # substrings, captures request bodies, and dispatches to either
+    # CURL_POST_FIXTURE / CURL_GET_FIXTURE / CURL_FIXTURE based on the HTTP
+    # method seen in -X. Tests targeting just one method-shape can set the
+    # generic CURL_FIXTURE; tests exercising the full POST-then-GET flow set
+    # both method-specific variables.
     cat > "$STUBS_DIR/curl" <<'STUB'
 #!/usr/bin/env bash
 echo "curl-call:" >> "$CALL_LOG"
 prev=""
+method="GET"
 for a in "$@"; do
     printf 'arg: %s\n' "$a" >> "$CALL_LOG"
     case "$prev" in
+        -X|--request) method="$a" ;;
         --data|-d|--data-binary|--data-raw)
             if [[ "$a" == @* ]]; then
                 body_path="${a#@}"
@@ -72,8 +76,15 @@ for a in "$@"; do
     esac
     prev="$a"
 done
-if [ -n "${CURL_FIXTURE:-}" ] && [ -f "$FIXTURE_DIR/$CURL_FIXTURE" ]; then
-    cat "$FIXTURE_DIR/$CURL_FIXTURE"
+echo "method: $method" >> "$CALL_LOG"
+fixture=""
+if [ "$method" = "POST" ]; then
+    fixture="${CURL_POST_FIXTURE:-${CURL_FIXTURE:-}}"
+else
+    fixture="${CURL_GET_FIXTURE:-${CURL_FIXTURE:-}}"
+fi
+if [ -n "$fixture" ] && [ -f "$FIXTURE_DIR/$fixture" ]; then
+    cat "$FIXTURE_DIR/$fixture"
 fi
 exit "${CURL_EXIT:-0}"
 STUB
@@ -276,4 +287,79 @@ JSON
     run bash -c "source '$QUOTA_HELPER'; bioaf_quota_poll my-proj bioaf-cpus-q"
     [ "$status" -eq 0 ]
     [ "$output" = "error" ]
+}
+
+# ---------------------------------------------------------------------------
+# bioaf_quota_ensure_all -- end-to-end orchestration
+# ---------------------------------------------------------------------------
+
+# Stage gcloud quota_info fixtures with the given current limits so each of
+# the three targets either meets or falls under its target.
+_stage_quota_limits() {
+    local cpus="$1" ssd="$2" disks="$3"
+    cat > "$FIXTURE_DIR/quota_info_CPUS-ALL-REGIONS-per-project.json" <<JSON
+{ "dimensionsInfos": [ { "dimensions": {}, "details": { "value": "$cpus" } } ] }
+JSON
+    cat > "$FIXTURE_DIR/quota_info_SSD-TOTAL-GB-per-project-region.json" <<JSON
+{ "dimensionsInfos": [ { "dimensions": {"region": "us-central1"}, "details": { "value": "$ssd" } } ] }
+JSON
+    cat > "$FIXTURE_DIR/quota_info_DISKS-TOTAL-GB-per-project-region.json" <<JSON
+{ "dimensionsInfos": [ { "dimensions": {"region": "us-central1"}, "details": { "value": "$disks" } } ] }
+JSON
+}
+
+@test "ensure_all skips quotas already at or above target and posts nothing" {
+    _stage_quota_limits 64 1024 2048
+    run bash -c "source '$QUOTA_HELPER'; BIOAF_QUOTA_POLL_INTERVAL=1 BIOAF_QUOTA_POLL_TIMEOUT=2 bioaf_quota_ensure_all my-proj us-central1"
+    [ "$status" -eq 0 ]
+    # No POST should have been issued.
+    ! grep -q "method: POST" "$CALL_LOG"
+    # Friendly message present for each.
+    [[ "$output" == *"already meets"* ]]
+}
+
+@test "ensure_all reports auto-granted when poll returns approved" {
+    _stage_quota_limits 12 100 200
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-x" }
+JSON
+    cat > "$FIXTURE_DIR/poll_approved.json" <<'JSON'
+{ "quotaConfig": { "preferredValue": "64", "grantedValue": "64" } }
+JSON
+    # Both POST and GET responses use the same body for simplicity. The
+    # POST one is required to extract a preference id; the GET one is what
+    # poll() classifies. We let the POST response also satisfy the granted
+    # check (any GET-shaped JSON is fine because grantedValue == preferredValue).
+    export CURL_POST_FIXTURE=post_resp.json
+    export CURL_GET_FIXTURE=poll_approved.json
+    run bash -c "source '$QUOTA_HELPER'; BIOAF_QUOTA_POLL_INTERVAL=1 BIOAF_QUOTA_POLL_TIMEOUT=2 bioaf_quota_ensure_all my-proj us-central1"
+    [ "$status" -eq 0 ]
+    grep -q "method: POST" "$CALL_LOG"
+    [[ "$output" == *"granted automatically"* ]]
+}
+
+@test "ensure_all reports pending review when poll never returns approved" {
+    _stage_quota_limits 12 100 200
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-x" }
+JSON
+    # Always-pending poll body (no grantedValue, reconciling true).
+    cat > "$FIXTURE_DIR/poll_pending.json" <<'JSON'
+{ "quotaConfig": { "preferredValue": "64" }, "reconciling": true }
+JSON
+    export CURL_POST_FIXTURE=post_resp.json
+    export CURL_GET_FIXTURE=poll_pending.json
+    run bash -c "source '$QUOTA_HELPER'; BIOAF_QUOTA_POLL_INTERVAL=1 BIOAF_QUOTA_POLL_TIMEOUT=2 bioaf_quota_ensure_all my-proj us-central1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Google needs to review"* ]]
+    [[ "$output" == *"This is normal"* ]]
+}
+
+@test "ensure_all visits all three target quotas" {
+    _stage_quota_limits 64 1024 2048
+    run bash -c "source '$QUOTA_HELPER'; BIOAF_QUOTA_POLL_INTERVAL=1 BIOAF_QUOTA_POLL_TIMEOUT=2 bioaf_quota_ensure_all my-proj us-central1"
+    [ "$status" -eq 0 ]
+    grep -q "alpha quotas info describe CPUS-ALL-REGIONS-per-project" "$CALL_LOG"
+    grep -q "alpha quotas info describe SSD-TOTAL-GB-per-project-region" "$CALL_LOG"
+    grep -q "alpha quotas info describe DISKS-TOTAL-GB-per-project-region" "$CALL_LOG"
 }

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Tests for installer/quota.sh -- the Cloud Quotas auto-request helper used
+# by install-gcp.sh.
+#
+# These tests run in isolation: they prepend a stubs directory to PATH so any
+# `gcloud` / `curl` calls made by the helper hit fixture-driven fakes instead
+# of real GCP. Each test asserts on either the helper's stdout or the call
+# log written by the stubs.
+
+QUOTA_HELPER="$BATS_TEST_DIRNAME/../../installer/quota.sh"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export STUBS_DIR="$TEST_DIR/stubs"
+    export CALL_LOG="$TEST_DIR/calls.log"
+    export FIXTURE_DIR="$TEST_DIR/fixtures"
+    mkdir -p "$STUBS_DIR" "$FIXTURE_DIR"
+    : > "$CALL_LOG"
+
+    # gcloud stub: logs invocation, then dispatches on subcommand to a fixture
+    # file the test has staged ahead of time.
+    cat > "$STUBS_DIR/gcloud" <<'STUB'
+#!/usr/bin/env bash
+printf 'gcloud %s\n' "$*" >> "$CALL_LOG"
+case "$1 $2" in
+    "auth print-access-token")
+        echo "ya29.fake-token"
+        ;;
+    "alpha quotas")
+        # `gcloud alpha quotas info describe ... --format=...`
+        if [ -f "$FIXTURE_DIR/quota_info_$4.json" ]; then
+            cat "$FIXTURE_DIR/quota_info_$4.json"
+            exit 0
+        fi
+        # Default: emit a benign empty quota response so callers parse 0.
+        echo '{"effectiveLimit":"0"}'
+        ;;
+    *) ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUBS_DIR/gcloud"
+
+    # curl stub: logs the invocation and serves a fixture body keyed by a
+    # marker the test sets via $CURL_FIXTURE.
+    cat > "$STUBS_DIR/curl" <<'STUB'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >> "$CALL_LOG"
+if [ -n "${CURL_FIXTURE:-}" ] && [ -f "$FIXTURE_DIR/$CURL_FIXTURE" ]; then
+    cat "$FIXTURE_DIR/$CURL_FIXTURE"
+fi
+exit 0
+STUB
+    chmod +x "$STUBS_DIR/curl"
+
+    export PATH="$STUBS_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+
+@test "quota.sh exists and is sourceable" {
+    [ -f "$QUOTA_HELPER" ]
+    run bash -c "source '$QUOTA_HELPER'"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Targets table
+# ---------------------------------------------------------------------------
+
+@test "bioaf_quota_targets emits the three required quota rows" {
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_targets"
+    [ "$status" -eq 0 ]
+    # Each row: service<TAB>quota_id<TAB>scope<TAB>preferred_value
+    [[ "$output" == *"compute.googleapis.com"*"CPUS-ALL-REGIONS-per-project"*"project"*"64"* ]]
+    [[ "$output" == *"compute.googleapis.com"*"SSD-TOTAL-GB-per-project-region"*"region"*"1024"* ]]
+    [[ "$output" == *"compute.googleapis.com"*"DISKS-TOTAL-GB-per-project-region"*"region"*"2048"* ]]
+}
+
+@test "bioaf_quota_targets emits exactly three rows" {
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_targets | wc -l"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | tr -d ' ')" = "3" ]
+}

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -394,6 +394,27 @@ JSON
     [[ "$output" == *"OK"* ]]
 }
 
+@test "request_increase surfaces the API error message when the response is a Google error body" {
+    cat > "$FIXTURE_DIR/post_resp_err.json" <<'JSON'
+{"error":{"code":400,"message":"Quota id 'BAD-ID' is not valid for service 'compute.googleapis.com'","status":"INVALID_ARGUMENT"}}
+JSON
+    # No CURL_EXIT: curl returns 0 (no -f), body is the error JSON.
+    export CURL_POST_FIXTURE=post_resp_err.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com BAD-ID my-proj 64"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Quota id 'BAD-ID' is not valid"* ]]
+}
+
+@test "request_increase yields empty stdout (no false pref id) when API returns an error body" {
+    cat > "$FIXTURE_DIR/post_resp_err.json" <<'JSON'
+{"error":{"code":400,"message":"bad quota id"}}
+JSON
+    export CURL_POST_FIXTURE=post_resp_err.json
+    run bash -c "set -euo pipefail; source '$QUOTA_HELPER'; pref_id=\$(bioaf_quota_request_increase compute.googleapis.com BAD-ID my-proj 64 2>/dev/null); echo \"pref_id=[\$pref_id]\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pref_id=[]"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # install-gcp.sh wiring -- static checks that the integration is in place.
 # These do not execute install-gcp.sh end-to-end (which would require gcloud

--- a/tests/shell/test_quota.bats
+++ b/tests/shell/test_quota.bats
@@ -26,6 +26,11 @@ case "$1 $2 $3" in
     "auth print-access-token "*)
         echo "ya29.fake-token"
         ;;
+    "config get-value account")
+        # Tests can override via $GCLOUD_ACCOUNT_FIXTURE; default is a
+        # syntactically-valid but obviously-fake address.
+        echo "${GCLOUD_ACCOUNT_FIXTURE:-tester@example.com}"
+        ;;
     "alpha quotas info")
         # `gcloud alpha quotas info describe <quota_id> --service=... --project=... --format=json`
         # The 4th positional arg is the quota id when subcommand is "describe".
@@ -413,6 +418,78 @@ JSON
     run bash -c "set -euo pipefail; source '$QUOTA_HELPER'; pref_id=\$(bioaf_quota_request_increase compute.googleapis.com BAD-ID my-proj 64 2>/dev/null); echo \"pref_id=[\$pref_id]\""
     [ "$status" -eq 0 ]
     [[ "$output" == *"pref_id=[]"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# contactEmail is required by Cloud Quotas: every QuotaPreference body
+# must carry one. We learned this the hard way after shipping the helper
+# without it -- the API returned "Contact email must be set in order to
+# increase quota value." Cover the field's presence and source-of-truth.
+# ---------------------------------------------------------------------------
+
+@test "request_increase includes contactEmail in the POST body when given" {
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-x" }
+JSON
+    export CURL_POST_FIXTURE=post_resp.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj 64 '' 'someone@example.com'"
+    [ "$status" -eq 0 ]
+    grep -q '"contactEmail":"someone@example.com"' "$CALL_LOG"
+}
+
+@test "request_increase passes contactEmail alongside region for regional quotas" {
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-x" }
+JSON
+    export CURL_POST_FIXTURE=post_resp.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com SSD-TOTAL-GB-per-project-region my-proj 1024 us-central1 'someone@example.com'"
+    [ "$status" -eq 0 ]
+    grep -q '"contactEmail":"someone@example.com"' "$CALL_LOG"
+    grep -q '"dimensions":{"region":"us-central1"}' "$CALL_LOG"
+}
+
+@test "request_increase omits contactEmail when empty arg given" {
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-x" }
+JSON
+    export CURL_POST_FIXTURE=post_resp.json
+    run bash -c "source '$QUOTA_HELPER'; bioaf_quota_request_increase compute.googleapis.com CPUS-ALL-REGIONS-per-project my-proj 64"
+    [ "$status" -eq 0 ]
+    ! grep -q '"contactEmail"' "$CALL_LOG"
+}
+
+@test "ensure_all resolves contactEmail from gcloud and threads it through to request_increase" {
+    _stage_quota_limits 12 100 200
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-x" }
+JSON
+    cat > "$FIXTURE_DIR/poll_approved.json" <<'JSON'
+{ "quotaConfig": { "preferredValue": "64", "grantedValue": "64" } }
+JSON
+    export CURL_POST_FIXTURE=post_resp.json
+    export CURL_GET_FIXTURE=poll_approved.json
+    export GCLOUD_ACCOUNT_FIXTURE='operator@example.com'
+    run bash -c "source '$QUOTA_HELPER'; BIOAF_QUOTA_POLL_INTERVAL=1 BIOAF_QUOTA_POLL_TIMEOUT=2 bioaf_quota_ensure_all my-proj us-central1"
+    [ "$status" -eq 0 ]
+    grep -q '"contactEmail":"operator@example.com"' "$CALL_LOG"
+}
+
+@test "ensure_all handles unset gcloud account by omitting contactEmail (api will then return its error)" {
+    _stage_quota_limits 12 100 200
+    cat > "$FIXTURE_DIR/post_resp.json" <<'JSON'
+{ "name": "projects/123/locations/global/quotaPreferences/bioaf-x" }
+JSON
+    cat > "$FIXTURE_DIR/poll_approved.json" <<'JSON'
+{ "quotaConfig": { "preferredValue": "64", "grantedValue": "64" } }
+JSON
+    export CURL_POST_FIXTURE=post_resp.json
+    export CURL_GET_FIXTURE=poll_approved.json
+    # gcloud emits "(unset)" when no account is configured; helper should
+    # treat that as empty, not as a literal contact email.
+    export GCLOUD_ACCOUNT_FIXTURE='(unset)'
+    run bash -c "source '$QUOTA_HELPER'; BIOAF_QUOTA_POLL_INTERVAL=1 BIOAF_QUOTA_POLL_TIMEOUT=2 bioaf_quota_ensure_all my-proj us-central1"
+    [ "$status" -eq 0 ]
+    ! grep -q '"contactEmail"' "$CALL_LOG"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **install-gcp.sh now auto-requests the GCP quotas bioAF needs at install time.** Resolves to-resolve.md issue #3 (CPUs) and its 2026-05-07 SSD/DISKS expansion. After region selection, the installer files `QuotaPreference`s for `CPUS-ALL-REGIONS-per-project=64`, `SSD-TOTAL-GB-per-project-region=1024`, and `DISKS-TOTAL-GB-per-project-region=2048`, polls briefly for auto-approval, and surfaces a clear "Google needs to review and approve, this is normal" message if review is needed. Logic lives in `installer/quota.sh` (sourced from a local clone or fetched over HTTPS for `curl|bash` users).
- **Two installer bugs found while user-testing on a fresh project, both with regression coverage:** (1) `set -euo pipefail` was aborting the installer silently when the API returned a 4xx, because curl's nonzero exit propagated through the orchestrator's `pref_id=$(...)` assignment; the helper now always returns 0 and signals failure via empty stdout, matching `bioaf_quota_poll`'s convention. (2) Cloud Quotas requires a `contactEmail` field on every `QuotaPreference` body ("Contact email must be set in order to increase quota value") and the helper was not sending it; the orchestrator now resolves the gcloud-active account and threads it through, with `(unset)` handled cleanly.
- **API error messages are now surfaced verbatim** instead of being collapsed into a generic "request failed", so a 4xx response shows the API's `code`/`status`/`message` and the user can act on it.
- **Shell test suite refresh.** `tests/shell/test_bioaf.bats` and `tests/shell/test_install.bats` had not been updated since their original commit (#58); three tests were checking for behavior that no longer exists (`create-admin` command, macOS-permissive `check-prereqs`, `generate-env` refuse-to-overwrite gate). All three rewritten to pin the current contracts. No production code touched in this section.

## Test plan

- [x] `bats tests/shell/` -- 51/51 passing on this branch (was 39/42 with 3 pre-existing rot failures on main).
- [x] `shellcheck installer/quota.sh` -- clean.
- [x] `bash -n install-gcp.sh` -- syntax OK after the wiring change.
- [x] `cd backend && ruff check . && ruff format --check .` -- clean.
- [x] `cd frontend && npx tsc --noEmit` -- clean.
- [x] **End-to-end manual test on a fresh GCP project** (operator-confirmed):
    - First failed run reproduced the silent-abort bug, validating the regression test.
    - Second run surfaced the verbatim Cloud Quotas API error ("Contact email must be set..."), validating the error-surfacing change.
    - Third run after the contactEmail fix went through cleanly: `CPUS-ALL-REGIONS-per-project` skipped (already at 64), regional SSD / DISKS requests filed and reported back appropriately.
- [ ] Reviewer to spot-check that the curl-piped install path still loads `installer/quota.sh` from the GitHub raw URL pinned to `main` (the local-clone path is what gets exercised in tests).