### PR TITLE
docs: add notice that repo has moved to bioAF/bioAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> ## This repository has moved
+>
+> **All new development of bioAF has moved to [github.com/bioAF/bioAF](https://github.com/bioAF/bioAF).**
+>
+> This repository is preserved for historical reference only. Issues, pull requests, and updates should be directed to the new repository. The documentation below is retained as-is and may be out of date.
+
+---
+
 <p align="center">
   <img src="assets/mascot.png" alt="bioAF" width="200" />
 </p>


### PR DESCRIPTION
Adds a header to the README directing users to the new repository at github.com/bioAF/bioAF for all new development. Preserves the existing documentation as historical reference.

## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Infrastructure / Terraform
- [ ] Documentation
- [ ] CI / tooling
- [ ] Refactor (no functional change)

## Related Issues

<!-- Link issues: Fixes #123, Relates to #456 -->

## What Changed

<!-- Bullet the key changes. For Terraform changes, include the affected components. -->

## How to Test

<!-- Steps a reviewer can follow to verify this works. -->

1. ...

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] My code follows the project's style conventions
- [ ] I have added/updated tests for my changes
- [ ] All new and existing tests pass locally
- [ ] I have updated documentation if needed
- [ ] Terraform changes include `terraform validate` output
- [ ] Database migrations are reversible (if applicable)
- [ ] No secrets, credentials, or API keys are committed
- [ ] Audit log coverage: state-changing operations write to audit log (if applicable)

## Screenshots / Outputs

<!-- If UI or CLI output changes, paste screenshots or terminal output here. -->

## Deployment Notes

<!-- Any special steps needed when deploying this change? Terraform plan review needed? Migration notes? -->
