### PR TITLE
v0.11.4: dedicated bioaf-system GKE node pool

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,88 @@
 # Release Notes
 
+## v0.11.4
+
+Point release that adds a dedicated `bioaf-system` GKE node pool to host
+the cluster's system addons (calico-typha, fluentbit, gmp-operator,
+gke-metadata-server, etc.) on its own infrastructure rather than
+piggy-backing on whichever user pool happens to be alive. Touches GKE
+topology only -- no schema changes, no migration required.
+
+### `bioaf-system` always-on pool
+
+Resolves the dedicated-system-pool follow-up flagged in to-resolve.md's
+second-round status. Before this release, calico-typha's 2-replica
+anti-affinity forced the `bioaf-pipelines` pool to spin up *two*
+`n2-highmem-16` nodes whenever any pipeline ran -- one for the pipeline
+pod, one purely for system addons sitting at ~10% disk utilization and
+otherwise wasted. Pipelines and interactive pools could not actually
+scale to zero between runs, because cluster-scoped Deployments
+(calico-typha, kube-dns, konnectivity-agent, etc.) needed a host.
+
+The new `bioaf-system` pool gives those addons a dedicated home:
+
+- 1 always-on `e2-standard-2` node (2 dedicated vCPU, 8 GiB RAM)
+- 30 GB `pd-standard` boot disk (does not consume `SSD_TOTAL_GB` quota
+  the way `pd-ssd` would)
+- On-demand, not spot -- system addons must not be evicted at random
+- `total_min_node_count = 1` / `total_max_node_count = 2` with
+  `location_policy = "ANY"`, so the autoscaler places the floor node
+  in whichever zone has `e2-standard-2` capacity at deploy time
+  (regional cluster, not multi-zone-redundant -- HA was never an
+  architected goal for cluster workloads, see commits `bde4d604` and
+  `c399ee21`)
+- No taint: GKE-managed DaemonSets do not reliably tolerate custom
+  taints. The pool is sized so Nextflow process pods do not fit and
+  fall back to the pipelines pool by resource constraint instead.
+
+With the system pool taking the addon load, both `bioaf-pipelines` and
+`bioaf-interactive` now genuinely scale to zero between workloads.
+Cost: ~$25/mo for the always-on system pool, replacing what was
+previously a ~$70-100/mo wasted node held by addons on the pipelines or
+interactive pool.
+
+Two new module variables (`k8s_system_machine_type`, `k8s_system_max_nodes`)
+expose machine-type and max-node tuning while keeping the always-on
+floor at 1. They are not yet wired into `platform_config` or the
+deploy wizard -- defaults take effect on every install. A future
+release may surface them as advanced options.
+
+### How sizing landed where it landed
+
+The right machine type took three iterations and is worth recording so
+the next person tuning this does not relearn it the hard way:
+
+- **e2-small** (first attempt): 940m CPU / 1.4 GiB allocatable. Pinned
+  the autoscaler at max=2 in every active zone -- one CPU-saturated
+  node could not host the full DaemonSet set, so a second came up.
+  Total: 4 nodes.
+- **e2-medium** (second attempt): same 940m CPU allocatable, just more
+  memory. Both `e2-small` and `e2-medium` are *shared-core* burstable
+  types: they advertise 2 vCPU max but baseline-share 0.5 / 1.0 vCPU
+  respectively, and Kubernetes treats only the burstable max as
+  `allocatable`. The autoscaler packs them identically. Same 4-node
+  outcome.
+- **e2-standard-2** (final): 2 *dedicated* vCPU, 8 GiB RAM, ~1.9 vCPU
+  allocatable. One node per zone fits the addon set. Combined with
+  `total_min_node_count`/`total_max_node_count` (global counts rather
+  than per-zone), drops to 1 node total.
+
+Use of `total_*_node_count` instead of `min_node_count`/`max_node_count`
+is what allows a regional pool to honor "1 node, anywhere with capacity"
+semantics. Per-zone counts would have multiplied the floor across every
+zone in `node_locations`.
+
+### What's still outstanding from to-resolve.md
+
+- **Issue #1 final mile**: the public `bioaf-base` GCE work-node image
+  still needs to be built and published. Backend seeder is in place
+  and gated on `BIOAF_BASE_WORK_NODE_IMAGE_URI`, so this is a one-time
+  operator task.
+- **Issue #3 bonus**: `_extract_pod_termination_info` does not yet
+  surface `Unschedulable: ...` reasons (e.g. `QUOTA_EXCEEDED`,
+  `pod didn't trigger scale-up`) in the run-log view. Will be a
+  separate follow-up branch.
+
 ## v0.11.3
 
 Point release that automates the GCP quota-increase requests bioAF

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioaf-backend"
-version = "0.11.3"
+version = "0.11.4"
 description = "bioAF control plane backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/terraform/modules/compute/main.tf
+++ b/backend/terraform/modules/compute/main.tf
@@ -82,20 +82,30 @@ resource "google_container_node_pool" "pipelines" {
 
 # --- System Node Pool ---
 #
-# Always-on (min=1) pool sized for GKE-managed addons only:
-# calico-typha, fluentbit, gmp-operator, gke-metadata-server, etc.
-# Without this pool, those DaemonSets piggy-back on whichever user pool
-# happens to have a node up; calico-typha's 2-replica anti-affinity then
-# pins the pipelines pool at 2 nodes whenever any pipeline runs, wasting
-# one full n2-highmem-16 node on system addons. With this pool, the
-# pipelines and interactive pools can genuinely scale to zero.
+# Always-on pool sized for GKE-managed addons only: calico-typha,
+# fluentbit, gmp-operator, gke-metadata-server, etc. Without this pool,
+# those DaemonSets piggy-back on whichever user pool happens to have a
+# node up; calico-typha's 2-replica anti-affinity then pins the pipelines
+# pool at 2 nodes whenever any pipeline runs, wasting one full
+# n2-highmem-16 node on system addons. With this pool, the pipelines and
+# interactive pools can genuinely scale to zero.
+#
+# Autoscaling uses total_min_node_count / total_max_node_count (global
+# counts across the regional cluster's zones), not min_node_count /
+# max_node_count (per-zone). Combined with location_policy=ANY and the
+# default empty node_locations (= all cluster zones), this lets the
+# autoscaler place the floor node in whichever zone has e2-standard-2
+# capacity at deploy time, instead of forcing one node per active zone.
+# total_min=1 keeps a single node always alive for the addons; HA was
+# never an architected goal for the cluster's workloads (see commits
+# bde4d604, c399ee21 -- multi-zone was for capacity fallback).
 #
 # Disk: pd-standard, not pd-ssd, so the always-on 30GB does not consume
 # SSD_TOTAL_GB regional quota (already pressured by pipeline pool boot
 # disks). On-demand, not spot -- system addons must not be evicted.
 # No taint: GKE-managed DaemonSets do not reliably tolerate custom
 # taints. Nextflow process pods are kept off this pool naturally by
-# its small size (e2-small allocatable < typical pipeline requests).
+# its small size (e2-standard-2 allocatable < typical pipeline requests).
 
 resource "google_container_node_pool" "system" {
   name           = "bioaf-system"
@@ -105,9 +115,9 @@ resource "google_container_node_pool" "system" {
   node_locations = var.k8s_node_zones
 
   autoscaling {
-    min_node_count  = 1
-    max_node_count  = var.k8s_system_max_nodes
-    location_policy = "ANY"
+    total_min_node_count = 1
+    total_max_node_count = var.k8s_system_max_nodes
+    location_policy      = "ANY"
   }
 
   node_config {

--- a/backend/terraform/modules/compute/main.tf
+++ b/backend/terraform/modules/compute/main.tf
@@ -80,6 +80,51 @@ resource "google_container_node_pool" "pipelines" {
   }
 }
 
+# --- System Node Pool ---
+#
+# Always-on (min=1) pool sized for GKE-managed addons only:
+# calico-typha, fluentbit, gmp-operator, gke-metadata-server, etc.
+# Without this pool, those DaemonSets piggy-back on whichever user pool
+# happens to have a node up; calico-typha's 2-replica anti-affinity then
+# pins the pipelines pool at 2 nodes whenever any pipeline runs, wasting
+# one full n2-highmem-16 node on system addons. With this pool, the
+# pipelines and interactive pools can genuinely scale to zero.
+#
+# Disk: pd-standard, not pd-ssd, so the always-on 30GB does not consume
+# SSD_TOTAL_GB regional quota (already pressured by pipeline pool boot
+# disks). On-demand, not spot -- system addons must not be evicted.
+# No taint: GKE-managed DaemonSets do not reliably tolerate custom
+# taints. Nextflow process pods are kept off this pool naturally by
+# its small size (e2-small allocatable < typical pipeline requests).
+
+resource "google_container_node_pool" "system" {
+  name           = "bioaf-system"
+  cluster        = google_container_cluster.bioaf.id
+  project        = var.project_id
+  location       = var.region
+  node_locations = var.k8s_node_zones
+
+  autoscaling {
+    min_node_count  = 1
+    max_node_count  = var.k8s_system_max_nodes
+    location_policy = "ANY"
+  }
+
+  node_config {
+    machine_type = var.k8s_system_machine_type
+    disk_size_gb = 30
+    disk_type    = "pd-standard"
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      "bioaf.io/pool" = "system"
+    }
+  }
+}
+
 # --- Interactive Node Pool ---
 
 resource "google_container_node_pool" "interactive" {
@@ -172,6 +217,7 @@ resource "google_service_account_iam_member" "notebook_runner_workload_identity"
     google_container_cluster.bioaf,
     google_container_node_pool.pipelines,
     google_container_node_pool.interactive,
+    google_container_node_pool.system,
   ]
 }
 

--- a/backend/terraform/modules/compute/variables.tf
+++ b/backend/terraform/modules/compute/variables.tf
@@ -62,8 +62,8 @@ variable "k8s_interactive_max_nodes" {
 
 variable "k8s_system_machine_type" {
   type        = string
-  default     = "e2-medium"
-  description = "Machine type for the always-on system node pool that hosts GKE addons (calico-typha, fluentbit, gmp-operator, gke-metadata-server, etc.). e2-medium (~1.9 vCPU, 3.5 GiB allocatable) gives one-node-per-zone headroom for the full addon DaemonSet set; e2-small was too tight and forced the autoscaler to max in every active zone. Still small enough that Nextflow process pods do not fit and fall back to the pipelines pool."
+  default     = "e2-standard-2"
+  description = "Machine type for the always-on system node pool that hosts GKE addons (calico-typha, fluentbit, gmp-operator, gke-metadata-server, etc.). e2-standard-2 has 2 dedicated vCPU and 8 GiB RAM (~1.9 CPU / ~7 GiB allocatable) -- enough headroom that one node per zone absorbs the full addon DaemonSet set. Avoid shared-core burstable types (e2-small, e2-medium): Kubernetes only sees the 940m burstable max as allocatable on either, so the autoscaler packs them identically and pins to max=2 per zone. Still small enough that Nextflow process pods cannot fit and fall back to the pipelines pool."
 }
 
 variable "k8s_system_max_nodes" {

--- a/backend/terraform/modules/compute/variables.tf
+++ b/backend/terraform/modules/compute/variables.tf
@@ -60,6 +60,18 @@ variable "k8s_interactive_max_nodes" {
   description = "Maximum number of nodes in the interactive autoscaler"
 }
 
+variable "k8s_system_machine_type" {
+  type        = string
+  default     = "e2-small"
+  description = "Machine type for the always-on system node pool that hosts GKE addons (calico-typha, fluentbit, gmp-operator, etc.). Sized so Nextflow process pods do not fit and fall back to the pipelines pool."
+}
+
+variable "k8s_system_max_nodes" {
+  type        = number
+  default     = 2
+  description = "Maximum number of nodes in the system pool autoscaler. Min is hardcoded at 1 -- the pool must always have a home for system addons."
+}
+
 variable "bioaf_bootstrap_sa_email" {
   type        = string
   default     = ""

--- a/backend/terraform/modules/compute/variables.tf
+++ b/backend/terraform/modules/compute/variables.tf
@@ -62,8 +62,8 @@ variable "k8s_interactive_max_nodes" {
 
 variable "k8s_system_machine_type" {
   type        = string
-  default     = "e2-small"
-  description = "Machine type for the always-on system node pool that hosts GKE addons (calico-typha, fluentbit, gmp-operator, etc.). Sized so Nextflow process pods do not fit and fall back to the pipelines pool."
+  default     = "e2-medium"
+  description = "Machine type for the always-on system node pool that hosts GKE addons (calico-typha, fluentbit, gmp-operator, gke-metadata-server, etc.). e2-medium (~1.9 vCPU, 3.5 GiB allocatable) gives one-node-per-zone headroom for the full addon DaemonSet set; e2-small was too tight and forced the autoscaler to max in every active zone. Still small enough that Nextflow process pods do not fit and fall back to the pipelines pool."
 }
 
 variable "k8s_system_max_nodes" {

--- a/backend/tests/test_compute_terraform.py
+++ b/backend/tests/test_compute_terraform.py
@@ -24,11 +24,12 @@ def test_compute_module_creates_cluster_and_pools():
     variables_tf = (COMPUTE_MODULE_DIR / "variables.tf").read_text()
     outputs_tf = (COMPUTE_MODULE_DIR / "outputs.tf").read_text()
 
-    # main.tf should define a GKE cluster and two node pools
+    # main.tf should define a GKE cluster and three node pools
     assert 'resource "google_container_cluster"' in main_tf, "Should define a GKE cluster resource"
     assert 'resource "google_container_node_pool"' in main_tf, "Should define node pool resources"
     assert "bioaf-pipelines" in main_tf, "Should have a pipelines node pool"
     assert "bioaf-interactive" in main_tf, "Should have an interactive node pool"
+    assert "bioaf-system" in main_tf, "Should have a system node pool for GKE addons"
 
     # Workload Identity should be configured
     assert "workload_identity_config" in main_tf, "Should configure Workload Identity"
@@ -47,9 +48,72 @@ def test_compute_module_creates_cluster_and_pools():
         "k8s_pipeline_use_spot",
         "k8s_interactive_machine_type",
         "k8s_interactive_max_nodes",
+        "k8s_system_machine_type",
+        "k8s_system_max_nodes",
     ):
         assert f'"{var_name}"' in variables_tf, f"variables.tf should define var {var_name}"
 
     # outputs.tf should define expected outputs
     for output_name in ("cluster_name", "cluster_endpoint", "cluster_ca_cert"):
         assert f'"{output_name}"' in outputs_tf, f"outputs.tf should define output {output_name}"
+
+
+def test_system_pool_is_always_on_and_uses_pd_standard():
+    """The bioaf-system pool must stay scaled up so GKE addons (calico-typha,
+    fluentbit, gmp-operator, etc.) always have a home, and must not consume
+    SSD_TOTAL_GB quota -- that quota is already pressured by pipeline pool
+    boot disks.
+    """
+    main_tf = (COMPUTE_MODULE_DIR / "main.tf").read_text()
+
+    # Locate the bioaf-system node pool block
+    system_pool_marker = 'name           = "bioaf-system"'
+    assert system_pool_marker in main_tf, "bioaf-system pool resource must exist"
+
+    start = main_tf.index(system_pool_marker)
+    # Take a generous window covering the resource body
+    end = main_tf.find('resource "', start + 1)
+    if end == -1:
+        end = len(main_tf)
+    system_block = main_tf[start:end]
+
+    # Always-on: min_node_count must be >= 1 so addons never lose their home.
+    assert "min_node_count  = 1" in system_block or "min_node_count = 1" in system_block, (
+        "bioaf-system pool must have min_node_count = 1 (always-on)"
+    )
+
+    # Disk type: pd-standard so we don't burn SSD_TOTAL_GB quota.
+    assert 'disk_type    = "pd-standard"' in system_block or 'disk_type = "pd-standard"' in system_block, (
+        "bioaf-system pool must use pd-standard disks"
+    )
+
+    # No spot: system addons cannot be evicted at random.
+    # spot defaults to false, so just assert it is not set to true.
+    assert "spot         = true" not in system_block and "spot = true" not in system_block, (
+        "bioaf-system pool must not use spot instances"
+    )
+
+    # Pool label so node selectors can target it explicitly when needed.
+    assert '"bioaf.io/pool" = "system"' in system_block, "bioaf-system pool must carry the bioaf.io/pool=system label"
+
+
+def test_notebook_runner_workload_identity_depends_on_system_pool():
+    """The notebook_runner_workload_identity binding's depends_on must include
+    the system pool, mirroring the existing pattern for the other two pools.
+    Without this, Terraform may schedule the binding before the WI pool is
+    fully registered and produce 'Identity Pool does not exist' errors.
+    """
+    main_tf = (COMPUTE_MODULE_DIR / "main.tf").read_text()
+
+    binding_marker = 'resource "google_service_account_iam_member" "notebook_runner_workload_identity"'
+    assert binding_marker in main_tf, "notebook_runner_workload_identity binding must exist"
+
+    start = main_tf.index(binding_marker)
+    end = main_tf.find('resource "', start + 1)
+    if end == -1:
+        end = len(main_tf)
+    binding_block = main_tf[start:end]
+
+    assert "google_container_node_pool.system" in binding_block, (
+        "notebook_runner_workload_identity must depend_on the system pool"
+    )

--- a/backend/tests/test_compute_terraform.py
+++ b/backend/tests/test_compute_terraform.py
@@ -4,6 +4,7 @@
 2. test_compute_module_creates_cluster_and_pools - Parse HCL and verify expected resources.
 """
 
+import re
 from pathlib import Path
 
 
@@ -63,6 +64,12 @@ def test_system_pool_is_always_on_and_uses_pd_standard():
     fluentbit, gmp-operator, etc.) always have a home, and must not consume
     SSD_TOTAL_GB quota -- that quota is already pressured by pipeline pool
     boot disks.
+
+    Uses total_min_node_count / total_max_node_count (global counts) rather
+    than min_node_count / max_node_count (per-zone). With ANY location
+    policy and a regional cluster, this lets the autoscaler place the
+    single floor node in whichever zone has e2-standard-2 capacity at
+    deploy time, rather than forcing one node per active zone.
     """
     main_tf = (COMPUTE_MODULE_DIR / "main.tf").read_text()
 
@@ -77,9 +84,26 @@ def test_system_pool_is_always_on_and_uses_pd_standard():
         end = len(main_tf)
     system_block = main_tf[start:end]
 
-    # Always-on: min_node_count must be >= 1 so addons never lose their home.
-    assert "min_node_count  = 1" in system_block or "min_node_count = 1" in system_block, (
-        "bioaf-system pool must have min_node_count = 1 (always-on)"
+    # Always-on, single-node global floor (not per-zone).
+    assert "total_min_node_count = 1" in system_block, (
+        "bioaf-system pool must use total_min_node_count = 1 (global, not per-zone)"
+    )
+    # The per-zone min_node_count knob must NOT be present -- it conflicts
+    # with total_min_node_count and would re-introduce per-zone semantics.
+    # Match it at line-start (with indent) so it doesn't false-positive on
+    # the "total_min_node_count" substring.
+    assert re.search(r"^\s+min_node_count\s*=", system_block, re.MULTILINE) is None, (
+        "bioaf-system pool must not set per-zone min_node_count; use total_min_node_count instead"
+    )
+    assert re.search(r"^\s+max_node_count\s*=", system_block, re.MULTILINE) is None, (
+        "bioaf-system pool must not set per-zone max_node_count; use total_max_node_count instead"
+    )
+
+    # Capacity-based zone selection. terraform fmt aligns `=` columns
+    # within a block, so the gap between `location_policy` and `=` is
+    # variable; match with regex.
+    assert re.search(r'location_policy\s*=\s*"ANY"', system_block), (
+        "bioaf-system pool must use location_policy=ANY so the autoscaler picks the zone with capacity"
     )
 
     # Disk type: pd-standard so we don't burn SSD_TOTAL_GB quota.

--- a/backend/tests/test_compute_terraform.py
+++ b/backend/tests/test_compute_terraform.py
@@ -97,17 +97,20 @@ def test_system_pool_is_always_on_and_uses_pd_standard():
     assert '"bioaf.io/pool" = "system"' in system_block, "bioaf-system pool must carry the bioaf.io/pool=system label"
 
 
-def test_system_pool_default_machine_is_e2_medium():
-    """Default machine type for the system pool must be e2-medium.
+def test_system_pool_default_machine_is_e2_standard_2():
+    """Default machine type for the system pool must be e2-standard-2.
 
-    e2-small (940m CPU, 1.4 GiB allocatable) was tried first but system
-    DaemonSets (calico-node, fluentbit-gke, gke-metrics-agent, gmp-system
-    collectors, gke-metadata-server, netd, ip-masq-agent, pdcsi-node,
-    node-local-dns, kube-proxy) plus per-node container runtime overhead
-    pushed CPU requests to ~99% on a single node, forcing the autoscaler
-    to max=2 in every active zone. e2-medium (~1.9 vCPU, ~3.5 GiB) gives
-    enough headroom that one node per zone covers the addon set, so the
-    pool sits at its minimum (1 per zone) instead of its ceiling.
+    Both e2-small and e2-medium are shared-core burstable machine types:
+    they report 2 vCPU max but baseline-share only 0.5 / 1.0 vCPU
+    respectively. Kubernetes treats the burstable max as `allocatable`
+    and shows ~940m for both, so the autoscaler packs the same number
+    of pods per node at either size. We confirmed this empirically on
+    fresh deploys -- e2-medium pinned at 4 nodes (2 per zone, max=2)
+    just like e2-small did, with CPU at 75-94% per node.
+
+    e2-standard-2 has 2 *dedicated* vCPU and 8 GiB RAM (~1.9 CPU /
+    ~7 GiB allocatable), enough that one node per zone absorbs the full
+    addon DaemonSet set. Cost is roughly equal to 4 x e2-medium.
     """
     variables_tf = (COMPUTE_MODULE_DIR / "variables.tf").read_text()
 
@@ -120,8 +123,8 @@ def test_system_pool_default_machine_is_e2_medium():
         end = len(variables_tf)
     block = variables_tf[start:end]
 
-    assert 'default     = "e2-medium"' in block or 'default = "e2-medium"' in block, (
-        "k8s_system_machine_type default must be e2-medium"
+    assert 'default     = "e2-standard-2"' in block or 'default = "e2-standard-2"' in block, (
+        "k8s_system_machine_type default must be e2-standard-2"
     )
 
 

--- a/backend/tests/test_compute_terraform.py
+++ b/backend/tests/test_compute_terraform.py
@@ -97,6 +97,34 @@ def test_system_pool_is_always_on_and_uses_pd_standard():
     assert '"bioaf.io/pool" = "system"' in system_block, "bioaf-system pool must carry the bioaf.io/pool=system label"
 
 
+def test_system_pool_default_machine_is_e2_medium():
+    """Default machine type for the system pool must be e2-medium.
+
+    e2-small (940m CPU, 1.4 GiB allocatable) was tried first but system
+    DaemonSets (calico-node, fluentbit-gke, gke-metrics-agent, gmp-system
+    collectors, gke-metadata-server, netd, ip-masq-agent, pdcsi-node,
+    node-local-dns, kube-proxy) plus per-node container runtime overhead
+    pushed CPU requests to ~99% on a single node, forcing the autoscaler
+    to max=2 in every active zone. e2-medium (~1.9 vCPU, ~3.5 GiB) gives
+    enough headroom that one node per zone covers the addon set, so the
+    pool sits at its minimum (1 per zone) instead of its ceiling.
+    """
+    variables_tf = (COMPUTE_MODULE_DIR / "variables.tf").read_text()
+
+    # Find the k8s_system_machine_type variable block
+    marker = 'variable "k8s_system_machine_type"'
+    assert marker in variables_tf, "k8s_system_machine_type variable must exist"
+    start = variables_tf.index(marker)
+    end = variables_tf.find("\nvariable ", start + 1)
+    if end == -1:
+        end = len(variables_tf)
+    block = variables_tf[start:end]
+
+    assert 'default     = "e2-medium"' in block or 'default = "e2-medium"' in block, (
+        "k8s_system_machine_type default must be e2-medium"
+    )
+
+
 def test_notebook_runner_workload_identity_depends_on_system_pool():
     """The notebook_runner_workload_identity binding's depends_on must include
     the system pool, mirroring the existing pattern for the other two pools.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bioaf-frontend",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Adds a dedicated `bioaf-system` GKE node pool so cluster-wide system addons (calico-typha, fluentbit, gmp-operator, gke-metadata-server, kube-dns, konnectivity-agent, etc.) stop piggy-backing on the user pools.
- Both `bioaf-pipelines` and `bioaf-interactive` now genuinely scale to zero between workloads -- previously calico-typha's 2-replica anti-affinity forced the pipelines pool to spin up two `n2-highmem-16` nodes whenever any pipeline ran, one purely for addons.
- System pool: 1 always-on `e2-standard-2` node, 30 GB `pd-standard`, on-demand. `total_min_node_count = 1` / `total_max_node_count = 2` with `location_policy = "ANY"` -- the autoscaler places the floor node in whichever zone has capacity at deploy time, on a regional cluster (HA was never an architected goal for cluster workloads, see commits bde4d604 and c399ee21).

Resolves the dedicated-system-pool follow-up from `documentation/to-resolve.md`'s second-round status.

## Sizing iterations on this branch

The right machine type took three rounds and is recorded in RELEASE_NOTES.md so the next person tuning this does not relearn it the hard way:

1. `e2-small` (initial): pinned the autoscaler at max=2 in every active zone (4 nodes total). 940m CPU allocatable; one node could not host the full DaemonSet set, so a second came up.
2. `e2-medium`: same 940m CPU allocatable -- both shared-core burstable types (2 vCPU max, 0.5/1.0 vCPU sustained baseline). Kubernetes treats only the burstable max as `allocatable`, so the autoscaler packed them identically. Same 4-node outcome.
3. `e2-standard-2` (final): 2 *dedicated* vCPU, ~1.9 vCPU allocatable. One node per zone fits the addon set; combined with `total_*_node_count` instead of per-zone `min_node_count`/`max_node_count`, drops to 1 node total.

## Test plan

- [x] `backend/tests/test_compute_terraform.py` -- new tests for system-pool invariants (always-on, pd-standard, no spot, `total_*_node_count`, `location_policy=ANY`, e2-standard-2 default)
- [x] Full backend test suite: `2097 passed`
- [x] `ruff format --check .`, `ruff check .`, `mypy . --ignore-missing-imports` -- all clean
- [x] Frontend `npx tsc --noEmit` -- clean
- [x] `markdownlint-cli2 RELEASE_NOTES.md` -- clean
- [ ] Live verification on the user's redeploy (in progress; gcloud reauth pending)